### PR TITLE
Add consistency in import from init

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: isort
         name: isort
-        args: [ "--profile", "black" ]
+        args: [ "--profile", "black", "--skip", "__init__.py", "--filter-files" ]
   - repo: local
     hooks:
       - id: mypy

--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -14,11 +14,10 @@ from starlette.status import HTTP_404_NOT_FOUND
 from azimuth import startup
 from azimuth.config import AzimuthConfig, load_azimuth_config, parse_args
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules import Module
+from azimuth.modules.base_classes import Module
 from azimuth.modules.utilities.validation import ValidationModule
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions
 from azimuth.types.validation import ValidationResponse
 from azimuth.utils.cluster import default_cluster
 from azimuth.utils.conversion import JSONResponseIgnoreNan

--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Literal, Optional, TypeVar, Union
 import structlog
 from pydantic import BaseModel, BaseSettings, Extra, Field, root_validator, validator
 
-from azimuth.types.general.modules import SupportedModelContract
+from azimuth.types import SupportedModelContract
 from azimuth.utils.conversion import md5_hash
 
 log = structlog.get_logger(__file__)

--- a/azimuth/dataset_split_manager.py
+++ b/azimuth/dataset_split_manager.py
@@ -19,7 +19,7 @@ from datasets import ClassLabel, Dataset, concatenate_datasets
 from filelock import FileLock
 
 from azimuth.config import AzimuthConfig, AzimuthValidationError, CommonFieldsConfig
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
+from azimuth.types import DatasetColumn, DatasetSplitName
 from azimuth.types.tag import SmartTag, Tag
 from azimuth.utils.validation import assert_not_none
 

--- a/azimuth/modules/README.md
+++ b/azimuth/modules/README.md
@@ -23,8 +23,8 @@ from typing import List
 
 from datasets import Dataset
 
-from azimuth.modules.base_classes.module import Module
-from azimuth.types.general.alias_model import ModuleResponse
+from azimuth.modules.base_classes import Module
+from azimuth.types import ModuleResponse
 
 
 class YourModule(Module):
@@ -182,9 +182,9 @@ See the example above how you would get the results of another module from `MyMo
 ```python
 from typing import List
 
-from azimuth.modules.base_classes.module import Module
+from azimuth.modules.base_classes import Module
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types.general.alias_model import ModuleResponse
+from azimuth.types import ModuleResponse
 
 
 class AnotherModule(Module):

--- a/azimuth/modules/__init__.py
+++ b/azimuth/modules/__init__.py
@@ -1,3 +1,0 @@
-# Module must be at the top!
-from azimuth.modules.base_classes.expirable_mixin import ExpirableMixin
-from azimuth.modules.base_classes.module import Module

--- a/azimuth/modules/base_classes/__init__.py
+++ b/azimuth/modules/base_classes/__init__.py
@@ -1,3 +1,15 @@
-# Copyright ServiceNow, Inc. 2021 – 2022
-# This source code is licensed under the Apache 2.0 license found in the LICENSE file
-# in the root directory of this source tree.
+# Do not reorder
+from azimuth.modules.base_classes.artifact_manager import ArtifactManager
+from azimuth.modules.base_classes.dask_module import ConfigScope, DaskModule
+from azimuth.modules.base_classes.module import Module
+from azimuth.modules.base_classes.expirable_mixin import ExpirableMixin
+from azimuth.modules.base_classes.aggregation_module import (
+    AggregationModule,
+    ComparisonModule,
+    FilterableModule,
+)
+from azimuth.modules.base_classes.indexable_module import (
+    DatasetResultModule,
+    IndexableModule,
+    ModelContractModule,
+)

--- a/azimuth/modules/base_classes/aggregation_module.py
+++ b/azimuth/modules/base_classes/aggregation_module.py
@@ -7,12 +7,8 @@ from typing import List, Optional
 
 from datasets import Dataset
 
-from azimuth.modules import ExpirableMixin
-from azimuth.modules.base_classes.dask_module import ConfigScope
-from azimuth.modules.base_classes.module import Module
-from azimuth.types.general.alias_model import ModuleResponse
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.modules.base_classes import ConfigScope, ExpirableMixin, Module
+from azimuth.types import DatasetSplitName, ModuleOptions, ModuleResponse
 from azimuth.utils.filtering import filter_dataset_split
 
 

--- a/azimuth/modules/base_classes/artifact_manager.py
+++ b/azimuth/modules/base_classes/artifact_manager.py
@@ -8,7 +8,7 @@ from transformers import AutoTokenizer
 
 from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.types.general.dataset import DatasetSplitName
+from azimuth.types import DatasetSplitName
 from azimuth.types.tag import ALL_PREDICTION_TAGS, ALL_STANDARD_TAGS
 from azimuth.utils.object_loader import load_custom_object
 from azimuth.utils.project import load_dataset_from_config

--- a/azimuth/modules/base_classes/caching.py
+++ b/azimuth/modules/base_classes/caching.py
@@ -12,7 +12,7 @@ import structlog
 from filelock import FileLock
 from retrying import RetryError, retry
 
-from azimuth.types.general.alias_model import ModuleResponse
+from azimuth.types import ModuleResponse
 from azimuth.utils.conversion import from_pickle_bytes, to_pickle_bytes
 
 log = structlog.get_logger(__name__)

--- a/azimuth/modules/base_classes/dask_module.py
+++ b/azimuth/modules/base_classes/dask_module.py
@@ -13,8 +13,7 @@ from distributed import Client, Event, Future, rejoin, secede
 
 from azimuth.config import CommonFieldsConfig
 from azimuth.modules.base_classes.caching import HDF5CacheMixin
-from azimuth.types.general.alias_model import ModuleResponse
-from azimuth.types.general.dataset import DatasetSplitName
+from azimuth.types import DatasetSplitName, ModuleResponse
 from azimuth.utils.logs import TimerLogging
 
 log = structlog.get_logger()

--- a/azimuth/modules/base_classes/indexable_module.py
+++ b/azimuth/modules/base_classes/indexable_module.py
@@ -10,12 +10,15 @@ from datasets import Dataset
 
 from azimuth.config import ModelContractConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules import Module
-from azimuth.modules.base_classes.dask_module import ConfigScope
-from azimuth.types.general.alias_model import InputResponse, ModuleResponse
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.modules.base_classes import ConfigScope, Module
+from azimuth.types import (
+    DatasetColumn,
+    DatasetSplitName,
+    InputResponse,
+    ModuleOptions,
+    ModuleResponse,
+    SupportedMethod,
+)
 from azimuth.types.tag import SmartTag
 from azimuth.types.task import PredictionResponse, SaliencyResponse
 from azimuth.utils.ml.postprocessing import PostProcessingIO

--- a/azimuth/modules/base_classes/module.py
+++ b/azimuth/modules/base_classes/module.py
@@ -14,11 +14,8 @@ from azimuth.config import (
     PipelineDefinition,
 )
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
-from azimuth.modules.base_classes.artifact_manager import ArtifactManager
-from azimuth.modules.base_classes.dask_module import ConfigScope, DaskModule
-from azimuth.types.general.alias_model import ModuleResponse
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.modules.base_classes import ArtifactManager, ConfigScope, DaskModule
+from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, ModuleResponse
 from azimuth.utils.conversion import md5_hash
 from azimuth.utils.validation import assert_not_none
 

--- a/azimuth/modules/dataset_analysis/dataset_warnings.py
+++ b/azimuth/modules/dataset_analysis/dataset_warnings.py
@@ -9,12 +9,13 @@ import pandas as pd
 
 from azimuth.config import DatasetWarningConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules.base_classes.aggregation_module import ComparisonModule
+from azimuth.modules.base_classes import ComparisonModule
 from azimuth.plots.dataset_warnings import (
     class_representation,
     min_nb_samples_plot,
     nb_tokens_plot,
 )
+from azimuth.types import DatasetColumn, DatasetSplitName
 from azimuth.types.dataset_warnings import (
     DatasetDistributionComparison,
     DatasetDistributionComparisonValue,
@@ -23,7 +24,6 @@ from azimuth.types.dataset_warnings import (
     DatasetWarningsResponse,
     FormatType,
 )
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
 
 
 class DatasetWarningsModule(ComparisonModule[DatasetWarningConfig]):

--- a/azimuth/modules/dataset_analysis/similarity_analysis.py
+++ b/azimuth/modules/dataset_analysis/similarity_analysis.py
@@ -15,14 +15,9 @@ from tqdm import tqdm
 
 from azimuth.config import SimilarityConfig, SimilarityOptions
 from azimuth.dataset_split_manager import FEATURE_FAISS, DatasetSplitManager
-from azimuth.modules.base_classes.indexable_module import (
-    DatasetResultModule,
-    IndexableModule,
-)
+from azimuth.modules.base_classes import DatasetResultModule, IndexableModule
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types.general.array_type import Array
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import Array, DatasetColumn, DatasetSplitName, ModuleOptions
 from azimuth.types.similarity_analysis import FAISSResponse
 from azimuth.types.tag import SmartTag, TaggingResponse
 from azimuth.utils.validation import assert_not_none

--- a/azimuth/modules/dataset_analysis/spectral_clustering.py
+++ b/azimuth/modules/dataset_analysis/spectral_clustering.py
@@ -6,11 +6,10 @@ from sklearn.metrics import pairwise_distances
 from spectral_metric.estimator import CumulativeGradientEstimator
 
 from azimuth.config import SimilarityConfig
-from azimuth.modules.base_classes.aggregation_module import AggregationModule
+from azimuth.modules.base_classes import AggregationModule
 from azimuth.modules.dataset_analysis.similarity_analysis import FAISSModule
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types.general.array_type import Array
-from azimuth.types.general.dataset import DatasetSplitName
+from azimuth.types import Array, DatasetSplitName
 from azimuth.types.similarity_analysis import FAISSResponse
 from azimuth.types.spectral_clustering import SpectralClusteringResponse
 

--- a/azimuth/modules/dataset_analysis/syntax_tagging.py
+++ b/azimuth/modules/dataset_analysis/syntax_tagging.py
@@ -10,9 +10,8 @@ from spacy.lang.en import English
 
 from azimuth.config import CommonFieldsConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules.base_classes.indexable_module import DatasetResultModule
-from azimuth.types.general.alias_model import ModuleResponse
-from azimuth.types.general.dataset import DatasetColumn
+from azimuth.modules.base_classes import DatasetResultModule
+from azimuth.types import DatasetColumn, ModuleResponse
 from azimuth.types.tag import ALL_SYNTAX_TAGS, SmartTag, TaggingResponse
 
 

--- a/azimuth/modules/model_contract_task_mapping.py
+++ b/azimuth/modules/model_contract_task_mapping.py
@@ -4,19 +4,13 @@
 from typing import Mapping, Optional, Type
 
 from azimuth.config import ModelContractConfig
-from azimuth.modules.base_classes.indexable_module import ModelContractModule
-from azimuth.modules.model_contracts.custom_classification import (
+from azimuth.modules.base_classes import ModelContractModule
+from azimuth.modules.model_contracts import (
     CustomTextClassificationModule,
-)
-from azimuth.modules.model_contracts.file_based_text_classification import (
     FileBasedTextClassificationModule,
-)
-from azimuth.modules.model_contracts.hf_text_classification import (
     HFTextClassificationModule,
 )
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedModelContract
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedModelContract
 
 # Black formats this in a way where the line is too long.
 # fmt: off

--- a/azimuth/modules/model_contracts/__init__.py
+++ b/azimuth/modules/model_contracts/__init__.py
@@ -1,3 +1,6 @@
-# Copyright ServiceNow, Inc. 2021 – 2022
-# This source code is licensed under the Apache 2.0 license found in the LICENSE file
-# in the root directory of this source tree.
+# Do not reorder
+from azimuth.modules.model_contracts.custom_classification import CustomTextClassificationModule
+from azimuth.modules.model_contracts.file_based_text_classification import (
+    FileBasedTextClassificationModule,
+)
+from azimuth.modules.model_contracts.hf_text_classification import HFTextClassificationModule

--- a/azimuth/modules/model_contracts/custom_classification.py
+++ b/azimuth/modules/model_contracts/custom_classification.py
@@ -6,7 +6,7 @@ from typing import Callable, List
 import structlog
 from datasets import Dataset
 
-from azimuth.modules.base_classes.indexable_module import ModelContractModule
+from azimuth.modules.base_classes import ModelContractModule
 from azimuth.modules.model_contracts.text_classification_no_saliency import (
     TextClassificationNoSaliencyModule,
 )

--- a/azimuth/modules/model_contracts/file_based_text_classification.py
+++ b/azimuth/modules/model_contracts/file_based_text_classification.py
@@ -10,9 +10,7 @@ from azimuth.modules.model_contracts.text_classification_no_saliency import (
     TextClassificationNoSaliencyModule,
 )
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import DatasetColumn, ModuleOptions, SupportedMethod
 from azimuth.types.task import PredictionResponse
 
 

--- a/azimuth/modules/model_contracts/hf_text_classification.py
+++ b/azimuth/modules/model_contracts/hf_text_classification.py
@@ -11,8 +11,8 @@ from datasets import Dataset
 
 from azimuth.config import ModelContractConfig
 from azimuth.modules.model_contracts.text_classification import TextClassificationModule
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import GradientCalculation, ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions
+from azimuth.types.general.module_options import GradientCalculation
 from azimuth.types.task import PredictionResponse, SaliencyResponse
 from azimuth.utils.ml.mc_dropout import MCDropout
 from azimuth.utils.ml.saliency import (

--- a/azimuth/modules/model_contracts/text_classification.py
+++ b/azimuth/modules/model_contracts/text_classification.py
@@ -13,12 +13,9 @@ from scipy.special import softmax
 from scipy.stats import entropy
 from transformers.file_utils import ModelOutput
 
-from azimuth.modules.base_classes.indexable_module import ModelContractModule
+from azimuth.modules.base_classes import ModelContractModule
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types.general.alias_model import InputResponse
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import DatasetColumn, InputResponse, ModuleOptions, SupportedMethod
 from azimuth.types.task import PredictionResponse, SaliencyResponse
 from azimuth.utils.ml.postprocessing import PostProcessingIO
 from azimuth.utils.project import postprocessing_editable

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -10,9 +10,8 @@ from datasets import Dataset
 
 from azimuth.config import ModelContractConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules.base_classes.aggregation_module import FilterableModule
-from azimuth.modules.base_classes.indexable_module import DatasetResultModule
-from azimuth.types.general.dataset import DatasetColumn
+from azimuth.modules.base_classes import DatasetResultModule, FilterableModule
+from azimuth.types import DatasetColumn
 from azimuth.types.model_performance import (
     ConfidenceBinDetails,
     ConfidenceHistogramResponse,

--- a/azimuth/modules/model_performance/confusion_matrix.py
+++ b/azimuth/modules/model_performance/confusion_matrix.py
@@ -8,8 +8,8 @@ from datasets import Dataset
 from sklearn.metrics import confusion_matrix
 
 from azimuth.config import ModelContractConfig
-from azimuth.modules.base_classes.aggregation_module import FilterableModule
-from azimuth.types.general.dataset import DatasetColumn
+from azimuth.modules.base_classes import FilterableModule
+from azimuth.types import DatasetColumn
 from azimuth.types.model_performance import ConfusionMatrixResponse
 from azimuth.utils.validation import assert_not_none
 

--- a/azimuth/modules/model_performance/metrics.py
+++ b/azimuth/modules/model_performance/metrics.py
@@ -13,16 +13,12 @@ from sklearn.exceptions import UndefinedMetricWarning
 from tqdm import tqdm
 
 from azimuth.config import AzimuthConfig, ModelContractConfig
-from azimuth.modules.base_classes.aggregation_module import (
-    AggregationModule,
-    FilterableModule,
-)
+from azimuth.modules.base_classes import AggregationModule, FilterableModule
 from azimuth.modules.model_performance.confidence_binning import (
     ConfidenceHistogramModule,
 )
 from azimuth.plots.ece import make_ece_figure
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import DatasetFilters, ModuleOptions
+from azimuth.types import DatasetColumn, DatasetFilters, ModuleOptions
 from azimuth.types.model_performance import (
     MetricsAPIResponse,
     MetricsModuleResponse,

--- a/azimuth/modules/model_performance/outcome_count.py
+++ b/azimuth/modules/model_performance/outcome_count.py
@@ -7,13 +7,9 @@ from tqdm import tqdm
 
 from azimuth.config import AzimuthConfig, ModelContractConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules.base_classes.aggregation_module import (
-    AggregationModule,
-    FilterableModule,
-)
+from azimuth.modules.base_classes import AggregationModule, FilterableModule
 from azimuth.modules.model_performance.outcomes import OutcomesModule
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetColumn, ModuleOptions
 from azimuth.types.model_performance import (
     OutcomeCountPerFilter,
     OutcomeCountPerFilterResponse,

--- a/azimuth/modules/model_performance/outcomes.py
+++ b/azimuth/modules/model_performance/outcomes.py
@@ -8,10 +8,9 @@ from numpy import ndarray
 
 from azimuth.config import ModelContractConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules.base_classes.indexable_module import DatasetResultModule
+from azimuth.modules.base_classes import DatasetResultModule
 from azimuth.modules.model_contract_task_mapping import model_contract_task_mapping
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import DatasetColumn, SupportedMethod
 from azimuth.types.outcomes import OutcomeName
 from azimuth.utils.validation import assert_not_none
 

--- a/azimuth/modules/perturbation_testing/perturbation_testing.py
+++ b/azimuth/modules/perturbation_testing/perturbation_testing.py
@@ -9,11 +9,14 @@ from datasets import Dataset
 
 from azimuth.config import PerturbationTestingScope
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules.base_classes.indexable_module import DatasetResultModule
+from azimuth.modules.base_classes import DatasetResultModule
 from azimuth.modules.model_contract_task_mapping import model_contract_task_mapping
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import (
+    DatasetColumn,
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+)
 from azimuth.types.perturbation_testing import (
     PRETTY_PERTURBATION_TYPES,
     PerturbationTestClass,

--- a/azimuth/modules/perturbation_testing/perturbation_testing_summary.py
+++ b/azimuth/modules/perturbation_testing/perturbation_testing_summary.py
@@ -8,11 +8,10 @@ from typing import List, Optional
 import pandas as pd
 
 from azimuth.config import PerturbationTestingScope
-from azimuth.modules.base_classes.aggregation_module import ComparisonModule
+from azimuth.modules.base_classes import ComparisonModule
 from azimuth.modules.perturbation_testing import PerturbationTestingModule
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions
 from azimuth.types.perturbation_testing import (
     PerturbationTestFailureReason,
     PerturbationTestFamily,

--- a/azimuth/modules/task_execution.py
+++ b/azimuth/modules/task_execution.py
@@ -8,8 +8,8 @@ import structlog
 from dask.context import thread_state
 from distributed import get_client, rejoin, secede
 
-from azimuth.modules import Module
-from azimuth.types.general.alias_model import ModuleResponse
+from azimuth.modules.base_classes import Module
+from azimuth.types import ModuleResponse
 
 log = structlog.get_logger(__name__)
 

--- a/azimuth/modules/task_mapping.py
+++ b/azimuth/modules/task_mapping.py
@@ -18,7 +18,7 @@ from azimuth.modules.model_performance import (
 )
 from azimuth.modules.utilities import validation
 from azimuth.modules.word_analysis import tokens_to_words, top_words
-from azimuth.types.general.modules import SupportedMethod, SupportedModule
+from azimuth.types import SupportedMethod, SupportedModule
 
 # Uses raw indices and needs access to the model.
 model_contract_methods = {

--- a/azimuth/modules/utilities/validation.py
+++ b/azimuth/modules/utilities/validation.py
@@ -5,10 +5,9 @@ from datasets import Dataset
 from transformers import TextClassificationPipeline
 
 from azimuth.config import ModelContractConfig
-from azimuth.modules.base_classes.aggregation_module import AggregationModule
+from azimuth.modules.base_classes import AggregationModule
 from azimuth.modules.model_contract_task_mapping import model_contract_task_mapping
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod, SupportedModelContract
+from azimuth.types import ModuleOptions, SupportedMethod, SupportedModelContract
 from azimuth.types.validation import ValidationResponse
 from azimuth.utils.validation import assert_not_none
 

--- a/azimuth/modules/word_analysis/tokens_to_words.py
+++ b/azimuth/modules/word_analysis/tokens_to_words.py
@@ -8,12 +8,10 @@ from typing import List, Tuple, cast
 from datasets import Dataset
 
 from azimuth.config import ModelContractConfig
-from azimuth.modules.base_classes.indexable_module import IndexableModule
+from azimuth.modules.base_classes import IndexableModule
 from azimuth.modules.model_contract_task_mapping import model_contract_task_mapping
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import DatasetColumn, ModuleOptions, SupportedMethod
 from azimuth.types.task import SaliencyResponse
 from azimuth.types.word_analysis import TokensToWordsResponse
 

--- a/azimuth/modules/word_analysis/top_words.py
+++ b/azimuth/modules/word_analysis/top_words.py
@@ -8,11 +8,10 @@ from typing import List, Tuple
 import numpy as np
 
 from azimuth.config import ModelContractConfig
-from azimuth.modules.base_classes.aggregation_module import FilterableModule
+from azimuth.modules.base_classes import FilterableModule
 from azimuth.modules.task_execution import get_task_result
 from azimuth.modules.word_analysis.tokens_to_words import TokensToWordsModule
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetColumn, ModuleOptions
 from azimuth.types.word_analysis import (
     TokensToWordsResponse,
     TopWordsImportanceCriteria,

--- a/azimuth/plots/dataset_warnings.py
+++ b/azimuth/plots/dataset_warnings.py
@@ -8,8 +8,8 @@ import numpy as np
 import plotly.graph_objs as go
 from plotly.subplots import make_subplots
 
+from azimuth.types import PlotSpecification
 from azimuth.types.dataset_warnings import DatasetWarningPlots
-from azimuth.types.general.alias_model import PlotSpecification
 from azimuth.utils.plots import (
     AXIS_FONT_SIZE,
     PAPER_MARGINS,

--- a/azimuth/plots/sankey_plot.py
+++ b/azimuth/plots/sankey_plot.py
@@ -15,7 +15,7 @@ from azimuth.modules.dataset_analysis.spectral_clustering import (
     SCALING_FACTOR,
     take,
 )
-from azimuth.types.general.alias_model import PlotSpecification
+from azimuth.types import PlotSpecification
 from azimuth.types.spectral_clustering import SpectralClusteringResponse
 from azimuth.utils.plots import SANKEY_PALETTE
 

--- a/azimuth/routers/v1/app.py
+++ b/azimuth/routers/v1/app.py
@@ -17,17 +17,15 @@ from azimuth.app import (
 )
 from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules import Module
+from azimuth.modules.base_classes import Module
 from azimuth.task_manager import TaskManager
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedModule
 from azimuth.types.app import (
     AvailableDatasetSplits,
     DatasetInfoResponse,
     PerturbationTestingSummary,
     StatusResponse,
 )
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedModule
 from azimuth.types.perturbation_testing import (
     PerturbationTestingMergedResponse,
     PerturbationTestingSummaryResponse,

--- a/azimuth/routers/v1/custom_utterances.py
+++ b/azimuth/routers/v1/custom_utterances.py
@@ -13,8 +13,7 @@ from azimuth.app import get_config, get_task_manager
 from azimuth.config import AzimuthConfig
 from azimuth.modules.perturbation_testing import PerturbationTestingModule
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import DatasetSplitName, SupportedMethod
 from azimuth.types.perturbation_testing import (
     PRETTY_PERTURBATION_TYPES,
     PerturbationTestFailureReason,

--- a/azimuth/routers/v1/dataset_warnings.py
+++ b/azimuth/routers/v1/dataset_warnings.py
@@ -9,9 +9,8 @@ from fastapi import APIRouter, Depends
 from azimuth.app import get_all_dataset_split_managers, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
+from azimuth.types import DatasetSplitName, SupportedModule
 from azimuth.types.dataset_warnings import DatasetWarningGroup, DatasetWarningsResponse
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.modules import SupportedModule
 from azimuth.utils.routers import get_last_update, get_standard_task_result
 
 router = APIRouter()

--- a/azimuth/routers/v1/export.py
+++ b/azimuth/routers/v1/export.py
@@ -21,9 +21,12 @@ from azimuth.app import (
 from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedModule
+from azimuth.types import (
+    DatasetColumn,
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedModule,
+)
 from azimuth.types.perturbation_testing import (
     PerturbationTestSummary,
     PerturbedUtteranceDetailedResult,

--- a/azimuth/routers/v1/model_performance/confidence_histogram.py
+++ b/azimuth/routers/v1/model_performance/confidence_histogram.py
@@ -9,9 +9,12 @@ from fastapi import APIRouter, Depends
 from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions, NamedDatasetFilters
-from azimuth.types.general.modules import SupportedModule
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    NamedDatasetFilters,
+    SupportedModule,
+)
 from azimuth.types.model_performance import (
     ConfidenceBinDetails,
     ConfidenceHistogramResponse,

--- a/azimuth/routers/v1/model_performance/confusion_matrix.py
+++ b/azimuth/routers/v1/model_performance/confusion_matrix.py
@@ -7,9 +7,12 @@ from fastapi import APIRouter, Depends
 from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions, NamedDatasetFilters
-from azimuth.types.general.modules import SupportedModule
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    NamedDatasetFilters,
+    SupportedModule,
+)
 from azimuth.types.model_performance import ConfusionMatrixResponse
 from azimuth.utils.routers import (
     build_named_dataset_filters,

--- a/azimuth/routers/v1/model_performance/metrics.py
+++ b/azimuth/routers/v1/model_performance/metrics.py
@@ -9,9 +9,12 @@ from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.model_performance.metrics import MetricsModule
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions, NamedDatasetFilters
-from azimuth.types.general.modules import SupportedModule
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    NamedDatasetFilters,
+    SupportedModule,
+)
 from azimuth.types.model_performance import (
     MetricsAPIResponse,
     MetricsModuleResponse,

--- a/azimuth/routers/v1/model_performance/outcome_count.py
+++ b/azimuth/routers/v1/model_performance/outcome_count.py
@@ -9,9 +9,12 @@ from fastapi import APIRouter, Depends
 from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions, NamedDatasetFilters
-from azimuth.types.general.modules import SupportedModule
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    NamedDatasetFilters,
+    SupportedModule,
+)
 from azimuth.types.model_performance import (
     OutcomeCountPerFilterResponse,
     OutcomeCountPerThresholdResponse,

--- a/azimuth/routers/v1/model_performance/utterance_count.py
+++ b/azimuth/routers/v1/model_performance/utterance_count.py
@@ -9,8 +9,7 @@ from fastapi import APIRouter, Depends
 from azimuth.app import get_config, get_dataset_split_manager
 from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import NamedDatasetFilters
+from azimuth.types import DatasetColumn, NamedDatasetFilters
 from azimuth.types.model_performance import (
     UtteranceCountPerFilter,
     UtteranceCountPerFilterResponse,

--- a/azimuth/routers/v1/spectral_clustering.py
+++ b/azimuth/routers/v1/spectral_clustering.py
@@ -6,9 +6,7 @@ from azimuth.app import get_all_dataset_split_managers, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.plots.sankey_plot import make_sankey_plot
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.alias_model import PlotSpecification
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.modules import SupportedModule
+from azimuth.types import DatasetSplitName, PlotSpecification, SupportedModule
 from azimuth.types.spectral_clustering import SpectralClusteringResponse
 from azimuth.utils.routers import get_standard_task_result
 

--- a/azimuth/routers/v1/tags.py
+++ b/azimuth/routers/v1/tags.py
@@ -10,7 +10,7 @@ from starlette.status import HTTP_400_BAD_REQUEST
 from azimuth.app import get_dataset_split_manager_mapping, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
+from azimuth.types import DatasetSplitName
 from azimuth.types.tag import (
     DataActionMapping,
     DataActionResponse,

--- a/azimuth/routers/v1/top_words.py
+++ b/azimuth/routers/v1/top_words.py
@@ -7,9 +7,12 @@ from fastapi import APIRouter, Depends
 from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions, NamedDatasetFilters
-from azimuth.types.general.modules import SupportedModule
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    NamedDatasetFilters,
+    SupportedModule,
+)
 from azimuth.types.word_analysis import TopWordsResponse
 from azimuth.utils.routers import (
     build_named_dataset_filters,

--- a/azimuth/routers/v1/utterances.py
+++ b/azimuth/routers/v1/utterances.py
@@ -16,10 +16,15 @@ from azimuth.app import (
 from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.alias_model import PaginationParams
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions, NamedDatasetFilters
-from azimuth.types.general.modules import SupportedMethod, SupportedModule
+from azimuth.types import (
+    DatasetColumn,
+    DatasetSplitName,
+    ModuleOptions,
+    NamedDatasetFilters,
+    PaginationParams,
+    SupportedMethod,
+    SupportedModule,
+)
 from azimuth.types.perturbation_testing import (
     PerturbedUtteranceResult,
     PerturbedUtteranceWithClassNames,

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -13,12 +13,11 @@ from distributed import Future
 
 from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules.base_classes.dask_module import DaskModule
-from azimuth.modules.base_classes.indexable_module import DatasetResultModule
+from azimuth.modules.base_classes import DaskModule, DatasetResultModule
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import (
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
     SupportedMethod,
     SupportedModule,
     SupportedTask,

--- a/azimuth/task_manager.py
+++ b/azimuth/task_manager.py
@@ -8,13 +8,14 @@ import structlog
 from distributed import Client, SpecCluster
 
 from azimuth.config import AzimuthConfig
-from azimuth.modules import ExpirableMixin
-from azimuth.modules.base_classes.artifact_manager import ArtifactManager
-from azimuth.modules.base_classes.dask_module import DaskModule
+from azimuth.modules.base_classes import ArtifactManager, DaskModule, ExpirableMixin
 from azimuth.modules.task_mapping import model_contract_methods, modules
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod, SupportedTask
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+    SupportedTask,
+)
 from azimuth.utils.cluster import default_cluster
 
 log = structlog.get_logger()

--- a/azimuth/types/__init__.py
+++ b/azimuth/types/__init__.py
@@ -1,0 +1,21 @@
+# Do not reorder
+from azimuth.types.general.alias_model import (
+    AliasModel,
+    InputResponse,
+    ModuleResponse,
+    PaginationParams,
+    PlotSpecification,
+)
+from azimuth.types.general.array_type import Array
+from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
+from azimuth.types.general.modules import (
+    SupportedMethod,
+    SupportedModelContract,
+    SupportedModule,
+    SupportedTask,
+)
+from azimuth.types.general.module_options import (
+    DatasetFilters,
+    ModuleOptions,
+    NamedDatasetFilters,
+)

--- a/azimuth/types/app.py
+++ b/azimuth/types/app.py
@@ -6,9 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import AliasModel
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.modules import SupportedModelContract
+from azimuth.types import AliasModel, DatasetSplitName, SupportedModelContract
 from azimuth.types.perturbation_testing import PerturbationTestSummary
 from azimuth.types.tag import DataAction, SmartTag
 

--- a/azimuth/types/dataset_warnings.py
+++ b/azimuth/types/dataset_warnings.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Union
 from pydantic import Field
 from pydantic.types import StrictFloat, StrictInt
 
-from azimuth.types.general.alias_model import AliasModel, PlotSpecification
+from azimuth.types import AliasModel, PlotSpecification
 
 
 class FormatType(str, Enum):

--- a/azimuth/types/general/module_options.py
+++ b/azimuth/types/general/module_options.py
@@ -7,8 +7,7 @@ from typing import List, Optional
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import AliasModel
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import AliasModel, SupportedMethod
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import DataAction, SmartTag
 

--- a/azimuth/types/model_performance.py
+++ b/azimuth/types/model_performance.py
@@ -6,12 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import (
-    AliasModel,
-    ModuleResponse,
-    PlotSpecification,
-)
-from azimuth.types.general.array_type import Array
+from azimuth.types import AliasModel, Array, ModuleResponse, PlotSpecification
 from azimuth.types.outcomes import OutcomeName
 
 

--- a/azimuth/types/perturbation_testing.py
+++ b/azimuth/types/perturbation_testing.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import AliasModel, ModuleResponse
+from azimuth.types import AliasModel, ModuleResponse
 
 
 class PerturbationTestType(str, Enum):

--- a/azimuth/types/similarity_analysis.py
+++ b/azimuth/types/similarity_analysis.py
@@ -6,8 +6,7 @@ from typing import List, Optional, Tuple
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import AliasModel, ModuleResponse
-from azimuth.types.general.array_type import Array
+from azimuth.types import AliasModel, Array, ModuleResponse
 
 
 class SimilarUtterance(AliasModel):

--- a/azimuth/types/spectral_clustering.py
+++ b/azimuth/types/spectral_clustering.py
@@ -1,5 +1,4 @@
-from azimuth.types.general.alias_model import AliasModel
-from azimuth.types.general.array_type import Array
+from azimuth.types import AliasModel, Array
 
 
 class SpectralClusteringResponse(AliasModel):

--- a/azimuth/types/tag.py
+++ b/azimuth/types/tag.py
@@ -7,8 +7,7 @@ from typing import Any, Dict, List
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import AliasModel, ModuleResponse
-from azimuth.types.general.dataset import DatasetSplitName
+from azimuth.types import AliasModel, DatasetSplitName, ModuleResponse
 
 
 class DataActionMapping(AliasModel):

--- a/azimuth/types/task.py
+++ b/azimuth/types/task.py
@@ -6,7 +6,7 @@ from typing import List
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import AliasModel, ModuleResponse
+from azimuth.types import AliasModel, ModuleResponse
 from azimuth.utils.ml.postprocessing import PostProcessingIO
 
 

--- a/azimuth/types/utterance.py
+++ b/azimuth/types/utterance.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import AliasModel
+from azimuth.types import AliasModel
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import DataAction, SmartTag
 

--- a/azimuth/types/validation.py
+++ b/azimuth/types/validation.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from azimuth.types.general.alias_model import AliasModel
+from azimuth.types import AliasModel
 
 
 class ValidationResponse(AliasModel):

--- a/azimuth/types/word_analysis.py
+++ b/azimuth/types/word_analysis.py
@@ -7,7 +7,7 @@ from typing import List
 
 from pydantic import Field
 
-from azimuth.types.general.alias_model import AliasModel, ModuleResponse
+from azimuth.types import AliasModel, ModuleResponse
 
 
 class TokensToWordsResponse(ModuleResponse):

--- a/azimuth/utils/filtering.py
+++ b/azimuth/utils/filtering.py
@@ -6,8 +6,7 @@ from typing import Union
 from datasets import Dataset
 
 from azimuth.config import ProjectConfig
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import DatasetFilters, NamedDatasetFilters
+from azimuth.types import DatasetColumn, DatasetFilters, NamedDatasetFilters
 from azimuth.types.tag import ALL_DATA_ACTIONS, ALL_SMART_TAGS, DataAction, SmartTag
 
 

--- a/azimuth/utils/ml/postprocessing.py
+++ b/azimuth/utils/ml/postprocessing.py
@@ -4,8 +4,7 @@ from typing import List
 import numpy as np
 from scipy.special import expit, softmax
 
-from azimuth.types.general.alias_model import AliasModel
-from azimuth.types.general.array_type import Array
+from azimuth.types import AliasModel, Array
 
 
 class PostProcessingIO(AliasModel):

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -13,8 +13,7 @@ from azimuth.config import (
     SimilarityConfig,
 )
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.modules import SupportedModelContract
+from azimuth.types import DatasetSplitName, SupportedModelContract
 from azimuth.types.tag import ALL_PREDICTION_TAGS, ALL_STANDARD_TAGS
 from azimuth.utils.object_loader import load_custom_object
 

--- a/azimuth/utils/routers.py
+++ b/azimuth/utils/routers.py
@@ -14,12 +14,15 @@ from starlette.status import (
 from azimuth.app import get_config, get_ready_flag, get_startup_tasks, get_task_manager
 from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules import Module
+from azimuth.modules.base_classes import Module
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.alias_model import PaginationParams
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions, NamedDatasetFilters
-from azimuth.types.general.modules import SupportedTask
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    NamedDatasetFilters,
+    PaginationParams,
+    SupportedTask,
+)
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import DataAction, SmartTag
 from azimuth.utils.project import predictions_available

--- a/azimuth_shr/models/file_based.py
+++ b/azimuth_shr/models/file_based.py
@@ -7,7 +7,7 @@ from datasets import Dataset
 """
 These comes from Azimuth codebase. You can access them from user-defined modules.
 """
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
+from azimuth.types import DatasetColumn, DatasetSplitName
 from azimuth.utils.object_loader import load_custom_object
 
 MAX_PREDS = 5

--- a/docs/docs/reference/configuration/model_contract.md
+++ b/docs/docs/reference/configuration/model_contract.md
@@ -9,7 +9,7 @@ Fields from this scope defines how Azimuth interacts with the ML pipelines and t
 
     from azimuth.config import MetricDefinition, PipelineDefinition,
         UncertaintyOptions
-    from azimuth.types.general.modules import SupportedModelContract
+    from azimuth.types import SupportedModelContract
 
 
     class ModelContractConfig:

--- a/docs/docs/reference/custom-objects/model.md
+++ b/docs/docs/reference/custom-objects/model.md
@@ -278,7 +278,7 @@ file-based models.
 from typing import Any, Dict
 
 from azimuth.modules.model_contracts.text_classification import SupportedOutput
-from azimuth.types.general.dataset import DatasetSplitName
+from azimuth.types import DatasetSplitName
 
 
 def __call__(utterances: Dict[str, Any],

--- a/docs/docs/reference/custom-objects/postprocessors.md
+++ b/docs/docs/reference/custom-objects/postprocessors.md
@@ -40,8 +40,7 @@ class PipelineOutputProtocol(Protocol):
 ```python
 from typing import List
 
-from azimuth.types.general.alias_model import AliasModel
-from azimuth.types.general.array_type import Array
+from azimuth.types import AliasModel, Array
 
 
 class PostProcessingIO(AliasModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,11 +18,11 @@ from azimuth.config import (
     TypoTestOptions,
 )
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
-from azimuth.modules.base_classes.artifact_manager import ArtifactManager
+from azimuth.modules.base_classes import ArtifactManager
 from azimuth.modules.task_mapping import model_contract_methods, modules
 from azimuth.startup import START_UP_THREAD_NAME
 from azimuth.task_manager import TaskManager
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
+from azimuth.types import DatasetColumn, DatasetSplitName
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import (
     ALL_DATA_ACTIONS,

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -13,7 +13,7 @@ from datasets import ClassLabel, Dataset, Features, Value
 
 from azimuth.config import AzimuthValidationError
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
+from azimuth.types import DatasetColumn, DatasetSplitName
 from azimuth.types.tag import ALL_STANDARD_TAGS, ALL_TAGS
 
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -13,7 +13,7 @@ from pprint import pprint
 from pydantic.main import BaseModel
 
 import azimuth
-from azimuth.modules import Module
+from azimuth.modules.base_classes import Module
 
 ROOT_MODULE = os.path.dirname(azimuth.__file__)
 

--- a/tests/test_experiments/test_top_words_tagging.py
+++ b/tests/test_experiments/test_top_words_tagging.py
@@ -7,7 +7,7 @@ import datasets
 import numpy as np
 import pandas as pd
 
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
+from azimuth.types import DatasetColumn, DatasetSplitName
 from azimuth.types.word_analysis import (
     TokensToWordsResponse,
     TopWordsImportanceCriteria,

--- a/tests/test_modules/conftest.py
+++ b/tests/test_modules/conftest.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from azimuth.modules.base_classes.artifact_manager import ArtifactManager
+from azimuth.modules.base_classes import ArtifactManager
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_modules/test_artifact_manager.py
+++ b/tests/test_modules/test_artifact_manager.py
@@ -1,9 +1,8 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
-from azimuth.modules import Module
-from azimuth.modules.base_classes.artifact_manager import ArtifactManager
-from azimuth.types.general.dataset import DatasetSplitName
+from azimuth.modules.base_classes import ArtifactManager, Module
+from azimuth.types import DatasetSplitName
 
 
 def test_artifact_manager(simple_text_config, file_text_config_top1):

--- a/tests/test_modules/test_caching.py
+++ b/tests/test_modules/test_caching.py
@@ -9,16 +9,19 @@ import h5py
 import pytest
 
 from azimuth.config import PerturbationTestingScope
-from azimuth.modules import Module
-from azimuth.modules.base_classes.aggregation_module import (
+from azimuth.modules.base_classes import (
     AggregationModule,
     FilterableModule,
+    IndexableModule,
+    Module,
 )
 from azimuth.modules.base_classes.caching import HDF5FileOpenerWithRetry
-from azimuth.modules.base_classes.indexable_module import IndexableModule
-from azimuth.types.general.alias_model import ModuleResponse
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import DatasetFilters, ModuleOptions
+from azimuth.types import (
+    DatasetFilters,
+    DatasetSplitName,
+    ModuleOptions,
+    ModuleResponse,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_modules/test_dataset_analysis/test_dataset_warnings.py
+++ b/tests/test_modules/test_dataset_analysis/test_dataset_warnings.py
@@ -10,8 +10,7 @@ import pytest
 
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.dataset_analysis.dataset_warnings import DatasetWarningsModule
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions
 
 
 @pytest.mark.parametrize("remove_one_class", [True, False])

--- a/tests/test_modules/test_dataset_analysis/test_similarity_analysis.py
+++ b/tests/test_modules/test_dataset_analysis/test_similarity_analysis.py
@@ -8,8 +8,7 @@ from sklearn.preprocessing import normalize
 import azimuth.modules.dataset_analysis.similarity_analysis as faiss_mod
 from azimuth.dataset_split_manager import FEATURE_FAISS
 from azimuth.modules.dataset_analysis.similarity_analysis import NeighborsTaggingModule
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions
 from azimuth.types.tag import SmartTag
 
 IDX = 3

--- a/tests/test_modules/test_dataset_analysis/test_syntax_tagging.py
+++ b/tests/test_modules/test_dataset_analysis/test_syntax_tagging.py
@@ -3,7 +3,7 @@
 # in the root directory of this source tree.
 
 from azimuth.modules.dataset_analysis.syntax_tagging import SyntaxTaggingModule
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
+from azimuth.types import DatasetColumn, DatasetSplitName
 from azimuth.types.tag import SmartTag
 
 

--- a/tests/test_modules/test_model_contracts/test_custom_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_custom_text_classification.py
@@ -1,12 +1,8 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
-from azimuth.modules.model_contracts.custom_classification import (
-    CustomTextClassificationModule,
-)
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.modules.model_contracts import CustomTextClassificationModule
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod
 
 
 def test_loading_model(guse_text_config):

--- a/tests/test_modules/test_model_contracts/test_file_based_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_file_based_text_classification.py
@@ -5,12 +5,8 @@ from typing import List, cast
 
 import numpy as np
 
-from azimuth.modules.model_contracts.file_based_text_classification import (
-    FileBasedTextClassificationModule,
-)
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.modules.model_contracts import FileBasedTextClassificationModule
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod
 from azimuth.types.task import PredictionResponse, SaliencyResponse
 
 

--- a/tests/test_modules/test_model_contracts/test_hf_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_hf_text_classification.py
@@ -8,12 +8,9 @@ import pytest
 import torch
 from datasets import Dataset
 
-from azimuth.modules.model_contracts.hf_text_classification import (
-    HFTextClassificationModule,
-)
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import GradientCalculation, ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.modules.model_contracts import HFTextClassificationModule
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod
+from azimuth.types.general.module_options import GradientCalculation
 from azimuth.types.task import PredictionResponse, SaliencyResponse
 from azimuth.utils.ml.saliency import find_word_embeddings_layer
 

--- a/tests/test_modules/test_model_contracts/test_model_contract_module.py
+++ b/tests/test_modules/test_model_contracts/test_model_contract_module.py
@@ -10,15 +10,16 @@ from datasets import Dataset
 
 from azimuth.config import PipelineDefinition
 from azimuth.dataset_split_manager import PredictionTableKey
-from azimuth.modules.model_contracts.custom_classification import (
+from azimuth.modules.model_contracts import (
     CustomTextClassificationModule,
-)
-from azimuth.modules.model_contracts.hf_text_classification import (
     HFTextClassificationModule,
 )
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import (
+    DatasetColumn,
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+)
 from azimuth.types.tag import SmartTag
 from azimuth.types.task import PredictionResponse
 from azimuth.utils.ml.postprocessing import PostProcessingIO

--- a/tests/test_modules/test_model_contracts/test_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_text_classification.py
@@ -12,15 +12,11 @@ from datasets import Dataset
 from transformers.file_utils import ModelOutput
 
 from azimuth.config import AzimuthConfig, PipelineDefinition
-from azimuth.modules.model_contracts.file_based_text_classification import (
+from azimuth.modules.model_contracts import (
     FileBasedTextClassificationModule,
-)
-from azimuth.modules.model_contracts.hf_text_classification import (
     HFTextClassificationModule,
 )
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod
 from azimuth.types.task import PredictionResponse, SaliencyResponse
 from azimuth.utils.ml.postprocessing import PostProcessingIO, TemperatureScaling
 

--- a/tests/test_modules/test_model_performance/test_confidence_binning.py
+++ b/tests/test_modules/test_model_performance/test_confidence_binning.py
@@ -9,8 +9,7 @@ from azimuth.modules.model_performance.confidence_binning import (
     ConfidenceBinIndexModule,
     ConfidenceHistogramModule,
 )
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import DatasetFilters, ModuleOptions
+from azimuth.types import DatasetColumn, DatasetFilters, DatasetSplitName, ModuleOptions
 
 UNKNOWN_TARGET = [3]
 BIN_GAP = 0.06

--- a/tests/test_modules/test_model_performance/test_confusion_matrix.py
+++ b/tests/test_modules/test_model_performance/test_confusion_matrix.py
@@ -5,8 +5,7 @@
 import numpy as np
 
 from azimuth.modules.model_performance.confusion_matrix import ConfusionMatrixModule
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import DatasetFilters, ModuleOptions
+from azimuth.types import DatasetFilters, DatasetSplitName, ModuleOptions
 
 
 def test_confusion_matrix(simple_text_config, apply_mocked_startup_task):

--- a/tests/test_modules/test_model_performance/test_metrics.py
+++ b/tests/test_modules/test_model_performance/test_metrics.py
@@ -9,9 +9,7 @@ import numpy as np
 import pytest
 
 from azimuth.config import MetricDefinition
-from azimuth.modules.model_contracts.hf_text_classification import (
-    HFTextClassificationModule,
-)
+from azimuth.modules.model_contracts import HFTextClassificationModule
 from azimuth.modules.model_performance.metrics import (
     MetricsModule,
     MetricsPerFilterModule,
@@ -22,9 +20,12 @@ from azimuth.modules.model_performance.outcome_count import (
 )
 from azimuth.modules.model_performance.outcomes import OutcomesModule
 from azimuth.plots.ece import make_ece_figure
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import DatasetFilters, ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import (
+    DatasetFilters,
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+)
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import ALL_DATA_ACTIONS, ALL_SMART_TAGS, DataAction, SmartTag
 

--- a/tests/test_modules/test_module.py
+++ b/tests/test_modules/test_module.py
@@ -9,15 +9,9 @@ from datasets import Dataset, DatasetDict
 from distributed import Variable
 
 from azimuth.config import CustomObject
-from azimuth.modules import Module
-from azimuth.modules.base_classes.aggregation_module import AggregationModule
-from azimuth.modules.base_classes.indexable_module import IndexableModule
-from azimuth.modules.model_contracts.hf_text_classification import (
-    HFTextClassificationModule,
-)
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.modules.base_classes import AggregationModule, IndexableModule, Module
+from azimuth.modules.model_contracts import HFTextClassificationModule
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod
 
 
 def test_ds_loading(simple_text_config):

--- a/tests/test_modules/test_perturbation_testing/test_perturbation_testing.py
+++ b/tests/test_modules/test_perturbation_testing/test_perturbation_testing.py
@@ -4,8 +4,7 @@
 from azimuth.modules.perturbation_testing.perturbation_testing import (
     PerturbationTestingModule,
 )
-from azimuth.types.general.dataset import DatasetColumn, DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions
 from azimuth.types.perturbation_testing import (
     PerturbationTestClass,
     PerturbationTestFailureReason,

--- a/tests/test_modules/test_perturbation_testing/test_perturbation_testing_summary.py
+++ b/tests/test_modules/test_perturbation_testing/test_perturbation_testing_summary.py
@@ -6,8 +6,7 @@ from azimuth.modules.perturbation_testing import (
     PerturbationTestingModule,
     PerturbationTestingSummaryModule,
 )
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions
 
 
 def test_perturbation_testing_summary(tiny_text_config, dask_client):

--- a/tests/test_modules/test_task_execution.py
+++ b/tests/test_modules/test_task_execution.py
@@ -2,11 +2,9 @@ from typing import List
 
 from distributed import get_client
 
-from azimuth.modules.base_classes.indexable_module import IndexableModule
+from azimuth.modules.base_classes import IndexableModule
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types.general.alias_model import ModuleResponse
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions, ModuleResponse
 
 
 class Potato(ModuleResponse):

--- a/tests/test_modules/test_utilities/test_validation.py
+++ b/tests/test_modules/test_utilities/test_validation.py
@@ -1,7 +1,6 @@
 from azimuth.config import CustomObject
 from azimuth.modules.utilities.validation import ValidationModule
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions
 
 
 class ExceptionRaiserOnInit:

--- a/tests/test_modules/test_word_analysis/test_tokens_to_words.py
+++ b/tests/test_modules/test_word_analysis/test_tokens_to_words.py
@@ -5,8 +5,7 @@
 import numpy as np
 
 from azimuth.modules.word_analysis.tokens_to_words import TokensToWordsModule
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions
 from azimuth.types.task import SaliencyResponse
 
 

--- a/tests/test_modules/test_word_analysis/test_top_words.py
+++ b/tests/test_modules/test_word_analysis/test_top_words.py
@@ -4,13 +4,14 @@
 
 import numpy as np
 
-from azimuth.modules.model_contracts.file_based_text_classification import (
-    FileBasedTextClassificationModule,
-)
+from azimuth.modules.model_contracts import FileBasedTextClassificationModule
 from azimuth.modules.word_analysis.top_words import TopWordsModule
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import DatasetFilters, ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.types import (
+    DatasetFilters,
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+)
 from azimuth.types.word_analysis import TokensToWordsResponse
 
 ALL_WORDS = [

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -8,13 +8,14 @@ from datasets import Dataset, DatasetDict
 
 from azimuth.app import get_ready_flag, initialize_managers
 from azimuth.config import CustomObject
-from azimuth.modules.model_contracts.hf_text_classification import (
-    HFTextClassificationModule,
-)
+from azimuth.modules.model_contracts import HFTextClassificationModule
 from azimuth.startup import on_end, startup_tasks
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod, SupportedModule
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+    SupportedModule,
+)
 from azimuth.utils.project import load_dataset_split_managers_from_config
 
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -6,16 +6,19 @@ import time
 
 import pytest
 
-from azimuth.modules import Module
+from azimuth.modules.base_classes import Module
 from azimuth.modules.task_mapping import model_contract_methods
 from azimuth.task_manager import TaskManager, TaskManagerLockedException
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import DatasetFilters, ModuleOptions
-from azimuth.types.general.modules import SupportedMethod, SupportedModule
+from azimuth.types import (
+    DatasetFilters,
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+    SupportedModule,
+)
 
 
 def test_get_all_task(text_task_manager):
-
     # We can find a task
     key, mod = text_task_manager.get_task(
         SupportedMethod.Inputs,

--- a/tests/test_utils/test_api_dependency_injection.py
+++ b/tests/test_utils/test_api_dependency_injection.py
@@ -3,7 +3,7 @@ from fastapi import HTTPException
 
 from azimuth import app
 from azimuth.app import get_all_dataset_split_managers, get_dataset_split_manager
-from azimuth.types.general.dataset import DatasetSplitName
+from azimuth.types import DatasetSplitName
 
 eval_split = "eval_split"
 train_split = "train_split"

--- a/tests/test_utils/test_array_type.py
+++ b/tests/test_utils/test_array_type.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import BaseModel, ValidationError
 from pydantic.schema import schema
 
-from azimuth.types.general.array_type import Array
+from azimuth.types import Array
 
 
 class MyModel(BaseModel):

--- a/tests/test_utils/test_dataset_filtering.py
+++ b/tests/test_utils/test_dataset_filtering.py
@@ -5,8 +5,7 @@ import math
 
 import pytest
 
-from azimuth.types.general.dataset import DatasetColumn
-from azimuth.types.general.module_options import DatasetFilters
+from azimuth.types import DatasetColumn, DatasetFilters
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import ALL_SMART_TAGS, DataAction, SmartTag
 from azimuth.utils.filtering import filter_dataset_split

--- a/tests/test_utils/test_ml/test_mc_dropout.py
+++ b/tests/test_utils/test_ml/test_mc_dropout.py
@@ -4,12 +4,8 @@
 
 import numpy as np
 
-from azimuth.modules.model_contracts.hf_text_classification import (
-    HFTextClassificationModule,
-)
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import ModuleOptions
-from azimuth.types.general.modules import SupportedMethod
+from azimuth.modules.model_contracts import HFTextClassificationModule
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod
 from azimuth.utils.ml.mc_dropout import MCDropout
 
 

--- a/tests/test_utils/test_task_running.py
+++ b/tests/test_utils/test_task_running.py
@@ -2,9 +2,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from azimuth.types.general.dataset import DatasetSplitName
-from azimuth.types.general.module_options import DatasetFilters, ModuleOptions
-from azimuth.types.general.modules import SupportedModule
+from azimuth.types import (
+    DatasetFilters,
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedModule,
+)
 from azimuth.utils.routers import get_custom_task_result, get_standard_task_result
 
 standard_task_result = "task_result"


### PR DESCRIPTION
## Description:
Brings some common classes in the `__init__.py`, so that the imports are shorter.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
