### PR TITLE
Polish postprocessing switch

### DIFF
--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -8,6 +8,7 @@ import {
   InputAdornment,
   OutlinedInput,
   Switch,
+  Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -229,15 +230,19 @@ const Controls: React.FC<Props> = ({
             />
           </Box>
           <Box margin={1}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={postprocessing.withoutPostprocessing ?? false}
-                  onChange={(_, checked) => handlePostprocessingChange(checked)}
-                />
-              }
-              label="Exclude post-processing"
-            />
+            <Tooltip title="Include or exclude post-processing in predictions and any derived output. This only affects the Exploration Space, and won't affect the smart tags.">
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={postprocessing.withoutPostprocessing ?? false}
+                    onChange={(_, checked) =>
+                      handlePostprocessingChange(checked)
+                    }
+                  />
+                }
+                label="Exclude post-processing"
+              />
+            </Tooltip>
           </Box>
           <Box display="flex" justifyContent="space-between" marginX={1}>
             <Box display="flex" alignItems="center" gap={1} whiteSpace="nowrap">

--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -140,13 +140,13 @@ const Controls: React.FC<Props> = ({
   const handleDatasetSplitChange = (name: DatasetSplitName) =>
     history.push(`/${jobId}/dataset_splits/${name}/${mainView}${searchString}`);
 
-  const handlePostprocessingChange = (enable: boolean) =>
+  const handlePostprocessingChange = (checked: boolean) =>
     history.push(
       `${baseUrl}${constructSearchString({
         ...filters,
         ...pagination,
         ...pipeline,
-        withoutPostprocessing: enable || undefined,
+        withoutPostprocessing: checked || undefined,
       })}`
     );
 

--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -230,7 +230,7 @@ const Controls: React.FC<Props> = ({
             />
           </Box>
           <Box margin={1}>
-            <Tooltip title="Include or exclude post-processing in predictions and any derived output. This only affects the Exploration Space, and won't affect the smart tags.">
+            <Tooltip title="Exclude post-processing in predictions and any derived output. This only affects the Exploration Space, and won't affect the smart tags.">
               <FormControlLabel
                 control={
                   <Switch

--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -236,7 +236,7 @@ const Controls: React.FC<Props> = ({
                   onChange={(_, checked) => handlePostprocessingChange(checked)}
                 />
               }
-              label="Without PostProcessing"
+              label="Exclude post-processing"
             />
           </Box>
           <Box display="flex" justifyContent="space-between" marginX={1}>

--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -239,13 +239,7 @@ const Controls: React.FC<Props> = ({
               label="Without PostProcessing"
             />
           </Box>
-          <Box
-            display="flex"
-            justifyContent="space-between"
-            margin={1}
-            marginBottom={0}
-            marginTop={2}
-          >
+          <Box display="flex" justifyContent="space-between" marginX={1}>
             <Box display="flex" alignItems="center" gap={1} whiteSpace="nowrap">
               <Typography variant="subtitle2">Filters</Typography>
               {isFetchingCountPerFilter ? (

--- a/webapp/src/components/Controls/FilterSelector.tsx
+++ b/webapp/src/components/Controls/FilterSelector.tsx
@@ -7,6 +7,7 @@ import {
   FormControlLabel,
   Tooltip,
   Typography,
+  TypographyProps,
   useTheme,
 } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
@@ -22,6 +23,8 @@ import SeeMoreLess, {
 } from "components/SeeMoreLess";
 
 const MotionArrowDropDownIcon = motion(ArrowDropDownIcon);
+
+const titleTypographyProps: TypographyProps = { variant: "subtitle2" };
 
 const useStyles = makeStyles((theme) => ({
   header: {
@@ -186,8 +189,6 @@ const FilterSelector = <FilterValue extends string>({
     );
   };
 
-  const title = <Typography variant="subtitle2">{label}</Typography>;
-
   return (
     <>
       <div className={classes.header}>
@@ -204,7 +205,7 @@ const FilterSelector = <FilterValue extends string>({
           />
         </Button>
         {operator === "AND" ? (
-          title
+          <Typography {...titleTypographyProps}>{label}</Typography>
         ) : (
           <FormControlLabel
             className={classes.checkboxGroup}
@@ -219,7 +220,8 @@ const FilterSelector = <FilterValue extends string>({
                 onChange={(_, checked) => handleSelectAll(checked)}
               />
             }
-            label={title}
+            label={label}
+            componentsProps={{ typography: titleTypographyProps }}
           />
         )}
         {selectedOptions.length > 0 && (


### PR DESCRIPTION
## Description:

* [Fix filter family deactivated style](https://github.com/ServiceNow/azimuth/pull/74/commits/0b115af27b6174f2f0a1bafecad27938b8941c80)
* [Rename enable to checked](https://github.com/ServiceNow/azimuth/pull/74/commits/4dddfefd8848a8b8e80a6bd7631170630d945c6c)
* [Polish spacing](https://github.com/ServiceNow/azimuth/pull/74/commits/54d1d388267a81230cc025fafbf94d992665248a)
* [Change switch label](https://github.com/ServiceNow/azimuth/pull/74/commits/7d966f094727ac81a39ba78c7a712b78d8ab3010) from "Without PostProcessing" to "Exclude post-processing"
* [Add tooltip](https://github.com/ServiceNow/azimuth/pull/74/commits/a4286b16ad19c4be8ea354db6c4a78df5e99de55)

| !hover | hover |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/8386369/170106082-8a899e00-7b5f-4b6f-a863-d8819e346247.png) | ![image](https://user-images.githubusercontent.com/8386369/170106043-a189eb0e-2db9-4cd2-ac64-5b7b508429d4.png) |

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
