### PR TITLE
Move confidence threshold out of `/dataset_info`

### DIFF
--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -38,13 +38,13 @@ class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
 
         ds: Dataset = assert_not_none(self.get_dataset_split())
 
-        result = []
         if len(ds) > 0:
             # Get the bin index for each prediction.
             confidences = np.max(self._get_confidences_from_ds(), axis=1)
             bin_indices = np.floor(confidences * CONFIDENCE_BINS_COUNT)
 
             # Create the records. We drop the last bin as it's the maximum.
+            result = []
             for bin_index, bin_min_value in enumerate(bins[:-1]):
                 bin_mask = bin_indices == bin_index
                 outcome_count = defaultdict(int)
@@ -65,15 +65,15 @@ class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
                 )
         else:
             # Create empty bins
-            for bin_index, bin_min_value in enumerate(bins[:-1]):
-                result.append(
-                    ConfidenceBinDetails(
-                        bin_index=bin_index,
-                        bin_confidence=0,
-                        mean_bin_confidence=0,
-                        outcome_count={outcome: 0 for outcome in ALL_OUTCOMES},
-                    )
+            result = [
+                ConfidenceBinDetails(
+                    bin_index=bin_index,
+                    bin_confidence=0,
+                    mean_bin_confidence=0,
+                    outcome_count={outcome: 0 for outcome in ALL_OUTCOMES},
                 )
+                for bin_index, bin_min_value in enumerate(bins[:-1])
+            ]
 
         return [ConfidenceHistogramResponse(details_all_bins=result)]
 

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -75,7 +75,7 @@ class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
                 for bin_index, bin_min_value in enumerate(bins[:-1])
             ]
 
-        return [ConfidenceHistogramResponse(details_all_bins=result)]
+        return [ConfidenceHistogramResponse(bins=result, confidence_threshold=self.get_threshold())]
 
 
 class ConfidenceBinIndexModule(DatasetResultModule[ModelContractConfig]):

--- a/azimuth/modules/model_performance/metrics.py
+++ b/azimuth/modules/model_performance/metrics.py
@@ -70,7 +70,7 @@ class MetricsModule(FilterableModule[ModelContractConfig]):
             config=self.config,
             mod_options=self.mod_options,
         )
-        bins = conf_hist_mod.compute_on_dataset_split()[0].details_all_bins
+        bins = conf_hist_mod.compute_on_dataset_split()[0].bins
         ece, acc, expected = compute_ece_from_bins(bins)
         count_per_bin = [sum(b.outcome_count.values()) for b in bins]
 

--- a/azimuth/routers/v1/app.py
+++ b/azimuth/routers/v1/app.py
@@ -35,7 +35,6 @@ from azimuth.utils.object_loader import load_custom_object
 from azimuth.utils.project import (
     perturbation_testing_available,
     postprocessing_editable,
-    postprocessing_known,
     predictions_available,
     similarity_available,
 )
@@ -96,15 +95,6 @@ def get_dataset_info(
 
     model_contract = task_manager.config.model_contract
 
-    threshold = (
-        None
-        if config.pipelines is None
-        else [
-            pipeline.threshold if postprocessing_known(task_manager.config, idx) else None
-            for idx, pipeline in enumerate(config.pipelines)
-        ]
-    )
-
     return DatasetInfoResponse(
         project_name=config.name,
         class_names=eval_dm.get_class_names(),
@@ -115,7 +105,6 @@ def get_dataset_info(
         if training_dm is not None
         else [],
         startup_tasks={k: v.status() for k, v in startup_tasks.items()},
-        default_threshold=threshold,
         model_contract=model_contract,
         prediction_available=predictions_available(task_manager.config),
         perturbation_testing_available=perturbation_testing_available(task_manager.config),

--- a/azimuth/routers/v1/model_performance/confidence_histogram.py
+++ b/azimuth/routers/v1/model_performance/confidence_histogram.py
@@ -2,8 +2,6 @@
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
 
-from typing import List
-
 from fastapi import APIRouter, Depends, Query
 
 from azimuth.app import get_dataset_split_manager, get_task_manager
@@ -15,10 +13,7 @@ from azimuth.types import (
     NamedDatasetFilters,
     SupportedModule,
 )
-from azimuth.types.model_performance import (
-    ConfidenceBinDetails,
-    ConfidenceHistogramResponse,
-)
+from azimuth.types.model_performance import ConfidenceHistogramResponse
 from azimuth.utils.routers import (
     build_named_dataset_filters,
     get_standard_task_result,
@@ -35,7 +30,7 @@ TAGS = ["Confidence Histogram v1"]
     summary="Get confidence histogram values",
     description="Get all confidence bins with their confidence and the outcome count",
     tags=TAGS,
-    response_model=List[ConfidenceBinDetails],
+    response_model=ConfidenceHistogramResponse,
 )
 def get_confidence_histogram(
     dataset_split_name: DatasetSplitName,
@@ -46,7 +41,7 @@ def get_confidence_histogram(
     without_postprocessing: bool = Query(
         False, title="Without Postprocessing", alias="withoutPostprocessing"
     ),
-) -> List[ConfidenceBinDetails]:
+) -> ConfidenceHistogramResponse:
     mod_options = ModuleOptions(
         filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),
         pipeline_index=pipeline_index,
@@ -61,4 +56,4 @@ def get_confidence_histogram(
         last_update=dataset_split_manager.last_update,
     )[0]
 
-    return result.details_all_bins
+    return result

--- a/azimuth/types/app.py
+++ b/azimuth/types/app.py
@@ -29,9 +29,6 @@ class DatasetInfoResponse(AliasModel):
     eval_class_distribution: List[int] = Field(..., title="Evaluation set class distribution")
     train_class_distribution: List[int] = Field(..., title="Training set class distribution")
     startup_tasks: Dict[str, Any] = Field(..., title="Startup tasks status")
-    default_threshold: Optional[List[Optional[float]]] = Field(
-        ..., title="Initial threshold set in config per pipeline.", nullable=True
-    )
     model_contract: SupportedModelContract = Field(..., title="Model Contract in the config.")
     prediction_available: bool = Field(..., title="Indicator if prediction values are available.")
     perturbation_testing_available: bool = Field(

--- a/azimuth/types/model_performance.py
+++ b/azimuth/types/model_performance.py
@@ -98,7 +98,10 @@ class ConfidenceBinDetails(AliasModel):
 
 
 class ConfidenceHistogramResponse(ModuleResponse):
-    details_all_bins: List[ConfidenceBinDetails] = Field(..., title="Details for all bins")
+    bins: List[ConfidenceBinDetails] = Field(..., title="Details for all bins")
+    confidence_threshold: Optional[float] = Field(
+        ..., title="Confidence threshold in selected pipeline", nullable=True
+    )
 
 
 class OutcomeCountPerThresholdValue(AliasModel):

--- a/azimuth/types/utterance.py
+++ b/azimuth/types/utterance.py
@@ -40,6 +40,9 @@ class Utterance(AliasModel):
 class GetUtterancesResponse(AliasModel):
     utterances: List[Utterance] = Field(..., title="Utterances")
     utterance_count: int = Field(..., title="Utterance count")
+    confidence_threshold: Optional[float] = Field(
+        ..., title="Confidence threshold in selected pipeline (if any)", nullable=True
+    )
 
     class Config:
         schema_extra = {

--- a/tests/test_modules/test_model_performance/test_confidence_binning.py
+++ b/tests/test_modules/test_model_performance/test_confidence_binning.py
@@ -44,9 +44,7 @@ def test_confidence_histogram(tiny_text_config):
         tiny_text_config,
         mod_options=ModuleOptions(pipeline_index=0, without_postprocessing=True),
     )
-    out_without_postprocessing = mod_without_postprocessing.compute_on_dataset_split()[
-        0
-    ].details_all_bins
+    out_without_postprocessing = mod_without_postprocessing.compute_on_dataset_split()[0].bins
 
     # Confidences should be lower with postprocessing
     mean_with_post = np.mean(

--- a/tests/test_modules/test_model_performance/test_confidence_binning.py
+++ b/tests/test_modules/test_model_performance/test_confidence_binning.py
@@ -26,7 +26,7 @@ def test_confidence_histogram(tiny_text_config):
         tiny_text_config,
         mod_options=ModuleOptions(pipeline_index=0),
     )
-    out = mod.compute_on_dataset_split()[0].details_all_bins
+    out = mod.compute_on_dataset_split()[0].bins
     ds = mod.get_dataset_split()
 
     assert len(out) == CONFIDENCE_BINS_COUNT  # We have CONFIDENCE_BINS_COUNT bins.
@@ -85,7 +85,7 @@ def test_confidence_histogram_empty(simple_text_config, apply_mocked_startup_tas
         simple_text_config,
         mod_options=ModuleOptions(filters=DatasetFilters(labels=UNKNOWN_TARGET), pipeline_index=0),
     )
-    out = mod.compute_on_dataset_split()[0].details_all_bins
+    out = mod.compute_on_dataset_split()[0].bins
 
     assert len(out) == CONFIDENCE_BINS_COUNT  # We have CONFIDENCE_BINS_COUNT bins.
     # When filters cause an empty dataset_split, we should return empty bins

--- a/tests/test_routers/test_app.py
+++ b/tests/test_routers/test_app.py
@@ -40,7 +40,6 @@ def test_get_dataset_info(app: FastAPI) -> None:
     assert data == {
         "availableDatasetSplits": {"eval": True, "train": True},
         "classNames": ["negative", "positive", "REJECTION_CLASS"],
-        "defaultThreshold": [None],
         "modelContract": "custom_text_classification",
         "perturbationTestingAvailable": True,
         "postprocessingEditable": [False],

--- a/tests/test_routers/test_model_performance/test_confidence_histogram.py
+++ b/tests/test_routers/test_model_performance/test_confidence_histogram.py
@@ -246,5 +246,5 @@ def test_get_confidence_histogram(app: FastAPI) -> None:
                 },
             },
         ],
-        "confidenceThreshold": 0.5,
+        "confidenceThreshold": None,
     }

--- a/tests/test_routers/test_model_performance/test_confidence_histogram.py
+++ b/tests/test_routers/test_model_performance/test_confidence_histogram.py
@@ -23,225 +23,228 @@ def test_get_confidence_histogram(app: FastAPI) -> None:
     assert resp.status_code == HTTP_200_OK, resp.text
     data = resp.json()
 
-    assert data == [
-        {
-            "binConfidence": 0.025,
-            "binIndex": 0,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+    assert data == {
+        "bins": [
+            {
+                "binConfidence": 0.025,
+                "binIndex": 0,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.07500000000000001,
-            "binIndex": 1,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.07500000000000001,
+                "binIndex": 1,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.125,
-            "binIndex": 2,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.125,
+                "binIndex": 2,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.17500000000000002,
-            "binIndex": 3,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.17500000000000002,
+                "binIndex": 3,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.225,
-            "binIndex": 4,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.225,
+                "binIndex": 4,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.275,
-            "binIndex": 5,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.275,
+                "binIndex": 5,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.32500000000000007,
-            "binIndex": 6,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.32500000000000007,
+                "binIndex": 6,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.37500000000000006,
-            "binIndex": 7,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.37500000000000006,
+                "binIndex": 7,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.42500000000000004,
-            "binIndex": 8,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.42500000000000004,
+                "binIndex": 8,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.47500000000000003,
-            "binIndex": 9,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.47500000000000003,
+                "binIndex": 9,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.525,
-            "binIndex": 10,
-            "meanBinConfidence": 0.5304411773021637,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 22,
+            {
+                "binConfidence": 0.525,
+                "binIndex": 10,
+                "meanBinConfidence": 0.5304411773021637,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 22,
+                },
             },
-        },
-        {
-            "binConfidence": 0.5750000000000001,
-            "binIndex": 11,
-            "meanBinConfidence": 0.5642743974538343,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 3,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.5750000000000001,
+                "binIndex": 11,
+                "meanBinConfidence": 0.5642743974538343,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 3,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.6250000000000001,
-            "binIndex": 12,
-            "meanBinConfidence": 0.6288018955444876,
-            "outcomeCount": {
-                "CorrectAndPredicted": 1,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 12,
+            {
+                "binConfidence": 0.6250000000000001,
+                "binIndex": 12,
+                "meanBinConfidence": 0.6288018955444876,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 1,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 12,
+                },
             },
-        },
-        {
-            "binConfidence": 0.675,
-            "binIndex": 13,
-            "meanBinConfidence": 0.6812974707353887,
-            "outcomeCount": {
-                "CorrectAndPredicted": 1,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 1,
-                "IncorrectAndRejected": 1,
+            {
+                "binConfidence": 0.675,
+                "binIndex": 13,
+                "meanBinConfidence": 0.6812974707353887,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 1,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 1,
+                    "IncorrectAndRejected": 1,
+                },
             },
-        },
-        {
-            "binConfidence": 0.7250000000000001,
-            "binIndex": 14,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.7250000000000001,
+                "binIndex": 14,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.775,
-            "binIndex": 15,
-            "meanBinConfidence": 0.7535185332847896,
-            "outcomeCount": {
-                "CorrectAndPredicted": 1,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.775,
+                "binIndex": 15,
+                "meanBinConfidence": 0.7535185332847896,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 1,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.8250000000000001,
-            "binIndex": 16,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.8250000000000001,
+                "binIndex": 16,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.8750000000000001,
-            "binIndex": 17,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.8750000000000001,
+                "binIndex": 17,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.925,
-            "binIndex": 18,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.925,
+                "binIndex": 18,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-        {
-            "binConfidence": 0.9750000000000001,
-            "binIndex": 19,
-            "meanBinConfidence": 0.0,
-            "outcomeCount": {
-                "CorrectAndPredicted": 0,
-                "CorrectAndRejected": 0,
-                "IncorrectAndPredicted": 0,
-                "IncorrectAndRejected": 0,
+            {
+                "binConfidence": 0.9750000000000001,
+                "binIndex": 19,
+                "meanBinConfidence": 0.0,
+                "outcomeCount": {
+                    "CorrectAndPredicted": 0,
+                    "CorrectAndRejected": 0,
+                    "IncorrectAndPredicted": 0,
+                    "IncorrectAndRejected": 0,
+                },
             },
-        },
-    ]
+        ],
+        "confidenceThreshold": 0.5,
+    }

--- a/webapp/src/components/ConfidenceHistogram/ConfidenceHistogram.tsx
+++ b/webapp/src/components/ConfidenceHistogram/ConfidenceHistogram.tsx
@@ -5,7 +5,11 @@ import BinLabel from "components/ConfidenceHistogram/BinLabel";
 import BinThresholdMarker from "components/ConfidenceHistogram/BinThresholdMarker";
 import Loading from "components/Loading";
 import React, { useMemo } from "react";
-import { ConfidenceBinDetails, Outcome } from "types/api";
+import {
+  ConfidenceBinDetails,
+  ConfidenceHistogramResponse,
+  Outcome,
+} from "types/api";
 
 const getBinHeights = ({ outcomeCount }: ConfidenceBinDetails) => [
   outcomeCount.CorrectAndRejected + outcomeCount.CorrectAndPredicted,
@@ -15,25 +19,23 @@ const getBinHeights = ({ outcomeCount }: ConfidenceBinDetails) => [
 type Props = {
   isFetching: boolean;
   error?: string;
-  bins?: ConfidenceBinDetails[];
+  data?: ConfidenceHistogramResponse;
   confidenceMin: number;
   confidenceMax: number;
   filteredOutcomes: readonly Outcome[];
-  threshold?: number;
 };
 
 const ConfidenceHistogram: React.FC<Props> = ({
   isFetching,
   error,
-  bins,
+  data,
   confidenceMin,
   confidenceMax,
   filteredOutcomes,
-  threshold,
 }) => {
   const max = useMemo(() => {
-    return bins ? Math.max(...bins.flatMap(getBinHeights)) : 0;
-  }, [bins]);
+    return data ? Math.max(...data.bins.flatMap(getBinHeights)) : 0;
+  }, [data]);
 
   return (
     <Box flex={1} height="100%" paddingTop={3} position="relative">
@@ -63,14 +65,14 @@ const ConfidenceHistogram: React.FC<Props> = ({
             }}
           >
             <BinLabel>0%</BinLabel>
-            {bins?.flatMap((bin, index) => [
+            {data?.bins.flatMap((bin, index, { length }) => [
               <BinColumn
                 key={index * 2}
                 bin={bin}
                 max={max}
                 filteredOutcomes={
-                  confidenceMin <= index / bins.length &&
-                  (index + 1) / bins.length <= confidenceMax
+                  confidenceMin <= index / length &&
+                  (index + 1) / length <= confidenceMax
                     ? filteredOutcomes
                     : []
                 }
@@ -81,11 +83,13 @@ const ConfidenceHistogram: React.FC<Props> = ({
                 ]}
               />,
               <BinLabel key={index * 2 + 1}>
-                {`${Math.round((100 / bins.length) * (index + 1))}%`}
+                {`${Math.round((100 / length) * (index + 1))}%`}
               </BinLabel>,
             ])}
           </Box>
-          {threshold && <BinThresholdMarker threshold={threshold} />}
+          {data && data.confidenceThreshold !== null && (
+            <BinThresholdMarker threshold={data.confidenceThreshold} />
+          )}
         </>
       )}
       {isFetching && (

--- a/webapp/src/components/ConfidenceHistogramTopWords.tsx
+++ b/webapp/src/components/ConfidenceHistogramTopWords.tsx
@@ -5,7 +5,6 @@ import ConfidenceHistogram from "components/ConfidenceHistogram/ConfidenceHistog
 import { DatasetSplitName } from "types/api";
 import {
   getConfidenceHistogramEndpoint,
-  getDatasetInfoEndpoint,
   getTopWordsEndpoint,
 } from "services/api";
 import TopWords from "components/TopWords/TopWords";
@@ -42,8 +41,6 @@ const ConfidenceHistogramTopWords: React.FC<Props> = ({
     datasetSplitName: DatasetSplitName;
   }>();
 
-  const { data: datasetInfo } = getDatasetInfoEndpoint.useQuery({ jobId });
-
   const {
     outcomes = ALL_OUTCOMES,
     confidenceMin = 0,
@@ -63,8 +60,6 @@ const ConfidenceHistogramTopWords: React.FC<Props> = ({
     ...postprocessing,
   });
 
-  const threshold = datasetInfo?.defaultThreshold?.[pipeline.pipelineIndex];
-
   const { data: topWords, isFetching: isFetchingTopWords } =
     getTopWordsEndpoint.useQuery({
       jobId,
@@ -83,11 +78,10 @@ const ConfidenceHistogramTopWords: React.FC<Props> = ({
       <ConfidenceHistogram
         isFetching={isFetchingConfidenceHistogram}
         error={error?.message}
-        bins={bins}
+        data={bins}
         confidenceMin={confidenceMin}
         confidenceMax={confidenceMax}
         filteredOutcomes={outcomes}
-        threshold={threshold}
       />
       <Box
         display="grid"

--- a/webapp/src/components/PageHeader.tsx
+++ b/webapp/src/components/PageHeader.tsx
@@ -100,7 +100,7 @@ const PageHeader = () => {
           name: "Settings",
         },
         {
-          pathname: `/${jobId}/threshold`,
+          pathname: `/${jobId}/thresholds`,
           name: "Threshold Comparison",
         },
         {

--- a/webapp/src/pages/UtteranceDetail.tsx
+++ b/webapp/src/pages/UtteranceDetail.tsx
@@ -166,9 +166,9 @@ const UtteranceDetail = () => {
                     {utterance.modelPrediction.postprocessedPrediction}
                   </span>
                   {isPipelineSelected(pipeline) &&
-                    datasetInfo?.defaultThreshold &&
+                    utterancesResponse?.confidenceThreshold !== null &&
                     ` (< ${formatRatioAsPercentageString(
-                      datasetInfo.defaultThreshold[pipeline.pipelineIndex]
+                      utterancesResponse.confidenceThreshold
                     )})`}
                 </Typography>
               )}

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -5,6 +5,8 @@ export type AvailableDatasetSplits =
   components["schemas"]["AvailableDatasetSplits"];
 export type ConfidenceBinDetails =
   components["schemas"]["ConfidenceBinDetails"];
+export type ConfidenceHistogramResponse =
+  components["schemas"]["ConfidenceHistogramResponse"];
 // TODO Fix generated type (problem with python "Array" types)
 export type ConfusionMatrixOperation =
   paths["/dataset_splits/{dataset_split_name}/confusion_matrix"]["get"] & {

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -155,6 +155,14 @@ export interface components {
      * This model should be used as the base for any model that defines aliases to ensure
      * that all fields are represented correctly.
      */
+    ConfidenceHistogramResponse: {
+      bins: components["schemas"]["ConfidenceBinDetails"][];
+      confidenceThreshold: number | null;
+    };
+    /**
+     * This model should be used as the base for any model that defines aliases to ensure
+     * that all fields are represented correctly.
+     */
     ConfusionMatrixResponse: {
       confusionMatrix: { [key: string]: any };
       normalized: boolean;
@@ -225,7 +233,6 @@ export interface components {
       evalClassDistribution: number[];
       trainClassDistribution: number[];
       startupTasks: { [key: string]: any };
-      defaultThreshold: number[] | null;
       modelContract: components["schemas"]["SupportedModelContract"];
       predictionAvailable: boolean;
       perturbationTestingAvailable: boolean;
@@ -283,6 +290,7 @@ export interface components {
     GetUtterancesResponse: {
       utterances: components["schemas"]["Utterance"][];
       utteranceCount: number;
+      confidenceThreshold: number | null;
     };
     HTTPValidationError: {
       detail?: components["schemas"]["ValidationError"][];
@@ -862,7 +870,7 @@ export interface operations {
       /** Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["ConfidenceBinDetails"][];
+          "application/json": components["schemas"]["ConfidenceHistogramResponse"];
         };
       };
       /** Validation Error */


### PR DESCRIPTION
## Description:

The idea is to remove pipeline-specific info from `/dataset_info`.

* [Fix typo in breadcrumbs](https://github.com/ServiceNow/azimuth/pull/61/commits/08e74363d54b57368d050b050163b536b9b6972f)
* [Clean up](https://github.com/ServiceNow/azimuth/pull/61/commits/c899d0592855122e360f3bfb392b10d7a2b4b7be)
* [Move confidence threshold out of `/dataset_info`](https://github.com/ServiceNow/azimuth/pull/61/commits/2d9e21f9138a67b1c3870dd55fffef13c6edb762) and into `/bins` and `/utterances`
  - I tried two approaches to get some feedback:
    - For `/utterances`, I get the confidence threshold in the router.
    - For `/bins`, I get the confidence threshold in the module. I have some trouble with `pipeline_index`. Before investing more time, is that even a sensible approach?

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
