### PR TITLE
Ggm/clean up conf test

### DIFF
--- a/azimuth/dataset_split_manager.py
+++ b/azimuth/dataset_split_manager.py
@@ -304,7 +304,7 @@ class DatasetSplitManager:
         }
         unknown_tag = {k: v for k, v in unknown_tag.items() if len(v) > 0}
         if len(unknown_tag) > 0:
-            raise ValueError(f"Unknown   tags {unknown_tag}")
+            raise ValueError(f"Unknown tags {unknown_tag}")
 
         # Process base tags
         base_tags_present = any(any(tag_values.values()) for tag_values in base_tags.values())

--- a/azimuth/routers/v1/app.py
+++ b/azimuth/routers/v1/app.py
@@ -30,7 +30,7 @@ from azimuth.types.perturbation_testing import (
     PerturbationTestingMergedResponse,
     PerturbationTestingSummaryResponse,
 )
-from azimuth.types.tag import ALL_DATA_ACTIONS, ALL_SMART_TAGS
+from azimuth.types.tag import ALL_DATA_ACTION_FILTERS, ALL_SMART_TAG_FILTERS
 from azimuth.utils.object_loader import load_custom_object
 from azimuth.utils.project import (
     perturbation_testing_available,
@@ -108,8 +108,8 @@ def get_dataset_info(
     return DatasetInfoResponse(
         project_name=config.name,
         class_names=eval_dm.get_class_names(),
-        data_actions=ALL_DATA_ACTIONS,
-        smart_tags=ALL_SMART_TAGS,
+        data_actions=ALL_DATA_ACTION_FILTERS,
+        smart_tags=ALL_SMART_TAG_FILTERS,
         eval_class_distribution=eval_dm.class_distribution().tolist(),
         train_class_distribution=training_dm.class_distribution().tolist()
         if training_dm is not None

--- a/azimuth/task_manager.py
+++ b/azimuth/task_manager.py
@@ -1,7 +1,6 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
-
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import structlog
@@ -128,7 +127,10 @@ class TaskManager:
         if self._is_locked:
             raise TaskManagerLockedException("Can't get/start tasks when TaskManager is locked!")
         task_cls = self.tasks.get(task_name)
-        mod_options = mod_options or ModuleOptions()
+        if mod_options:
+            mod_options = mod_options.copy(deep=True)
+        else:
+            mod_options = ModuleOptions()
 
         if task_cls is not None:
             # We found the task, we can instantiate it.

--- a/azimuth/types/tag.py
+++ b/azimuth/types/tag.py
@@ -58,10 +58,10 @@ class SmartTag(str, Enum):
 
 Tag = str
 ALL_DATA_ACTION_FILTERS = [a.value for a in DataAction]
-ALL_DATA_ACTIONS = [a for a in ALL_DATA_ACTION_FILTERS if a is not DataAction.no_action]
+ALL_DATA_ACTIONS = [a for a in ALL_DATA_ACTION_FILTERS if a != DataAction.no_action]
 
 ALL_SMART_TAG_FILTERS = [a.value for a in SmartTag]
-ALL_SMART_TAGS = [a for a in ALL_SMART_TAG_FILTERS if a is not SmartTag.no_smart_tag]
+ALL_SMART_TAGS = [a for a in ALL_SMART_TAG_FILTERS if a != SmartTag.no_smart_tag]
 
 ALL_TAGS = ALL_SMART_TAGS + ALL_DATA_ACTIONS
 ALL_SYNTAX_TAGS = [

--- a/azimuth/utils/filtering.py
+++ b/azimuth/utils/filtering.py
@@ -72,7 +72,7 @@ def filter_dataset_split(
         # We do OR for data_action tags.
         dataset_split = dataset_split.filter(
             lambda x: any(
-                ((not any(x[v] for v in ALL_DATA_ACTIONS)) if v is DataAction.no_action else x[v])
+                ((not any(x[v] for v in ALL_DATA_ACTIONS)) if v == DataAction.no_action else x[v])
                 for v in filters.data_actions
             )
         )
@@ -89,7 +89,7 @@ def filter_dataset_split(
         # We do AND for smart tags.
         dataset_split = dataset_split.filter(
             lambda x: all(
-                ((not any(x[v] for v in ALL_SMART_TAGS)) if v is SmartTag.no_smart_tag else x[v])
+                ((not any(x[v] for v in ALL_SMART_TAGS)) if v == SmartTag.no_smart_tag else x[v])
                 for v in filters.smart_tags
             )
         )

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,76 @@
+# Tests
+
+Run tests with `make test`.
+
+    Reminder, when running router tests, don't forget to clean the cache before, either
+    with `make clean` or `rm -r /tmp/azimuth_test_cache`.
+
+## Different Fixtures
+
+Fixtures mentioned here are in `conftest.py`. Functions are in `utils.py`.
+
+### Configs
+
+#### Sentiment Analysis
+
+Most of our tests use a version of the sentiment analysis dataset and a model with random weights.
+The dataset has 2 labels: `positive` and `negative`. The pipeline can predict the `REJECTION_CLASS`
+if the threshold is set higher than 0.5.
+
+* `simple_text_config` is the 'base' config. The dataset is quite big for tests (42 samples in each
+  split), and should not be used for computationally intensive tests. However, it can be useful if
+  the test needs a diversity of data point. It can be coupled with `apply_mocked_startup_task`, if
+  the prediction data can be mocked (see below).
+    * `simple_text_config_multi_pipeline` is the same but have 2 pipelines with a different
+      threshold.
+* `tiny_text_config` is the same as `simple_text_config`, but only have 2 samples in each split.
+  This is useful for tasks that don't need a diversity of data points, but might need the real
+  prediction results (instead of mocked). See the functions `save_predictions`
+  and `save_outcomes` below.
+    * `tiny_text_config_no_train`: No training set.
+    * `tiny_text_config_no_pipeline`: No pipeline.
+
+#### Intent Classification
+
+Some tests need to test other model contracts than `hf_text_classification`, or might need more than
+2 classes. The following fixtures can be useful for that.
+
+* File-based configs are useful to test modules where you expect a given result based on specific
+  values in the dataset (Ex: Determining outcomes based on predictions).
+    * `file_text_config_top1` is the most useful, with a simple use case of a single prediction. It
+      has 5 classes, 6 samples in eval and 8 samples in train.
+    * `file_text_config_top3` is only useful to test the top3 implementation of the file-based
+      module.
+    * `file_text_config_no_intent` is only useful to test the file-based module with no_intent.
+* `clinc_text_config` is mostly useful to test that the clinc dataset can be loaded, but can also be
+  used in other tests, where it is useful to look at the dataset (it is
+  under `fixtures/sample_CLINC150.json`). It has 16 classes according to the config, but only data
+  for 3 classes in the subset. It has 6 samples in the training set and 5 in the evaluation set.
+* `guse_text_config` is mostly useful to test the `CustomTextClassificationModule`.
+
+### Predictions
+
+#### Mocking DatasetSplitManager and Start-Up Tasks
+
+* If the predictions, outcomes, tags (and so on) can be mocked for the test, you can use the
+  fixture `apply_mocked_startup_task`. By default, it should be paired with `simple_text_config`.
+  However, you can run it on any config, by adding `apply_mocked_startup_task(config)` at the
+  beginning of the test.
+* If you don't need the 2 dataset split managers (train and eval), and just need a
+  mocked `DatasetSplitManager`, you can simply call in your test: `dm = generate_mocked_dm(config)`.
+
+#### Saving real predictions and outcomes
+
+* If the predictions and outcomes should be real (not mocked), you can use the
+  functions `save_predictions(config)` and `save_outcomes(config)` at the beginning of the test. It
+  will call the prediction and outcomes module on the config, and save them in the dataset.
+
+#### Table Key
+
+* To get a table key, you can use the function `get_table_key(config)`.
+
+### Task Manager and Dask Client
+
+* If your test needs a Dask Client, you can add the fixture `dask_client`.
+* If your test needs a TaskManager (most don't), `tiny_text_task_manager` is set up to work with
+  the `tiny_text_config`. Use both for the tests.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,45 +2,31 @@
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
 
-import random
 import threading
 from copy import deepcopy
-from pathlib import Path
 
-import numpy as np
 import pytest
 from distributed import Client, LocalCluster
 
-from azimuth.config import (
-    AzimuthConfig,
-    BehavioralTestingOptions,
-    NeutralTokenOptions,
-    TypoTestOptions,
-)
-from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
+from azimuth.config import AzimuthConfig
 from azimuth.modules.base_classes import ArtifactManager
-from azimuth.modules.model_performance.outcomes import OutcomesModule
-from azimuth.modules.task_mapping import model_contract_methods, modules
 from azimuth.startup import START_UP_THREAD_NAME
 from azimuth.task_manager import TaskManager
-from azimuth.types import DatasetColumn, DatasetSplitName
-from azimuth.types.outcomes import OutcomeName
-from azimuth.types.tag import (
-    ALL_DATA_ACTIONS,
-    ALL_PREDICTION_TAGS,
-    ALL_SMART_TAGS,
-    ALL_STANDARD_TAGS,
+from azimuth.types import DatasetSplitName
+from tests.utils import (
+    DATASET_CFG,
+    DATASET_CLINC150_CFG,
+    PIPELINE_CFG,
+    PIPELINE_GUSE_CFG,
+    SAMPLE_INTENT_TRAIN_FILE_NO_INTENT,
+    SAMPLE_PREDICTIONS_FILEPATH_TOP3,
+    SIMPLE_PERTURBATION_TESTING_CONFIG,
+    file_based_ds_from_paths,
+    file_based_pipeline_from,
+    generate_mocked_dm,
 )
-from azimuth.utils.project import (
-    load_dataset_from_config,
-    load_dataset_split_managers_from_config,
-)
-from tests.test_loading_resources import load_sst2_dataset
 
-SIMPLE_PERTURBATION_TESTING_CONFIG = BehavioralTestingOptions(
-    neutral_suffix=NeutralTokenOptions(suffix_list=["pls", "thanks"], prefix_list=["pls", "hello"]),
-    typo=TypoTestOptions(threshold=0.005),
-)
+# General Fixtures
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -74,37 +60,17 @@ def dask_client():
     client.close()
 
 
-_AZ_ROOT = Path(__file__).parents[1].resolve()
-_CURRENT_DIR = Path(__file__).parent.resolve()
-_SAMPLE_DATA_DIR = _CURRENT_DIR / "fixtures"
-_SAMPLE_VOCAB_DIR = _SAMPLE_DATA_DIR / "distilbert-tokenizer-files"
+@pytest.fixture
+def apply_mocked_startup_task(simple_text_config):
+    def fn(config):
+        generate_mocked_dm(config, DatasetSplitName.eval)
+        generate_mocked_dm(config, DatasetSplitName.train)
 
-CHECKPOINT_PATH = str(_SAMPLE_VOCAB_DIR)
-MODEL_CFG = {
-    "name": "Default Model",
-    "model": {
-        "class_name": "tests.test_loading_resources.load_hf_text_classif_pipeline",
-        "kwargs": {"checkpoint_path": CHECKPOINT_PATH},
-    },
-}
+    fn(simple_text_config)
+    return fn
 
-HIGH_THRESHOLD_MODEL = {
-    "name": "High threshold Model",
-    "model": {
-        "class_name": "tests.test_loading_resources.load_hf_text_classif_pipeline",
-        "kwargs": {"checkpoint_path": CHECKPOINT_PATH},
-    },
-    "postprocessors": [{"threshold": 0.99}],
-}
-DATASET_CFG = {
-    "class_name": "tests.test_loading_resources.load_sst2_dataset",
-    "kwargs": {},
-}
 
-TINY_DATASET_CFG = {
-    "class_name": "tests.test_loading_resources.load_sst2_dataset",
-    "kwargs": {"max_dataset_len": 2},
-}
+# Sentiment Analysis Fixtures
 
 
 @pytest.fixture
@@ -112,10 +78,9 @@ def simple_text_config(tmp_path):
     return AzimuthConfig(
         name="sentiment-analysis",
         dataset=DATASET_CFG,
-        pipelines=[MODEL_CFG],
+        pipelines=[PIPELINE_CFG],
         artifact_path=str(tmp_path),
         batch_size=10,
-        use_cuda="auto",
         model_contract="hf_text_classification",
         saliency_layer="distilbert.embeddings.word_embeddings",
         rejection_class=None,
@@ -124,194 +89,43 @@ def simple_text_config(tmp_path):
 
 
 @pytest.fixture
-def simple_multipipeline_text_config(tmp_path):
-    return AzimuthConfig(
-        name="sentiment-analysis",
-        dataset=DATASET_CFG,
-        pipelines=[MODEL_CFG, HIGH_THRESHOLD_MODEL],
-        artifact_path=str(tmp_path),
-        batch_size=10,
-        use_cuda="auto",
-        model_contract="hf_text_classification",
-        saliency_layer="distilbert.embeddings.word_embeddings",
-        rejection_class=None,
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
+def simple_text_config_multi_pipeline(simple_text_config):
+    pipeline_cfg_low = deepcopy(PIPELINE_CFG)
+    pipeline_cfg_low["name"] = "Low threshold Model"
+    pipeline_cfg_low["postprocessors"][0]["threshold"] = 0.2
+    pipeline_cfg_high = deepcopy(PIPELINE_CFG)
+    pipeline_cfg_high["name"] = "High threshold Model"
+    pipeline_cfg_high["postprocessors"][0]["threshold"] = 0.99
+    simple_multipipeline_text_config = simple_text_config.copy(
+        deep=True, update=dict(pipelines=[pipeline_cfg_low, pipeline_cfg_high])
     )
+    return simple_multipipeline_text_config
 
 
 @pytest.fixture
-def simple_no_pipeline_text_config(tmp_path):
-    return AzimuthConfig(
-        name="sentiment-analysis",
-        dataset=DATASET_CFG,
-        pipelines=None,
-        artifact_path=str(tmp_path),
-        batch_size=10,
-        use_cuda="auto",
-        model_contract="hf_text_classification",
-        saliency_layer="distilbert.embeddings.word_embeddings",
-        rejection_class=None,
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
-    )
+def tiny_text_config(simple_text_config) -> AzimuthConfig:
+    tiny_text_config = simple_text_config.copy(deep=True)
+    tiny_text_config.dataset.kwargs["max_dataset_len"] = 2
+    return tiny_text_config
 
 
 @pytest.fixture
-def simple_table_key(simple_text_config):
-    return PredictionTableKey.from_pipeline_index(
-        0,
-        simple_text_config,
-    )
+def tiny_text_config_no_train(tiny_text_config) -> AzimuthConfig:
+    tiny_text_config_no_train = tiny_text_config.copy(deep=True)
+    tiny_text_config_no_train.dataset.kwargs["train"] = False
+    return tiny_text_config_no_train
 
 
 @pytest.fixture
-def clinc_table_key(text_config_CLINC150):
-    return PredictionTableKey.from_pipeline_index(
-        0,
-        text_config_CLINC150,
-    )
+def tiny_text_config_no_pipeline(tiny_text_config) -> AzimuthConfig:
+    tiny_text_config_no_pipeline = tiny_text_config.copy(deep=True)
+    tiny_text_config_no_pipeline.pipelines = None
+    return tiny_text_config_no_pipeline
 
 
 @pytest.fixture
-def simple_text_config_high_threshold(tmp_path):
-    # We set the threshold very high because our test model has random weights
-    return AzimuthConfig(
-        name="sentiment-analysis",
-        dataset=DATASET_CFG,
-        pipelines=[HIGH_THRESHOLD_MODEL],
-        artifact_path=str(tmp_path),
-        batch_size=10,
-        model_contract="hf_text_classification",
-        use_cuda="auto",
-        saliency_layer="distilbert.embeddings.word_embeddings",
-        rejection_class=None,
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
-    )
-
-
-@pytest.fixture
-def simple_text_config_with_postprocessors(simple_text_config):
-    simple_text_config_postprocessors = simple_text_config.copy(deep=True)
-    simple_text_config_postprocessors.pipelines[0].postprocessors[-1].threshold = 0.7
-    simple_text_config_postprocessors.pipelines[0].postprocessors[0].temperature = 3
-    return simple_text_config_postprocessors
-
-
-@pytest.fixture
-def simple_text_config_no_train(tmp_path):
-    config = deepcopy(DATASET_CFG)
-    config["kwargs"]["train"] = False
-    return AzimuthConfig(
-        name="sentiment-analysis",
-        dataset=config,
-        pipelines=[MODEL_CFG],
-        artifact_path=str(tmp_path),
-        batch_size=10,
-        use_cuda="auto",
-        rejection_class=None,
-        model_contract="hf_text_classification",
-        saliency_layer="distilbert.embeddings.word_embeddings",
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
-    )
-
-
-@pytest.fixture
-def tiny_text_config(simple_text_config):
-    tiny_cfg = simple_text_config.copy(deep=True, update=dict(dataset=TINY_DATASET_CFG))
-    return tiny_cfg
-
-
-@pytest.fixture
-def tiny_text_config_postprocessors(tiny_text_config):
-    tiny_cfg_postprocessors = tiny_text_config.copy(deep=True)
-    tiny_cfg_postprocessors.pipelines[0].postprocessors[-1].threshold = 0.9
-    tiny_cfg_postprocessors.pipelines[0].postprocessors[0].temperature = 3
-    return tiny_cfg_postprocessors
-
-
-@pytest.fixture
-def a_text_dataset():
-    return load_sst2_dataset()["validation"]
-
-
-@pytest.fixture
-def text_dm_with_tags(simple_text_config_with_postprocessors):
-    ds = load_dataset_from_config(simple_text_config_with_postprocessors)[DatasetSplitName.eval]
-    ds = ds.map(
-        lambda x, i: {
-            DatasetColumn.model_predictions: [i % 2, 1 - i % 2],
-            DatasetColumn.model_confidences: [i / len(ds), 1 - i / len(ds)],
-            # 0.9 simulates temperature scaling
-            DatasetColumn.postprocessed_confidences: [0.9 * (i / len(ds)), 1 - 0.9 * (i / len(ds))],
-            DatasetColumn.confidence_bin_idx: np.random.randint(1, 20),
-        },
-        with_indices=True,
-    )
-
-    ds = ds.map(
-        lambda x: {
-            DatasetColumn.postprocessed_prediction: x[DatasetColumn.model_predictions][0]
-            if x[DatasetColumn.postprocessed_confidences][0]
-            > simple_text_config_with_postprocessors.pipelines[0].threshold
-            else -1,
-        }
-    )
-    ds = ds.map(
-        lambda x: {
-            DatasetColumn.model_outcome: OutcomesModule.compute_outcome(
-                x[DatasetColumn.model_predictions][0], x["label"], -1
-            ),
-            DatasetColumn.postprocessed_outcome: OutcomesModule.compute_outcome(
-                x[DatasetColumn.postprocessed_prediction], x["label"], -1
-            ),
-            DatasetColumn.neighbors_train: [
-                [np.random.randint(1, 1000), np.random.rand()] for i in range(0, 20)
-            ],
-            DatasetColumn.neighbors_eval: [
-                [np.random.randint(1, 1000), np.random.rand()] for i in range(0, 20)
-            ],
-        }
-    )
-
-    dm = DatasetSplitManager(
-        DatasetSplitName.eval,
-        simple_text_config_with_postprocessors,
-        initial_tags=ALL_STANDARD_TAGS,
-        initial_prediction_tags=ALL_PREDICTION_TAGS,
-        dataset_split=ds,
-    )
-    add_every_tag_once(dm)
-    yield dm
-
-
-def add_every_tag_once(dm):
-    # Tags some utterances
-    for idx, t in enumerate(ALL_DATA_ACTIONS):
-        tags = {idx: {t: True}}
-        dm.add_tags(
-            tags,
-            PredictionTableKey.from_pipeline_index(
-                0,
-                dm.config,
-            ),
-        )
-    # Tags some utterances
-    for idx, t in enumerate(ALL_SMART_TAGS):
-        tags = {idx: {t: True}}
-        dm.add_tags(
-            tags,
-            PredictionTableKey.from_pipeline_index(
-                0,
-                dm.config,
-            ),
-        )
-
-
-@pytest.fixture
-def text_task_manager(simple_text_config, dask_client):
-    task_manager = TaskManager(simple_text_config, cluster=dask_client.cluster)
-    for task_type in [model_contract_methods, modules]:
-        for k, v in task_type.items():
-            task_manager.register_task(k, v)
+def tiny_text_task_manager(tiny_text_config, dask_client):
+    task_manager = TaskManager(tiny_text_config, cluster=dask_client.cluster)
 
     yield task_manager
 
@@ -323,145 +137,18 @@ def text_task_manager(simple_text_config, dask_client):
         th.join()
 
 
-@pytest.fixture
-def text_task_manager_high_threshold(simple_text_config_high_threshold, dask_client):
-    task_manager = TaskManager(simple_text_config_high_threshold, cluster=dask_client.cluster)
-    for task_type in [model_contract_methods, modules]:
-        for k, v in task_type.items():
-            task_manager.register_task(k, v)
-
-    yield task_manager
-
-    task_manager.close()
-    thread = threading.enumerate()
-    start_up_thread = [th for th in thread if th.name == START_UP_THREAD_NAME]
-    for th in start_up_thread:
-        th.join()
-
-
-@pytest.fixture
-def simple_text_config_cuda(tmp_path):
-    return AzimuthConfig(
-        name="sentiment-analysis",
-        dataset=DATASET_CFG,
-        pipelines=[MODEL_CFG],
-        artifact_path=str(tmp_path),
-        batch_size=10,
-        use_cuda="auto",
-        rejection_class=None,
-        model_contract="hf_text_classification",
-        saliency_layer="distilbert.embeddings.word_embeddings",
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
-    )
-
-
-@pytest.fixture
-def apply_mocked_startup_task(simple_text_config):
-    def fn(config):
-        faiss_features = lambda: np.random.randn(786)
-        columns = [
-            (DatasetColumn.model_predictions, lambda: np.random.randint(0, 2, size=2).tolist()),
-            (DatasetColumn.postprocessed_prediction, lambda: np.random.randint(0, 2)),
-            (DatasetColumn.model_confidences, lambda: [0.4, 0.6]),
-            (DatasetColumn.postprocessed_confidences, lambda: [0.4, 0.6]),
-            (DatasetColumn.token_count, lambda: np.random.randint(5, 12)),
-            (DatasetColumn.postprocessed_outcome, lambda: random.choice([r for r in OutcomeName])),
-        ]
-        dms = load_dataset_split_managers_from_config(config)
-        for dm in dms.values():
-            row = dm.num_rows
-            [dm.add_column(name, [fn() for _ in range(row)]) for name, fn in columns]
-            add_every_tag_once(dm)
-            dm.add_faiss_index([faiss_features() for _ in range(row)])
-
-    fn(simple_text_config)
-    return fn
-
-
-_SAMPLE_INTENT_DIR = _SAMPLE_DATA_DIR / "intent"
-_SAMPLE_INTENT_TRAIN_FILE = str(_SAMPLE_INTENT_DIR / "sample_train_file.csv")
-_SAMPLE_INTENT_TRAIN_FILE_WNOINTENT = str(_SAMPLE_INTENT_DIR / "sample_train_file_wnointent.csv")
-_SAMPLE_PREDICTIONS_FILEPATH_TOP3 = str(_SAMPLE_INTENT_DIR / "sample_predictions_top3.csv")
-_SAMPLE_PREDICTIONS_FILEPATH_TOP1 = str(_SAMPLE_INTENT_DIR / "sample_predictions_top1.csv")
-
-_SAMPLE_CLINC150 = str(_SAMPLE_DATA_DIR / "sample_CLINC150.json")
-
-DATASET_INTENT_TOP3_CFG = {
-    "class_name": "tests.test_loading_resources.load_file_dataset",
-    "args": ["csv"],
-    "kwargs": {
-        "data_files": {
-            "train": _SAMPLE_INTENT_TRAIN_FILE,
-            "test": _SAMPLE_PREDICTIONS_FILEPATH_TOP3,
-        },
-    },
-}
-
-DATASET_INTENT_TOP1_CFG = {
-    "class_name": "tests.test_loading_resources.load_file_dataset",
-    "args": ["csv"],
-    "kwargs": {
-        "data_files": {
-            "train": _SAMPLE_INTENT_TRAIN_FILE,
-            "test": _SAMPLE_PREDICTIONS_FILEPATH_TOP1,
-        },
-    },
-}
-
-DATASET_NOINTENT_CFG = {
-    "class_name": "tests.test_loading_resources.load_file_dataset",
-    "args": ["csv"],
-    "kwargs": {
-        "data_files": {
-            "train": _SAMPLE_INTENT_TRAIN_FILE_WNOINTENT,
-            "test": _SAMPLE_PREDICTIONS_FILEPATH_TOP1,
-        },
-    },
-}
-
-DATASET_CLINC150_CFG = {
-    "class_name": "tests.test_loading_resources.load_CLINC150_data",
-    "kwargs": {
-        "python_loader": str(_AZ_ROOT / "azimuth_shr/data/CLINC150.py"),
-        "full_path": _SAMPLE_CLINC150,
-    },
-}
-
-
-def file_based_model_from(ds_config):
-    return {
-        "class_name": "models.file_based.FileBasedModel",
-        "remote": str(_AZ_ROOT / "azimuth_shr"),
-        "kwargs": {
-            "test_path": ds_config["kwargs"]["data_files"]["test"],
-        },
-    }
-
-
-@pytest.fixture
-def file_text_config_top3(tmp_path):
-    return AzimuthConfig(
-        name="intent-test",
-        pipelines=[{"model": file_based_model_from(DATASET_INTENT_TOP3_CFG)}],
-        dataset=DATASET_INTENT_TOP3_CFG,
-        artifact_path=str(tmp_path),
-        batch_size=3,
-        use_cuda="auto",
-        rejection_class="NO_INTENT",
-        model_contract="file_based_text_classification",
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
-    )
+# File-Based Fixtures
 
 
 @pytest.fixture
 def file_text_config_top1(tmp_path):
+    ds_config = file_based_ds_from_paths()
     return AzimuthConfig(
         name="intent-test",
-        pipelines=[{"model": file_based_model_from(DATASET_INTENT_TOP1_CFG)}],
-        dataset=DATASET_INTENT_TOP1_CFG,
+        pipelines=[{"model": file_based_pipeline_from(ds_config)}],
+        dataset=ds_config,
         artifact_path=str(tmp_path),
-        batch_size=3,
-        use_cuda="auto",
+        batch_size=10,
         rejection_class="NO_INTENT",
         model_contract="file_based_text_classification",
         behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
@@ -469,53 +156,41 @@ def file_text_config_top1(tmp_path):
 
 
 @pytest.fixture
-def file_text_config_no_intent(tmp_path):
-    return AzimuthConfig(
-        name="intent-test",
-        dataset=DATASET_NOINTENT_CFG,
-        pipelines=[{"model": file_based_model_from(DATASET_NOINTENT_CFG)}],
-        artifact_path=str(tmp_path),
-        batch_size=3,
-        use_cuda="auto",
-        rejection_class="NO_INTENT",
-        model_contract="file_based_text_classification",
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
+def file_text_config_top3(file_text_config_top1):
+    ds_config = file_based_ds_from_paths(test=SAMPLE_PREDICTIONS_FILEPATH_TOP3)
+    file_text_config_top3 = file_text_config_top1.copy(
+        deep=True,
+        update=dict(pipelines=[{"model": file_based_pipeline_from(ds_config)}], dataset=ds_config),
     )
+    return file_text_config_top3
 
 
 @pytest.fixture
-def text_config_CLINC150(tmp_path):
-    return AzimuthConfig(
-        name="intent-test",
-        dataset=DATASET_CLINC150_CFG,
-        pipelines=[MODEL_CFG],
-        artifact_path=str(tmp_path),
-        batch_size=3,
-        use_cuda="auto",
-        rejection_class="NO_INTENT",
-        model_contract="hf_text_classification",
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
+def file_text_config_no_intent(file_text_config_top1):
+    ds_config = file_based_ds_from_paths(train=SAMPLE_INTENT_TRAIN_FILE_NO_INTENT)
+    file_text_config_no_intent = file_text_config_top1.copy(
+        deep=True,
+        update=dict(pipelines=[{"model": file_based_pipeline_from(ds_config)}], dataset=ds_config),
     )
+    return file_text_config_no_intent
 
 
-MODEL_GUSE_CFG = {
-    "model": {
-        "class_name": "tests.test_loading_resources.load_tf_model",
-        "kwargs": {"checkpoint_path": CHECKPOINT_PATH},
-    }
-}
+# Specific Dataset/Pipelines Fixtures
 
 
 @pytest.fixture
-def guse_text_config(tmp_path):
-    return AzimuthConfig(
-        name="intent-test",
-        dataset=DATASET_INTENT_TOP1_CFG,
-        pipelines=[MODEL_GUSE_CFG],
-        artifact_path=str(tmp_path),
-        batch_size=3,
-        use_cuda="auto",
-        rejection_class="NO_INTENT",
-        model_contract="custom_text_classification",
-        behavioral_testing=SIMPLE_PERTURBATION_TESTING_CONFIG,
+def clinc_text_config(simple_text_config):
+    clinc_text_config = simple_text_config.copy(deep=True)
+    clinc_text_config.dataset = DATASET_CLINC150_CFG
+    clinc_text_config.rejection_class = "NO_INTENT"
+    clinc_text_config.name = "clinc-test"
+    return clinc_text_config
+
+
+@pytest.fixture
+def guse_text_config(file_text_config_top1):
+    guse_text_config = file_text_config_top1.copy(
+        deep=True, update=dict(pipelines=[PIPELINE_GUSE_CFG])
     )
+    guse_text_config.model_contract = "custom_text_classification"
+    return guse_text_config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,10 +92,10 @@ def simple_text_config(tmp_path):
 def simple_text_config_multi_pipeline(simple_text_config):
     pipeline_cfg_low = deepcopy(PIPELINE_CFG)
     pipeline_cfg_low["name"] = "Low threshold Model"
-    pipeline_cfg_low["postprocessors"][0]["threshold"] = 0.2
+    pipeline_cfg_low["postprocessors"][-1]["threshold"] = 0.2
     pipeline_cfg_high = deepcopy(PIPELINE_CFG)
     pipeline_cfg_high["name"] = "High threshold Model"
-    pipeline_cfg_high["postprocessors"][0]["threshold"] = 0.99
+    pipeline_cfg_high["postprocessors"][-1]["threshold"] = 0.99
     simple_multipipeline_text_config = simple_text_config.copy(
         deep=True, update=dict(pipelines=[pipeline_cfg_low, pipeline_cfg_high])
     )
@@ -184,6 +184,10 @@ def clinc_text_config(simple_text_config):
     clinc_text_config.dataset = DATASET_CLINC150_CFG
     clinc_text_config.rejection_class = "NO_INTENT"
     clinc_text_config.name = "clinc-test"
+    clinc_text_config.pipelines[0].postprocessors[0].temperature = 1
+    clinc_text_config.pipelines[0].postprocessors[0].kwargs["temperature"] = 1
+    clinc_text_config.pipelines[0].postprocessors[-1].threshold = 0.5
+    clinc_text_config.pipelines[0].postprocessors[-1].kwargs["threshold"] = 0.5
     return clinc_text_config
 
 

--- a/tests/test_modules/test_caching.py
+++ b/tests/test_modules/test_caching.py
@@ -60,8 +60,8 @@ def test_hdf5_caching(data, indices, simple_text_config):
     modified_th_config = deepcopy(simple_text_config)
     # We modify the threshold at both places to be consistent,
     # but in practice only the `kwargs` is used.
-    modified_th_config.pipelines[0].postprocessors[-1].kwargs["threshold"] = 0.8
-    modified_th_config.pipelines[0].postprocessors[-1].threshold = 0.8
+    modified_th_config.pipelines[0].postprocessors[0].kwargs["threshold"] = 0.8
+    modified_th_config.pipelines[0].postprocessors[0].threshold = 0.8
     modified_th_mod = IndexableModule(
         DatasetSplitName.eval, modified_th_config, mod_options=ModuleOptions(indices=indices)
     )

--- a/tests/test_modules/test_caching.py
+++ b/tests/test_modules/test_caching.py
@@ -60,8 +60,8 @@ def test_hdf5_caching(data, indices, simple_text_config):
     modified_th_config = deepcopy(simple_text_config)
     # We modify the threshold at both places to be consistent,
     # but in practice only the `kwargs` is used.
-    modified_th_config.pipelines[0].postprocessors[0].kwargs["threshold"] = 0.8
-    modified_th_config.pipelines[0].postprocessors[0].threshold = 0.8
+    modified_th_config.pipelines[0].postprocessors[-1].kwargs["threshold"] = 0.8
+    modified_th_config.pipelines[0].postprocessors[-1].threshold = 0.8
     modified_th_mod = IndexableModule(
         DatasetSplitName.eval, modified_th_config, mod_options=ModuleOptions(indices=indices)
     )

--- a/tests/test_modules/test_dataset_analysis/test_similarity_analysis.py
+++ b/tests/test_modules/test_dataset_analysis/test_similarity_analysis.py
@@ -10,6 +10,7 @@ from azimuth.dataset_split_manager import FEATURE_FAISS
 from azimuth.modules.dataset_analysis.similarity_analysis import NeighborsTaggingModule
 from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions
 from azimuth.types.tag import SmartTag
+from tests.utils import get_table_key
 
 IDX = 3
 
@@ -22,13 +23,15 @@ class MockedTransformer:
         return normalize(np.random.rand(len(x), self.num_features), axis=1, norm="l1")
 
 
-def test_neighbors(simple_text_config, dask_client, monkeypatch, simple_table_key):
+def test_neighbors(simple_text_config, dask_client, monkeypatch):
     monkeypatch.setattr(faiss_mod, "SentenceTransformer", MockedTransformer)
     # Mock SentenceTransformer on all workers.
     dask_client.run(
         lambda: monkeypatch.setattr(faiss_mod, "SentenceTransformer", MockedTransformer)
     )
     simple_text_config.similarity.conflicting_neighbors_threshold = 0.1
+    simple_table_key = get_table_key(simple_text_config)
+
     mod = NeighborsTaggingModule(DatasetSplitName.eval, simple_text_config)
     res = mod.compute_on_dataset_split()
 

--- a/tests/test_modules/test_model_contracts/test_hf_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_hf_text_classification.py
@@ -109,11 +109,10 @@ def test_prediction(simple_text_config):
         assert pred_res.postprocessed_output.probs.shape == (1, 2)
 
 
-def test_rejection_class(simple_text_config_high_threshold):
-    # We set the threshold very high because our test model has random weights
+def test_rejection_class(simple_text_config):
     mod = HFTextClassificationModule(
         DatasetSplitName.eval,
-        simple_text_config_high_threshold,
+        simple_text_config,
         mod_options=ModuleOptions(
             model_contract_method_name=SupportedMethod.Predictions,
             pipeline_index=0,
@@ -127,8 +126,7 @@ def test_rejection_class(simple_text_config_high_threshold):
         lambda k: k.postprocessed_output.preds[0] != k.model_output.preds[0], out
     )
     assert all(
-        np.max(pred_response.model_output.probs[0])
-        <= simple_text_config_high_threshold.pipelines[0].threshold
+        np.max(pred_response.model_output.probs[0]) <= simple_text_config.pipelines[0].threshold
         for pred_response in rejected_items
     )
 
@@ -233,10 +231,10 @@ def test_custom_class_saliency(simple_text_config):
     assert not np.allclose(result[1][0].saliency, result[2][0].saliency)
 
 
-def test_load_CLINC150_dataset(text_config_CLINC150):
+def test_load_CLINC150_dataset(clinc_text_config):
     task = HFTextClassificationModule(
         DatasetSplitName.train,
-        text_config_CLINC150,
+        clinc_text_config,
         mod_options=ModuleOptions(model_contract_method_name=SupportedMethod.Predictions),
     )
 

--- a/tests/test_modules/test_model_contracts/test_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_text_classification.py
@@ -35,7 +35,7 @@ def test_create_dataset(simple_text_config):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda enabled")
-def test_cuda_support(simple_text_config_cuda):
+def test_cuda_support(simple_text_config):
     batch = Dataset.from_dict(
         {
             "utterance": ["I love my life"],
@@ -44,7 +44,7 @@ def test_cuda_support(simple_text_config_cuda):
 
     task = HFTextClassificationModule(
         DatasetSplitName.eval,
-        simple_text_config_cuda,
+        simple_text_config,
         mod_options=ModuleOptions(
             model_contract_method_name=SupportedMethod.Saliency, pipeline_index=0
         ),
@@ -99,12 +99,12 @@ def test_post_process(simple_text_config):
     rejection_class_idx = mod_high.get_dataset_split_manager().rejection_class_idx
     assert np.all([pred.postprocessed_output.preds == rejection_class_idx for pred in res_high])
 
-    # Try with threshold set at None.
+    # Try with threshold set at 0.
     mod_none = HFTextClassificationModule(
         DatasetSplitName.eval,
         simple_text_config,
         mod_options=ModuleOptions(
-            threshold=None,
+            threshold=0,
             model_contract_method_name=SupportedMethod.PostProcess,
             pipeline_index=0,
             indices=indices,

--- a/tests/test_modules/test_model_contracts/test_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_text_classification.py
@@ -179,7 +179,7 @@ def test_temperature_scaling(simple_text_config):
                             model=simple_text_config.pipelines[0].model,
                             postprocessors=[
                                 {"temperature": temp},
-                                {"threshold": simple_text_config.pipelines[0].threshold},
+                                {"threshold": simple_text_config.pipelines[-1].threshold},
                             ],
                         )
                     ]

--- a/tests/test_modules/test_model_performance/test_confidence_binning.py
+++ b/tests/test_modules/test_model_performance/test_confidence_binning.py
@@ -17,14 +17,14 @@ UNKNOWN_TARGET = [3]
 BIN_GAP = 0.06
 
 
-def test_confidence_histogram(tiny_text_config_postprocessors):
-    save_predictions(tiny_text_config_postprocessors)
-    save_outcomes(tiny_text_config_postprocessors)
+def test_confidence_histogram(tiny_text_config):
+    save_predictions(tiny_text_config)
+    save_outcomes(tiny_text_config)
 
     mod = ConfidenceHistogramModule(
         DatasetSplitName.eval,
-        tiny_text_config_postprocessors,
-        mod_options=ModuleOptions(filters=DatasetFilters(labels=[0]), pipeline_index=0),
+        tiny_text_config,
+        mod_options=ModuleOptions(pipeline_index=0),
     )
     out = mod.compute_on_dataset_split()[0].details_all_bins
     ds = mod.get_dataset_split()
@@ -41,10 +41,8 @@ def test_confidence_histogram(tiny_text_config_postprocessors):
 
     mod_without_postprocessing = ConfidenceHistogramModule(
         DatasetSplitName.eval,
-        tiny_text_config_postprocessors,
-        mod_options=ModuleOptions(
-            filters=DatasetFilters(labels=[0]), pipeline_index=0, without_postprocessing=True
-        ),
+        tiny_text_config,
+        mod_options=ModuleOptions(pipeline_index=0, without_postprocessing=True),
     )
     out_without_postprocessing = mod_without_postprocessing.compute_on_dataset_split()[
         0
@@ -94,11 +92,13 @@ def test_confidence_histogram_empty(simple_text_config, apply_mocked_startup_tas
     assert sum(count for v in out for count in v.outcome_count.values()) == 0
 
 
-def test_confidence_bin_idx(simple_text_config, apply_mocked_startup_task):
+def test_confidence_bin_idx(tiny_text_config):
+    save_predictions(tiny_text_config)
+    save_outcomes(tiny_text_config)
     mod = ConfidenceBinIndexModule(
         DatasetSplitName.eval,
-        simple_text_config,
-        mod_options=ModuleOptions(pipeline_index=0, indices=list(range(10))),
+        tiny_text_config,
+        mod_options=ModuleOptions(pipeline_index=0),
     )
     out = mod.compute_on_dataset_split()
     ds = mod.get_dataset_split()

--- a/tests/test_modules/test_model_performance/test_confusion_matrix.py
+++ b/tests/test_modules/test_model_performance/test_confusion_matrix.py
@@ -51,7 +51,7 @@ def test_confusion_matrix(tiny_text_config):
     # When not normalized, we get the predictions.
     mod_not_normalized = ConfusionMatrixModule(
         DatasetSplitName.eval,
-        tiny_text_config_postprocessors,
+        tiny_text_config,
         mod_options=ModuleOptions(pipeline_index=0, cf_normalized=False),
     )
     [json_output_not_normalized] = mod_not_normalized.compute_on_dataset_split()

--- a/tests/test_modules/test_model_performance/test_confusion_matrix.py
+++ b/tests/test_modules/test_model_performance/test_confusion_matrix.py
@@ -9,13 +9,13 @@ from azimuth.types import DatasetFilters, DatasetSplitName, ModuleOptions
 from tests.utils import save_predictions
 
 
-def test_confusion_matrix(tiny_text_config_postprocessors):
-    save_predictions(tiny_text_config_postprocessors)
+def test_confusion_matrix(tiny_text_config):
+    save_predictions(tiny_text_config)
 
     # Basic confusion matrix
     mod = ConfusionMatrixModule(
         DatasetSplitName.eval,
-        tiny_text_config_postprocessors,
+        tiny_text_config,
         mod_options=ModuleOptions(pipeline_index=0),
     )
     [json_output] = mod.compute_on_dataset_split()
@@ -28,7 +28,7 @@ def test_confusion_matrix(tiny_text_config_postprocessors):
     # Filtered confusion matrix
     mod_filter = ConfusionMatrixModule(
         DatasetSplitName.eval,
-        tiny_text_config_postprocessors,
+        tiny_text_config,
         mod_options=ModuleOptions(filters=DatasetFilters(labels=[0]), pipeline_index=0),
     )
     [json_output_filter] = mod_filter.compute_on_dataset_split()
@@ -39,7 +39,7 @@ def test_confusion_matrix(tiny_text_config_postprocessors):
     # Confusion matrix without postprocessing
     mod_without_postprocessing = ConfusionMatrixModule(
         DatasetSplitName.eval,
-        tiny_text_config_postprocessors,
+        tiny_text_config,
         mod_options=ModuleOptions(pipeline_index=0, without_postprocessing=True),
     )
     [json_output_without_postprocessing] = mod_without_postprocessing.compute_on_dataset_split()

--- a/tests/test_modules/test_model_performance/test_metrics.py
+++ b/tests/test_modules/test_model_performance/test_metrics.py
@@ -21,7 +21,12 @@ from azimuth.modules.model_performance.outcomes import OutcomesModule
 from azimuth.plots.ece import make_ece_figure
 from azimuth.types import DatasetFilters, DatasetSplitName, ModuleOptions
 from azimuth.types.outcomes import OutcomeName, OutcomeResponse
-from azimuth.types.tag import ALL_DATA_ACTIONS, ALL_SMART_TAGS, DataAction, SmartTag
+from azimuth.types.tag import (
+    ALL_DATA_ACTION_FILTERS,
+    ALL_SMART_TAG_FILTERS,
+    DataAction,
+    SmartTag,
+)
 from tests.utils import save_outcomes, save_predictions
 
 
@@ -226,10 +231,11 @@ def test_outcome_count_per_filter(tiny_text_config):
     assert res_post.count_per_filter.smart_tag != res.count_per_filter.smart_tag
 
 
-def test_metrics_per_filter(simple_text_config, apply_mocked_startup_task):
+def test_metrics_per_filter(tiny_text_config, apply_mocked_startup_task):
+    apply_mocked_startup_task(tiny_text_config)
     mf_module = MetricsPerFilterModule(
         dataset_split_name=DatasetSplitName.eval,
-        config=simple_text_config,
+        config=tiny_text_config,
         mod_options=ModuleOptions(pipeline_index=0),
     )
     [result] = mf_module.compute_on_dataset_split()
@@ -247,11 +253,11 @@ def test_metrics_per_filter(simple_text_config, apply_mocked_startup_task):
 
     smart_tag_metrics = result.metrics_per_filter.smart_tag
     assert sum([mf_v.utterance_count for mf_v in smart_tag_metrics]) == ds_len
-    assert len(smart_tag_metrics) == len(ALL_SMART_TAGS)
+    assert len(smart_tag_metrics) == len(ALL_SMART_TAG_FILTERS)
 
     data_action_metrics = result.metrics_per_filter.data_action
     assert sum([mf_v.utterance_count for mf_v in data_action_metrics]) == ds_len
-    assert len(data_action_metrics) == len(ALL_DATA_ACTIONS)
+    assert len(data_action_metrics) == len(ALL_DATA_ACTION_FILTERS)
 
     outcome_metrics = result.metrics_per_filter.outcome
     assert sum([mf_v.utterance_count for mf_v in outcome_metrics]) == ds_len

--- a/tests/test_modules/test_module.py
+++ b/tests/test_modules/test_module.py
@@ -48,17 +48,17 @@ def test_threshold(simple_text_config):
                 model_contract_method_name=SupportedMethod.Inputs, pipeline_index=0
             ),
         ).get_threshold()
-        == 0.5
+        == 0.7
     )
     assert (
         HFTextClassificationModule(
             DatasetSplitName.eval,
             config=simple_text_config,
             mod_options=ModuleOptions(
-                threshold=0.7, model_contract_method_name=SupportedMethod.Inputs, pipeline_index=0
+                threshold=0.9, model_contract_method_name=SupportedMethod.Inputs, pipeline_index=0
             ),
         ).get_threshold()
-        == 0.7
+        == 0.9
     )
 
 

--- a/tests/test_modules/test_perturbation_testing/test_perturbation_testing.py
+++ b/tests/test_modules/test_perturbation_testing/test_perturbation_testing.py
@@ -21,6 +21,7 @@ from azimuth.utils.ml.perturbation_functions import (
     typo,
 )
 from azimuth.utils.ml.perturbation_test import PerturbationTest
+from tests.utils import get_table_key
 
 
 def test_perturbation_testing(simple_text_config):
@@ -184,7 +185,7 @@ def test_contractions(simple_text_config):
     assert "I'm" in results[1].perturbations
 
 
-def test_save(simple_text_config, simple_table_key):
+def test_save(simple_text_config):
     mod = PerturbationTestingModule(
         DatasetSplitName.eval,
         config=simple_text_config,
@@ -214,5 +215,6 @@ def test_save(simple_text_config, simple_table_key):
         for idx in range(dm.num_rows)
     ]
     mod.save_result(res, dm)
+    simple_table_key = get_table_key(simple_text_config)
     assert any(dm.get_dataset_split(simple_table_key)[SmartTag.failed_fuzzy_matching])
     assert any(dm.get_dataset_split(simple_table_key)[SmartTag.failed_punctuation])

--- a/tests/test_modules/test_perturbation_testing/test_perturbation_testing_summary.py
+++ b/tests/test_modules/test_perturbation_testing/test_perturbation_testing_summary.py
@@ -9,7 +9,7 @@ from azimuth.modules.perturbation_testing import (
 from azimuth.types import DatasetSplitName, ModuleOptions
 
 
-def test_perturbation_testing_summary(tiny_text_config, dask_client):
+def test_perturbation_testing_summary(tiny_text_config):
     mod = PerturbationTestingMergedModule(
         dataset_split_name=DatasetSplitName.all,
         config=tiny_text_config,
@@ -39,12 +39,10 @@ def test_perturbation_testing_summary(tiny_text_config, dask_client):
             assert any(test.name in r.name for r in res)
 
 
-def test_without_train(tiny_text_config, dask_client):
-    tiny_text_config.dataset.kwargs["train"] = False
-
+def test_without_train(tiny_text_config_no_train):
     mod = PerturbationTestingMergedModule(
         dataset_split_name=DatasetSplitName.all,
-        config=tiny_text_config,
+        config=tiny_text_config_no_train,
         mod_options=ModuleOptions(pipeline_index=0),
     )
     [res] = mod.compute_on_dataset_split()
@@ -52,7 +50,7 @@ def test_without_train(tiny_text_config, dask_client):
 
     mod_sum = PerturbationTestingSummaryModule(
         dataset_split_name=DatasetSplitName.all,
-        config=tiny_text_config,
+        config=tiny_text_config_no_train,
         mod_options=ModuleOptions(pipeline_index=0),
     )
 

--- a/tests/test_modules/test_pipeline_comparison/test_prediction_comparison.py
+++ b/tests/test_modules/test_pipeline_comparison/test_prediction_comparison.py
@@ -9,10 +9,10 @@ from azimuth.types.pipeline_comparison import PredictionComparisonResponse
 from azimuth.types.tag import SmartTag
 
 
-def test_response(simple_multipipeline_text_config):
+def test_response(simple_text_config_multi_pipeline):
     module = PredictionComparisonModule(
         dataset_split_name=DatasetSplitName.eval,
-        config=simple_multipipeline_text_config,
+        config=simple_text_config_multi_pipeline,
     )
     result = module.compute_on_dataset_split()
     predictions_0 = module._get_predictions(0)
@@ -32,8 +32,8 @@ def test_response(simple_multipipeline_text_config):
         )
 
 
-def test_less_than_two_pipeline(simple_text_config, simple_no_pipeline_text_config):
-    for cfg in (simple_text_config, simple_no_pipeline_text_config):
+def test_less_than_two_pipeline(simple_text_config, tiny_text_config_no_pipeline):
+    for cfg in (simple_text_config, tiny_text_config_no_pipeline):
         module = PredictionComparisonModule(
             dataset_split_name=DatasetSplitName.eval,
             config=cfg,
@@ -42,9 +42,9 @@ def test_less_than_two_pipeline(simple_text_config, simple_no_pipeline_text_conf
             module.compute_on_dataset_split()
 
 
-def test_save_results(simple_multipipeline_text_config):
+def test_save_results(simple_text_config_multi_pipeline):
     module = PredictionComparisonModule(
-        dataset_split_name=DatasetSplitName.eval, config=simple_multipipeline_text_config
+        dataset_split_name=DatasetSplitName.eval, config=simple_text_config_multi_pipeline
     )
     dm = module.get_dataset_split_manager()
     preds = [
@@ -58,9 +58,9 @@ def test_save_results(simple_multipipeline_text_config):
     assert SmartTag.incorrect_for_all_pipelines not in dm.get_dataset_split(None)
 
     # Check that the tag is applied to all prediction tables.
-    for pipeline_index in range(len(simple_multipipeline_text_config.pipelines)):
+    for pipeline_index in range(len(simple_text_config_multi_pipeline.pipelines)):
         table_key = PredictionTableKey.from_pipeline_index(
-            pipeline_index, simple_multipipeline_text_config
+            pipeline_index, simple_text_config_multi_pipeline
         )
         ds = dm.get_dataset_split(table_key)
         assert (

--- a/tests/test_modules/test_word_analysis/test_tokens_to_words.py
+++ b/tests/test_modules/test_word_analysis/test_tokens_to_words.py
@@ -40,7 +40,7 @@ def fake_saliency_record(indices):
     return records
 
 
-def test_get_words(monkeypatch, simple_text_config, dask_client, apply_mocked_startup_task):
+def test_get_words(monkeypatch, simple_text_config, apply_mocked_startup_task):
     mod = TokensToWordsModule(
         dataset_split_name=DatasetSplitName.eval,
         config=simple_text_config,
@@ -57,11 +57,11 @@ def test_get_words(monkeypatch, simple_text_config, dask_client, apply_mocked_st
     assert np.isclose(hello_saliency, json_output[0].saliency[0])
 
 
-def test_top_words_get_tokens_saliencies(simple_text_config, dask_client):
+def test_top_words_get_tokens_saliencies(tiny_text_config):
     mod = TokensToWordsModule(
         DatasetSplitName.eval,
-        simple_text_config,
-        mod_options=ModuleOptions(pipeline_index=0, indices=[1, 2]),
+        tiny_text_config,
+        mod_options=ModuleOptions(pipeline_index=0),
     )
-    rec = mod.get_tokens_saliencies([1, 2])
+    rec = mod.get_tokens_saliencies([0, 1])
     assert len(rec) == 2

--- a/tests/test_modules/test_word_analysis/test_top_words.py
+++ b/tests/test_modules/test_word_analysis/test_top_words.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from azimuth.modules.word_analysis.top_words import TopWordsModule
-from azimuth.types import DatasetFilters, DatasetSplitName, ModuleOptions
+from azimuth.types import DatasetSplitName, ModuleOptions
 from azimuth.types.word_analysis import TokensToWordsResponse
 from tests.utils import save_predictions
 
@@ -42,15 +42,11 @@ def fake_get_words_saliencies(indices):
     return records
 
 
-def test_top_words_with_saliency(
-    monkeypatch, simple_text_config, dask_client, apply_mocked_startup_task
-):
+def test_top_words_with_saliency(tiny_text_config, apply_mocked_startup_task, monkeypatch):
     mod = TopWordsModule(
         dataset_split_name=DatasetSplitName.eval,
-        config=simple_text_config,
-        mod_options=ModuleOptions(
-            filters=DatasetFilters(labels=[0]), top_x=4, pipeline_index=0  # reduce time
-        ),
+        config=tiny_text_config,
+        mod_options=ModuleOptions(top_x=4, pipeline_index=0),
     )
     monkeypatch.setattr(mod, "get_words_saliencies", fake_get_words_saliencies)
     assert mod is not None
@@ -71,7 +67,7 @@ def fake_no_saliency(indices):
     return records
 
 
-def test_top_words_without_saliency(monkeypatch, file_text_config_top1, dask_client):
+def test_top_words_without_saliency(monkeypatch, file_text_config_top1):
     save_predictions(file_text_config_top1)
 
     mod = TopWordsModule(

--- a/tests/test_modules/test_word_analysis/test_top_words.py
+++ b/tests/test_modules/test_word_analysis/test_top_words.py
@@ -42,10 +42,10 @@ def fake_get_words_saliencies(indices):
     return records
 
 
-def test_top_words_with_saliency(tiny_text_config, apply_mocked_startup_task, monkeypatch):
+def test_top_words_with_saliency(simple_text_config, apply_mocked_startup_task, monkeypatch):
     mod = TopWordsModule(
         dataset_split_name=DatasetSplitName.eval,
-        config=tiny_text_config,
+        config=simple_text_config,
         mod_options=ModuleOptions(top_x=4, pipeline_index=0),
     )
     monkeypatch.setattr(mod, "get_words_saliencies", fake_get_words_saliencies)

--- a/tests/test_routers/conftest.py
+++ b/tests/test_routers/conftest.py
@@ -11,7 +11,7 @@ from starlette.testclient import TestClient
 import azimuth.app as me_app
 from azimuth.app import get_ready_flag
 from azimuth.config import AzimuthConfig
-from tests.conftest import DATASET_CFG, SIMPLE_PERTURBATION_TESTING_CONFIG
+from tests.utils import DATASET_CFG, SIMPLE_PERTURBATION_TESTING_CONFIG
 
 
 def mock_ready_flag_false():

--- a/tests/test_routers/test_app.py
+++ b/tests/test_routers/test_app.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from starlette.status import HTTP_200_OK
 from starlette.testclient import TestClient
 
-from azimuth.types.tag import ALL_DATA_ACTIONS, ALL_SMART_TAGS
+from azimuth.types.tag import ALL_DATA_ACTION_FILTERS, ALL_SMART_TAG_FILTERS
 
 
 def test_openapi(app: FastAPI):
@@ -46,9 +46,9 @@ def test_get_dataset_info(app: FastAPI) -> None:
         "postprocessingEditable": [False],
         "predictionAvailable": True,
         "projectName": "sentiment-analysis",
-        "dataActions": ALL_DATA_ACTIONS,
+        "dataActions": ALL_DATA_ACTION_FILTERS,
         "similarityAvailable": True,
-        "smartTags": ALL_SMART_TAGS,
+        "smartTags": ALL_SMART_TAG_FILTERS,
         "evalClassDistribution": [22, 20, 0],
         "trainClassDistribution": [23, 19, 0],
     }

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -87,17 +87,18 @@ def test_clearing_cache(tiny_text_config):
 
 def test_expired_task(tiny_text_task_manager):
     current_update = time.time()
+    pipeline_index_option = ModuleOptions(pipeline_index=0)
     _, pred_task = tiny_text_task_manager.get_task(
         SupportedMethod.Predictions,
         dataset_split_name=DatasetSplitName.eval,
         last_update=current_update,
-        mod_options=ModuleOptions(pipeline_index=0),
+        mod_options=pipeline_index_option,
     )
     # Get an expirable task
     _, confusion_matrix_task = tiny_text_task_manager.get_task(
         SupportedModule.ConfusionMatrix,
         dataset_split_name=DatasetSplitName.eval,
-        mod_options=ModuleOptions(pipeline_index=0),
+        mod_options=pipeline_index_option,
         last_update=current_update,
     )
     assert not pred_task.done() and not confusion_matrix_task.done()
@@ -108,13 +109,13 @@ def test_expired_task(tiny_text_task_manager):
         SupportedMethod.Predictions,
         dataset_split_name=DatasetSplitName.eval,
         last_update=current_update,
-        mod_options=ModuleOptions(pipeline_index=0),
+        mod_options=pipeline_index_option,
     )
     # Get an expirable task
     _, confusion_matrix_task = tiny_text_task_manager.get_task(
         SupportedModule.ConfusionMatrix,
         dataset_split_name=DatasetSplitName.eval,
-        mod_options=ModuleOptions(pipeline_index=0),
+        mod_options=pipeline_index_option,
         last_update=current_update,
     )
     assert pred_task.done() and confusion_matrix_task.done()
@@ -125,13 +126,13 @@ def test_expired_task(tiny_text_task_manager):
         SupportedMethod.Predictions,
         dataset_split_name=DatasetSplitName.eval,
         last_update=current_update,
-        mod_options=ModuleOptions(pipeline_index=0),
+        mod_options=pipeline_index_option,
     )
     # Get an expirable task
     _, confusion_matrix_task = tiny_text_task_manager.get_task(
         SupportedModule.ConfusionMatrix,
         dataset_split_name=DatasetSplitName.eval,
-        mod_options=ModuleOptions(pipeline_index=0),
+        mod_options=pipeline_index_option,
         last_update=current_update,
     )
     assert pred_task.done() and not confusion_matrix_task.done()

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -7,10 +7,8 @@ import time
 import pytest
 
 from azimuth.modules.base_classes import Module
-from azimuth.modules.task_mapping import model_contract_methods
 from azimuth.task_manager import TaskManager, TaskManagerLockedException
 from azimuth.types import (
-    DatasetFilters,
     DatasetSplitName,
     ModuleOptions,
     SupportedMethod,
@@ -18,9 +16,9 @@ from azimuth.types import (
 )
 
 
-def test_get_all_task(text_task_manager):
+def test_get_all_task(tiny_text_task_manager):
     # We can find a task
-    key, mod = text_task_manager.get_task(
+    key, mod = tiny_text_task_manager.get_task(
         SupportedMethod.Inputs,
         dataset_split_name=DatasetSplitName.eval,
         mod_options=ModuleOptions(pipeline_index=0, indices=[0]),
@@ -30,11 +28,11 @@ def test_get_all_task(text_task_manager):
     mod.result()
 
     # The task history is logged
-    tasks = text_task_manager.get_all_tasks_status("Inputs")
+    tasks = tiny_text_task_manager.get_all_tasks_status("Inputs")
     assert len(tasks) == 1
 
     # We can make a new task!
-    key, mod = text_task_manager.get_task(
+    key, mod = tiny_text_task_manager.get_task(
         SupportedModule.SyntaxTagging,
         dataset_split_name=DatasetSplitName.eval,
         mod_options=ModuleOptions(indices=[0]),
@@ -42,16 +40,16 @@ def test_get_all_task(text_task_manager):
     assert mod is not None
 
     # The length stays the same
-    assert len(text_task_manager.get_all_tasks_status("Inputs")) == 1
-    assert len(text_task_manager.get_all_tasks_status("SyntaxTagging")) == 1
-    assert len(text_task_manager.get_all_tasks_status(task=None)) == 2
+    assert len(tiny_text_task_manager.get_all_tasks_status("Inputs")) == 1
+    assert len(tiny_text_task_manager.get_all_tasks_status("SyntaxTagging")) == 1
+    assert len(tiny_text_task_manager.get_all_tasks_status(task=None)) == 2
 
     # We can get info on the cluster
-    info = text_task_manager.status()
+    info = tiny_text_task_manager.status()
     assert "cluster" in info
 
     # If we request something that does not exists, it is None
-    key, mod = text_task_manager.get_task("allo", dataset_split_name=DatasetSplitName.eval)
+    key, mod = tiny_text_task_manager.get_task("allo", dataset_split_name=DatasetSplitName.eval)
     assert mod is None
 
 
@@ -64,118 +62,111 @@ def get_module_data(simple_text_config):
     )
 
 
-def test_clearing_cache(simple_text_config):
-    task_manager = TaskManager(simple_text_config)
-    for k, v in model_contract_methods.items():
-        task_manager.register_task(k, v)
+def test_clearing_cache(tiny_text_config):
+    task_manager = TaskManager(tiny_text_config)
 
     key, mod = task_manager.get_task(
         SupportedMethod.Predictions,
         dataset_split_name=DatasetSplitName.eval,
-        mod_options=ModuleOptions(pipeline_index=0, indices=[1, 2, 3]),
+        mod_options=ModuleOptions(pipeline_index=0, indices=[0, 1]),
     )
     assert mod is not None
     # The task can be awaited
     mod.result()
 
     # The cache is populated somewhere
-    cached = task_manager.client.run(get_module_data, simple_text_config)
+    cached = task_manager.client.run(get_module_data, tiny_text_config)
     assert any([m and d for m, d in cached.values()])
 
     task_manager.clear_worker_cache()
 
     # The cache is cleared somewhere
-    cached = task_manager.client.run(get_module_data, simple_text_config)
+    cached = task_manager.client.run(get_module_data, tiny_text_config)
     assert not any([m and d for m, d in cached.values()])
 
 
-def test_expired_task(text_task_manager, apply_mocked_startup_task):
-    fixed_pred_options = ModuleOptions(indices=[0], pipeline_index=0)
-    fixed_bin_options = ModuleOptions(
-        filters=DatasetFilters(labels=[0], utterance="same"), pipeline_index=0
-    )  # Reduce time.
-
+def test_expired_task(tiny_text_task_manager):
     current_update = time.time()
-    _, pred_task = text_task_manager.get_task(
+    _, pred_task = tiny_text_task_manager.get_task(
         SupportedMethod.Predictions,
         dataset_split_name=DatasetSplitName.eval,
         last_update=current_update,
-        mod_options=fixed_pred_options,
+        mod_options=ModuleOptions(pipeline_index=0),
     )
     # Get an expirable task
-    _, bin_task = text_task_manager.get_task(
-        SupportedModule.ConfidenceHistogram,
+    _, confusion_matrix_task = tiny_text_task_manager.get_task(
+        SupportedModule.ConfusionMatrix,
         dataset_split_name=DatasetSplitName.eval,
-        mod_options=fixed_bin_options,
+        mod_options=ModuleOptions(pipeline_index=0),
         last_update=current_update,
     )
-    assert not pred_task.done() and not bin_task.done()
-    _ = bin_task.wait(), pred_task.wait()
+    assert not pred_task.done() and not confusion_matrix_task.done()
+    _ = confusion_matrix_task.wait(), pred_task.wait()
 
     # If we don't change the time, the task are cached
-    _, pred_task = text_task_manager.get_task(
+    _, pred_task = tiny_text_task_manager.get_task(
         SupportedMethod.Predictions,
         dataset_split_name=DatasetSplitName.eval,
         last_update=current_update,
-        mod_options=fixed_pred_options,
+        mod_options=ModuleOptions(pipeline_index=0),
     )
     # Get an expirable task
-    _, bin_task = text_task_manager.get_task(
-        SupportedModule.ConfidenceHistogram,
+    _, confusion_matrix_task = tiny_text_task_manager.get_task(
+        SupportedModule.ConfusionMatrix,
         dataset_split_name=DatasetSplitName.eval,
-        mod_options=fixed_bin_options,
+        mod_options=ModuleOptions(pipeline_index=0),
         last_update=current_update,
     )
-    assert pred_task.done() and bin_task.done()
+    assert pred_task.done() and confusion_matrix_task.done()
 
     # If we update the dataset_split, bin task will be recomputed
     current_update = time.time()
-    _, pred_task = text_task_manager.get_task(
+    _, pred_task = tiny_text_task_manager.get_task(
         SupportedMethod.Predictions,
         dataset_split_name=DatasetSplitName.eval,
         last_update=current_update,
-        mod_options=fixed_pred_options,
+        mod_options=ModuleOptions(pipeline_index=0),
     )
     # Get an expirable task
-    _, bin_task = text_task_manager.get_task(
-        SupportedModule.ConfidenceHistogram,
+    _, confusion_matrix_task = tiny_text_task_manager.get_task(
+        SupportedModule.ConfusionMatrix,
         dataset_split_name=DatasetSplitName.eval,
-        mod_options=fixed_bin_options,
+        mod_options=ModuleOptions(pipeline_index=0),
         last_update=current_update,
     )
-    assert pred_task.done() and not bin_task.done()
+    assert pred_task.done() and not confusion_matrix_task.done()
 
 
-def test_lock(text_task_manager):
-    assert not text_task_manager.is_locked
+def test_lock(tiny_text_task_manager):
+    assert not tiny_text_task_manager.is_locked
     # Can't unlock a TaskManager that is Unlock
     with pytest.raises(ValueError):
-        text_task_manager.unlock()
-    text_task_manager.lock()
+        tiny_text_task_manager.unlock()
+    tiny_text_task_manager.lock()
     # Can't lock a TaskManager that is lock
     with pytest.raises(ValueError):
-        text_task_manager.lock()
+        tiny_text_task_manager.lock()
 
     # Cant schedule task:
     with pytest.raises(TaskManagerLockedException):
-        text_task_manager.get_task(
+        tiny_text_task_manager.get_task(
             SupportedMethod.Predictions,
             dataset_split_name=DatasetSplitName.eval,
         )
-    text_task_manager.unlock()
-    _ = text_task_manager.get_task(
+    tiny_text_task_manager.unlock()
+    _ = tiny_text_task_manager.get_task(
         SupportedMethod.Predictions,
         dataset_split_name=DatasetSplitName.eval,
-        mod_options=ModuleOptions(pipeline_index=0, indices=[1, 2, 3]),
+        mod_options=ModuleOptions(pipeline_index=0, indices=[0, 1]),
     )
 
 
-def test_custom_query(text_task_manager):
-    _, pred_task = text_task_manager.get_custom_task(
+def test_custom_query(tiny_text_task_manager):
+    _, pred_task = tiny_text_task_manager.get_custom_task(
         SupportedMethod.Predictions,
         custom_query={
-            text_task_manager.config.columns.text_input: ["hello, this is fred"],
-            text_task_manager.config.columns.label: [-1],
+            tiny_text_task_manager.config.columns.text_input: ["hello, this is fred"],
+            tiny_text_task_manager.config.columns.label: [-1],
         },
         mod_options=ModuleOptions(pipeline_index=0),
     )
@@ -185,11 +176,11 @@ def test_custom_query(text_task_manager):
     # Wait for callbacks
     pred_task.wait()
     # Check that we have the same module
-    _, pred_task2 = text_task_manager.get_custom_task(
+    _, pred_task2 = tiny_text_task_manager.get_custom_task(
         SupportedMethod.Predictions,
         custom_query={
-            text_task_manager.config.columns.text_input: ["hello, this is fred"],
-            text_task_manager.config.columns.label: [-1],
+            tiny_text_task_manager.config.columns.text_input: ["hello, this is fred"],
+            tiny_text_task_manager.config.columns.label: [-1],
         },
         mod_options=ModuleOptions(pipeline_index=0),
     )

--- a/tests/test_utils/test_dataset_filtering.py
+++ b/tests/test_utils/test_dataset_filtering.py
@@ -110,7 +110,7 @@ def test_dataset_filtering_no_smart_tag(simple_text_config):
 
     ds_filtered = filter_dataset_split(
         dm.get_dataset_split(simple_table_key),
-        DatasetFilters(smart_tags=["NO_SMART_TAGS"]),
+        DatasetFilters(smart_tags=[SmartTag.no_smart_tag]),
         config=dm.config,
     )
     assert len(ds_filtered) > 0

--- a/tests/test_utils/test_dataset_filtering.py
+++ b/tests/test_utils/test_dataset_filtering.py
@@ -8,15 +8,17 @@ from azimuth.types import DatasetColumn, DatasetFilters
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import ALL_SMART_TAGS, DataAction, SmartTag
 from azimuth.utils.filtering import filter_dataset_split
+from tests.utils import generate_mocked_dm, get_table_key
 
 
-def test_dataset_filtering(text_dm_with_tags, simple_table_key):
-    ds = text_dm_with_tags.get_dataset_split(simple_table_key)
+def test_dataset_filtering(simple_text_config):
+    dm = generate_mocked_dm(simple_text_config)
+    ds = dm.get_dataset_split(get_table_key(simple_text_config))
 
     ds_len = {}
 
     def filtered_len(tf: DatasetFilters) -> int:
-        ds_filtered = filter_dataset_split(ds, tf, config=text_dm_with_tags.config)
+        ds_filtered = filter_dataset_split(ds, tf, config=dm.config)
         ds_len[(tuple(tf.labels), tuple(tf.predictions))] = len(ds_filtered)
         return len(ds_filtered)
 
@@ -36,77 +38,70 @@ def test_dataset_filtering(text_dm_with_tags, simple_table_key):
     assert combination_len < min(ds_len[((), (1,))], ds_len[((0,), ())])
 
 
-def test_dataset_filtering_errors(text_dm_with_tags, simple_table_key):
-    ds = text_dm_with_tags.get_dataset_split(simple_table_key)
+def test_dataset_filtering_errors(simple_text_config):
+    dm = generate_mocked_dm(simple_text_config)
+    ds = dm.get_dataset_split(get_table_key(simple_text_config))
     ds = ds.rename_column(DatasetColumn.postprocessed_prediction, "col1")
     ds = ds.rename_column("label", "col2")
-    ds = ds.rename_column(text_dm_with_tags.config.columns.text_input, "col3")
+    ds = ds.rename_column(dm.config.columns.text_input, "col3")
     ds = ds.rename_column(DatasetColumn.postprocessed_outcome, "col4")
     ds = ds.rename_column(DatasetColumn.postprocessed_confidences, "col5")
 
     with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(
-            ds, DatasetFilters(predictions=[0]), config=text_dm_with_tags.config
-        )
+        _ = filter_dataset_split(ds, DatasetFilters(predictions=[0]), config=dm.config)
     assert DatasetColumn.postprocessed_prediction in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(
-            ds, DatasetFilters(utterance="substring"), config=text_dm_with_tags.config
-        )
+        _ = filter_dataset_split(ds, DatasetFilters(utterance="substring"), config=dm.config)
     assert "utterance" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(ds, DatasetFilters(labels=[1]), config=text_dm_with_tags.config)
+        _ = filter_dataset_split(ds, DatasetFilters(labels=[1]), config=dm.config)
     assert "label" in str(e.value)
 
     with pytest.raises(ValueError) as e:
         _ = filter_dataset_split(
             ds,
             DatasetFilters(outcomes=[OutcomeName.IncorrectAndRejected]),
-            config=text_dm_with_tags.config,
+            config=dm.config,
         )
     assert DatasetColumn.postprocessed_outcome in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(
-            ds, DatasetFilters(confidence_max=0.5), config=text_dm_with_tags.config
-        )
+        _ = filter_dataset_split(ds, DatasetFilters(confidence_max=0.5), config=dm.config)
     assert DatasetColumn.postprocessed_confidences in str(e.value)
 
 
-def test_dataset_filtering_multi(text_dm_with_tags, simple_table_key):
-    ds = text_dm_with_tags.get_dataset_split(simple_table_key)
+def test_dataset_filtering_multi(simple_text_config):
+    simple_table_key = get_table_key(simple_text_config)
+    dm = generate_mocked_dm(simple_text_config)
+    ds = dm.get_dataset_split(simple_table_key)
 
     # We can filter by nothing!
     filters = DatasetFilters()
-    ds_filtered = filter_dataset_split(ds, filters, config=text_dm_with_tags.config)
+    ds_filtered = filter_dataset_split(ds, filters, config=dm.config)
     assert len(ds_filtered) == len(ds)
 
     # We can filter by multiple targets ie does nothing in this case.
-    ds_filtered = filter_dataset_split(
-        ds, DatasetFilters(labels=[0, 1]), config=text_dm_with_tags.config
-    )
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(labels=[0, 1]), config=dm.config)
     assert len(ds) == len(ds_filtered)
 
     # We can filter by multiple preds, will remove the rejection class from preds
-    ds_filtered = filter_dataset_split(
-        ds, DatasetFilters(predictions=[0, 1]), config=text_dm_with_tags.config
-    )
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(predictions=[0, 1]), config=dm.config)
     num_rejection_class = sum(
-        p != -1
-        for p in text_dm_with_tags.get_dataset_split(simple_table_key)[
-            DatasetColumn.postprocessed_prediction
-        ]
+        p != dm.rejection_class_idx
+        for p in dm.get_dataset_split(simple_table_key)[DatasetColumn.postprocessed_prediction]
     )
     assert num_rejection_class == len(ds_filtered)
 
 
-def test_dataset_filtering_no_smart_tag(text_dm_with_tags, simple_table_key):
+def test_dataset_filtering_no_smart_tag(simple_text_config):
+    dm = generate_mocked_dm(simple_text_config)
+    simple_table_key = get_table_key(simple_text_config)
     # Reset all tags to False for the first utterance, to ensure that at least one row is
     # associated with no smart tags.
     [
-        text_dm_with_tags.add_tags(
+        dm.add_tags(
             {0: {smart_tag: False}},
             table_key=simple_table_key,
         )
@@ -114,18 +109,19 @@ def test_dataset_filtering_no_smart_tag(text_dm_with_tags, simple_table_key):
     ]
 
     ds_filtered = filter_dataset_split(
-        text_dm_with_tags.get_dataset_split(simple_table_key),
+        dm.get_dataset_split(simple_table_key),
         DatasetFilters(smart_tags=["NO_SMART_TAGS"]),
-        config=text_dm_with_tags.config,
+        config=dm.config,
     )
     assert len(ds_filtered) > 0
     assert len(ds_filtered.filter(lambda x: any(x[v] for v in ALL_SMART_TAGS))) == 0
 
 
-def test_dataset_filtering_confidence(text_dm_with_tags, simple_table_key):
-    ds = text_dm_with_tags.get_dataset_split(simple_table_key)
+def test_dataset_filtering_confidence(simple_text_config):
+    dm = generate_mocked_dm(simple_text_config)
+    ds = dm.get_dataset_split(get_table_key(simple_text_config))
     ds_filtered = filter_dataset_split(
-        ds, DatasetFilters(confidence_min=0.4, confidence_max=0.6), config=text_dm_with_tags.config
+        ds, DatasetFilters(confidence_min=0.4, confidence_max=0.6), config=dm.config
     )
     assert len(ds_filtered) == 10
     assert (
@@ -138,27 +134,29 @@ def test_dataset_filtering_confidence(text_dm_with_tags, simple_table_key):
     )
 
 
-def test_dataset_filtering_mutually_exclusive(text_dm_with_tags, simple_table_key):
-    ds = text_dm_with_tags.get_dataset_split(simple_table_key)
+def test_dataset_filtering_mutually_exclusive(simple_text_config):
+    dm = generate_mocked_dm(simple_text_config)
+    ds = dm.get_dataset_split(get_table_key(simple_text_config))
     ds_filtered = filter_dataset_split(
         ds,
         DatasetFilters(smart_tags=["NO_SMART_TAGS", "short_sentence"]),
-        config=text_dm_with_tags.config,
+        config=dm.config,
     )
     assert len(ds_filtered) == 0
 
 
-def test_dataset_filtering_without_postprocessing(text_dm_with_tags, simple_table_key):
-    ds = text_dm_with_tags.get_dataset_split(simple_table_key)
+def test_dataset_filtering_without_postprocessing(simple_text_config):
+    dm = generate_mocked_dm(simple_text_config)
+    ds = dm.get_dataset_split(get_table_key(simple_text_config))
     ds_filtered_with_postprocessing = filter_dataset_split(
         ds,
         DatasetFilters(predictions=[0]),
-        config=text_dm_with_tags.config,
+        config=dm.config,
     )
     ds_filtered_without_postprocessing = filter_dataset_split(
         ds,
         DatasetFilters(predictions=[0]),
-        config=text_dm_with_tags.config,
+        config=dm.config,
         without_postprocessing=True,
     )
     assert len(ds_filtered_with_postprocessing) != len(ds_filtered_without_postprocessing)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,101 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
+from pathlib import Path
+
+import numpy as np
+
+from azimuth.config import (
+    BehavioralTestingOptions,
+    NeutralTokenOptions,
+    TypoTestOptions,
+)
+from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
 from azimuth.modules.model_contract_task_mapping import model_contract_task_mapping
 from azimuth.modules.model_performance.outcomes import OutcomesModule
-from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod
+from azimuth.types import (
+    DatasetColumn,
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+)
+from azimuth.types.tag import (
+    ALL_DATA_ACTIONS,
+    ALL_PREDICTION_TAGS,
+    ALL_SMART_TAGS,
+    ALL_STANDARD_TAGS,
+)
+from azimuth.utils.project import load_dataset_from_config
+
+_AZ_ROOT = Path(__file__).parents[1].resolve()
+_CURRENT_DIR = Path(__file__).parent.resolve()
+_SAMPLE_DATA_DIR = _CURRENT_DIR / "fixtures"
+_SAMPLE_VOCAB_DIR = _SAMPLE_DATA_DIR / "distilbert-tokenizer-files"
+_CHECKPOINT_PATH = str(_SAMPLE_VOCAB_DIR)
+SIMPLE_PERTURBATION_TESTING_CONFIG = BehavioralTestingOptions(
+    neutral_suffix=NeutralTokenOptions(suffix_list=["pls", "thanks"], prefix_list=["pls", "hello"]),
+    typo=TypoTestOptions(threshold=0.005),
+)
+
+# Sentiment Analysis
+PIPELINE_CFG = {
+    "name": "Default Model",
+    "model": {
+        "class_name": "tests.test_loading_resources.load_hf_text_classif_pipeline",
+        "kwargs": {"checkpoint_path": _CHECKPOINT_PATH},
+    },
+    "postprocessors": [{"threshold": 0.7}, {"temperature": 3}],
+}
+DATASET_CFG = {
+    "class_name": "tests.test_loading_resources.load_sst2_dataset",
+    "kwargs": {},
+}
+
+# Intent Classification
+_SAMPLE_INTENT_DIR = _SAMPLE_DATA_DIR / "intent"
+_SAMPLE_INTENT_TRAIN_FILE = str(_SAMPLE_INTENT_DIR / "sample_train_file.csv")
+_SAMPLE_PREDICTIONS_FILEPATH_TOP1 = str(_SAMPLE_INTENT_DIR / "sample_predictions_top1.csv")
+_SAMPLE_CLINC150 = str(_SAMPLE_DATA_DIR / "sample_CLINC150.json")
+SAMPLE_INTENT_TRAIN_FILE_NO_INTENT = str(_SAMPLE_INTENT_DIR / "sample_train_file_wnointent.csv")
+SAMPLE_PREDICTIONS_FILEPATH_TOP3 = str(_SAMPLE_INTENT_DIR / "sample_predictions_top3.csv")
+DATASET_CLINC150_CFG = {
+    "class_name": "tests.test_loading_resources.load_CLINC150_data",
+    "kwargs": {
+        "python_loader": str(_AZ_ROOT / "azimuth_shr/data/CLINC150.py"),
+        "full_path": _SAMPLE_CLINC150,
+    },
+}
+PIPELINE_GUSE_CFG = {
+    "model": {
+        "class_name": "tests.test_loading_resources.load_tf_model",
+        "kwargs": {"checkpoint_path": _CHECKPOINT_PATH},
+    }
+}
+
+
+def file_based_ds_from_paths(
+    train=_SAMPLE_INTENT_TRAIN_FILE, test=_SAMPLE_PREDICTIONS_FILEPATH_TOP1
+):
+    return {
+        "class_name": "tests.test_loading_resources.load_file_dataset",
+        "args": ["csv"],
+        "kwargs": {
+            "data_files": {
+                "train": train,
+                "test": test,
+            },
+        },
+    }
+
+
+def file_based_pipeline_from(ds_config):
+    return {
+        "class_name": "models.file_based.FileBasedModel",
+        "remote": str(_AZ_ROOT / "azimuth_shr"),
+        "kwargs": {
+            "test_path": ds_config["kwargs"]["data_files"]["test"],
+        },
+    }
 
 
 def save_predictions(config, ds_split_name=DatasetSplitName.eval):
@@ -28,3 +120,76 @@ def save_outcomes(config, ds_split_name=DatasetSplitName.eval):
     outcome_res = outcome_mod.compute_on_dataset_split()
     dm = outcome_mod.get_dataset_split_manager()
     outcome_mod.save_result(outcome_res, dm)
+
+
+def get_table_key(config, use_bma=False):
+    return PredictionTableKey.from_pipeline_index(0, config, use_bma=use_bma)
+
+
+def generate_mocked_dm(config, dataset_split_name=DatasetSplitName.eval):
+    ds = load_dataset_from_config(config)[DatasetSplitName.eval]
+    ds = ds.map(
+        lambda x, i: {
+            DatasetColumn.model_predictions: [i % 2, 1 - i % 2],
+            DatasetColumn.model_confidences: [i / len(ds), 1 - i / len(ds)],
+            # 0.9 simulates temperature scaling
+            DatasetColumn.postprocessed_confidences: [0.9 * (i / len(ds)), 1 - 0.9 * (i / len(ds))],
+            DatasetColumn.confidence_bin_idx: np.random.randint(1, 20),
+        },
+        with_indices=True,
+    )
+
+    base_class_names = ds.features[config.columns.label].names
+    try:
+        rejection_class_idx = base_class_names.index(config.rejection_class)
+    except ValueError:
+        rejection_class_idx = len(base_class_names)
+
+    ds = ds.map(
+        lambda x: {
+            DatasetColumn.postprocessed_prediction: x[DatasetColumn.model_predictions][0]
+            if x[DatasetColumn.postprocessed_confidences][0] > config.pipelines[0].threshold
+            else rejection_class_idx,
+        }
+    )
+    ds = ds.map(
+        lambda x: {
+            DatasetColumn.model_outcome: OutcomesModule.compute_outcome(
+                x[DatasetColumn.model_predictions][0], x["label"], rejection_class_idx
+            ),
+            DatasetColumn.postprocessed_outcome: OutcomesModule.compute_outcome(
+                x[DatasetColumn.postprocessed_prediction], x["label"], rejection_class_idx
+            ),
+            DatasetColumn.neighbors_train: [
+                [np.random.randint(1, 1000), np.random.rand()] for i in range(0, 20)
+            ],
+            DatasetColumn.neighbors_eval: [
+                [np.random.randint(1, 1000), np.random.rand()] for i in range(0, 20)
+            ],
+            DatasetColumn.token_count: np.random.randint(5, 12),
+        }
+    )
+
+    dm = DatasetSplitManager(
+        dataset_split_name,
+        config,
+        initial_tags=ALL_STANDARD_TAGS,
+        initial_prediction_tags=ALL_PREDICTION_TAGS,
+        dataset_split=ds,
+    )
+    add_every_tag_once(dm)
+    faiss_features = lambda: np.random.randn(786)
+    dm.add_faiss_index([faiss_features() for _ in range(dm.num_rows)])
+    return dm
+
+
+def add_every_tag_once(dm):
+    table_key = get_table_key(dm.config)
+    # Tags some utterances
+    for idx, t in enumerate(ALL_DATA_ACTIONS):
+        tags = {idx: {t: True}}
+        dm.add_tags(tags, table_key)
+    # Tags some utterances
+    for idx, t in enumerate(ALL_SMART_TAGS):
+        tags = {idx: {t: True}}
+        dm.add_tags(tags, table_key)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,7 +44,7 @@ PIPELINE_CFG = {
         "class_name": "tests.test_loading_resources.load_hf_text_classif_pipeline",
         "kwargs": {"checkpoint_path": _CHECKPOINT_PATH},
     },
-    "postprocessors": [{"threshold": 0.7}, {"temperature": 3}],
+    "postprocessors": [{"temperature": 3}, {"threshold": 0.7}],
 }
 DATASET_CFG = {
     "class_name": "tests.test_loading_resources.load_sst2_dataset",
@@ -177,19 +177,18 @@ def generate_mocked_dm(config, dataset_split_name=DatasetSplitName.eval):
         initial_prediction_tags=ALL_PREDICTION_TAGS,
         dataset_split=ds,
     )
-    add_every_tag_once(dm)
+    add_tags(dm)
     faiss_features = lambda: np.random.randn(786)
     dm.add_faiss_index([faiss_features() for _ in range(dm.num_rows)])
     return dm
 
 
-def add_every_tag_once(dm):
+def add_tags(dm):
+    def add_all_tags_once(all_tags):
+        for idx, t in enumerate(all_tags):
+            tags = {idx: {t: True}}
+            dm.add_tags(tags, table_key)
+
     table_key = get_table_key(dm.config)
-    # Tags some utterances
-    for idx, t in enumerate(ALL_DATA_ACTIONS):
-        tags = {idx: {t: True}}
-        dm.add_tags(tags, table_key)
-    # Tags some utterances
-    for idx, t in enumerate(ALL_SMART_TAGS):
-        tags = {idx: {t: True}}
-        dm.add_tags(tags, table_key)
+    add_all_tags_once(ALL_DATA_ACTIONS)
+    add_all_tags_once(ALL_SMART_TAGS)

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -586,6 +586,8 @@ export interface components {
       | "high_epistemic_uncertainty"
       | "correct_top_3"
       | "correct_low_conf"
+      | "incorrect_for_all_pipelines"
+      | "pipeline_disagreement"
       | "NO_SMART_TAGS";
     /**
      * This model should be used as the base for any model that defines aliases to ensure


### PR DESCRIPTION
## Description:
- Clean-up fixtures and and various tests.
- Fix bug where `NO_SMART_TAGS` and `NO_DATA_ACTIONS` were added to the dataset as columns, but the values were never the right ones. This was due because `is not` in  `[a for a in ALL_DATA_ACTION_FILTERS if a is not DataAction.no_action]`  was not working. `!=` works.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
