### PR TITLE
Remove badges underline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,13 @@
   <br>
   <br>
   <a href="https://servicenow.github.io/azimuth">
-    <img alt="Documentation" src="https://github.com/ServiceNow/azimuth/actions/workflows/docs_cd.yml/badge.svg"/>
-  </a>
+    <img alt="Documentation" src="https://github.com/ServiceNow/azimuth/actions/workflows/docs_cd.yml/badge.svg"/></a>
   <a href="https://join.slack.com/t/newworkspace-5wx1461/shared_invite/zt-16x8eqt1h-ho3Hh6ilcN7FpZyLkjr9oA">
-    <img alt="Slack" src="https://img.shields.io/badge/slack-chat-green.svg?logo=slack"/>
-  </a>
+    <img alt="Slack" src="https://img.shields.io/badge/slack-chat-green.svg?logo=slack"/></a>
   <a href="./LICENSE">
-    <img alt="Licence" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"/>
-  </a>
+    <img alt="Licence" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"/></a>
   <a href="https://github.com/ServiceNow/azimuth/actions/workflows/pythonci.yml">
-    <img alt="Tests" src="https://github.com/ServiceNow/azimuth/actions/workflows/pythonci.yml/badge.svg"/>
-  </a>
-  
+    <img alt="Tests" src="https://github.com/ServiceNow/azimuth/actions/workflows/pythonci.yml/badge.svg"/></a>
   <br>
   <br>
   Azimuth, an open-source dataset and error analysis tool for text classification, with love from ServiceNow.


### PR DESCRIPTION
## Description:

Remove the whitespaces after the badges, as they were causing a small underline between the badges.

Unfortunately, it makes the code a little bit less readable, but it seems to be the only way since GitHub strips any `style` attribute during sanitization.

For example, when hovering `documentation`:

Before:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/8386369/164458924-90060b4a-4fa5-47e5-9161-c18876c66a27.png">

After:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/8386369/164459010-8beea474-026c-4134-86c6-5d3cfcd75e82.png">

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
