### PR TITLE
Use label column name from config in outcome

### DIFF
--- a/azimuth/modules/model_performance/outcomes.py
+++ b/azimuth/modules/model_performance/outcomes.py
@@ -58,7 +58,7 @@ class OutcomesModule(DatasetResultModule[ModelContractConfig]):
         """
         ds = assert_not_none(self.get_dataset_split())
         postprocessed_predictions = self._get_postprocessed_predictions()
-        labels = ds["label"]
+        labels = ds[self.config.columns.label]
 
         outcomes_list: List[OutcomeName] = [
             self._compute_outcome(y_pred, label)


### PR DESCRIPTION
## Description:

Fix issue where we use "label" to access the label column

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
