### PR TITLE
Add profiling code and caching for metrics

### DIFF
--- a/azimuth/modules/base_classes/artifact_manager.py
+++ b/azimuth/modules/base_classes/artifact_manager.py
@@ -10,6 +10,7 @@ from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.types import DatasetSplitName
 from azimuth.types.tag import ALL_PREDICTION_TAGS, ALL_STANDARD_TAGS
+from azimuth.utils.conversion import md5_hash
 from azimuth.utils.object_loader import load_custom_object
 from azimuth.utils.project import load_dataset_from_config
 from azimuth.utils.validation import assert_not_none
@@ -34,6 +35,7 @@ class ArtifactManager:
         ] = {}
         self.models_mapping: Dict[Hash, Dict[int, Callable]] = {}
         self.tokenizer = None
+        self.metrics = {}
 
     @classmethod
     def get_instance(cls):
@@ -119,6 +121,12 @@ class ArtifactManager:
         if self.tokenizer is None:
             self.tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         return self.tokenizer
+
+    def get_metric(self, config, name: str, **kwargs):
+        hash: Hash = md5_hash({**{"name": name}, **kwargs})
+        if hash not in self.metrics:
+            self.metrics[hash] = load_custom_object(config.metrics[name], **kwargs)
+        return self.metrics[hash]
 
     @classmethod
     def clear_cache(cls) -> None:

--- a/azimuth/modules/model_performance/metrics.py
+++ b/azimuth/modules/model_performance/metrics.py
@@ -30,7 +30,6 @@ from azimuth.types.outcomes import ALL_OUTCOMES
 from azimuth.types.tag import ALL_DATA_ACTION_FILTERS, ALL_SMART_TAG_FILTERS
 from azimuth.utils.ml.ece import compute_ece_from_bins
 from azimuth.utils.ml.model_performance import sorted_by_utterance_count_with_last
-from azimuth.utils.object_loader import load_custom_object
 from azimuth.utils.validation import assert_not_none
 
 MAX_PRED = 3
@@ -78,8 +77,9 @@ class MetricsModule(FilterableModule[ModelContractConfig]):
         metric_values = {}
         dm = self.get_dataset_split_manager()
         for metric_name, metric_obj_def in self.config.metrics.items():
-            met: Metric = load_custom_object(
-                metric_obj_def,
+            met: Metric = self.artifact_manager.get_metric(
+                self.config,
+                metric_name,
                 label_list=dm.get_class_names(),
                 rejection_class_idx=dm.rejection_class_idx,
                 force_kwargs=True,  # Set True here as load_metrics has **kwargs.

--- a/azimuth/task_manager.py
+++ b/azimuth/task_manager.py
@@ -133,7 +133,7 @@ class TaskManager:
         if task_cls is not None:
             # We found the task, we can instantiate it.
             if isinstance(task_name, SupportedMethod):
-                mod_options.model_contract_method_name = task_name
+                mod_options = mod_options.copy(update={"model_contract_method_name": task_name})
 
             task: DaskModule = task_cls(
                 dataset_split_name=dataset_split_name,

--- a/tests/profiling_debugging.py
+++ b/tests/profiling_debugging.py
@@ -1,0 +1,52 @@
+"""
+This file help profiling Module. Change the constants and run the file.
+"""
+import tempfile
+
+from pyinstrument import Profiler
+from tqdm import tqdm
+
+from azimuth.config import AzimuthConfig
+from azimuth.modules.base_classes import DatasetResultModule
+from azimuth.modules.model_performance.metrics import MetricsPerFilterModule
+from azimuth.task_manager import TaskManager
+from azimuth.types import (
+    DatasetSplitName,
+    ModuleOptions,
+    SupportedMethod,
+    SupportedModule,
+)
+from azimuth.utils.project import load_dataset_split_managers_from_config
+
+CFG_FILE = "../local_configs/development/clinc/conf.json"
+MODULE = MetricsPerFilterModule
+DATASET_SPLIT = DatasetSplitName.eval
+
+DEPENDENCIES = [SupportedMethod.Predictions, SupportedModule.Outcome]
+DEPS_MOD_OPTIONS = ModuleOptions(pipeline_index=0)
+MOD_OPTIONS = ModuleOptions(pipeline_index=0)
+
+
+def main():
+    config = AzimuthConfig.parse_file(CFG_FILE).copy(
+        update={"artifact_path": str(tempfile.mkdtemp())}
+    )
+    _ = load_dataset_split_managers_from_config(config)
+    task_manager = TaskManager(config)
+    for dep in tqdm(DEPENDENCIES, desc="Running dependencies..."):
+        _, mod = task_manager.get_task(
+            dep, dataset_split_name=DATASET_SPLIT, mod_options=DEPS_MOD_OPTIONS
+        )
+        if isinstance(mod, DatasetResultModule):
+            mod.save_result(mod.result(), mod.get_dataset_split_manager())
+
+    print("Starting profiler!")
+    with Profiler() as p:
+        mod = MODULE(dataset_split_name=DATASET_SPLIT, config=config, mod_options=MOD_OPTIONS)
+        mod.compute_on_dataset_split()
+
+    p.print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description:

Add code to profile different Modules. Work similarly as startup tasks, but run our profiling tool.

By doing so, I was able to find that loading metrics would cause a large bottleneck. So I added them to the artifact manager.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
