### PR TITLE
Fix issue where we sent OutcomeCountPerThreshold filters

### DIFF
--- a/azimuth/routers/v1/model_performance/outcome_count.py
+++ b/azimuth/routers/v1/model_performance/outcome_count.py
@@ -40,13 +40,11 @@ TAGS = ["Outcome Count v1"]
 )
 def get_outcome_count_per_threshold(
     dataset_split_name: DatasetSplitName,
-    named_filters: NamedDatasetFilters = Depends(build_named_dataset_filters),
     task_manager: TaskManager = Depends(get_task_manager),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
 ) -> List[OutcomeCountPerThresholdValue]:
     mod_options = ModuleOptions(
-        filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),
         pipeline_index=pipeline_index,
     )
 

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -965,14 +965,6 @@ export interface operations {
       };
       query: {
         pipelineIndex: number;
-        confidenceMin?: number;
-        confidenceMax?: number;
-        labels?: string[];
-        predictions?: string[];
-        smartTags?: components["schemas"]["SmartTag"][];
-        dataActions?: components["schemas"]["DataAction"][];
-        outcomes?: components["schemas"]["OutcomeName"][];
-        utterance?: string;
       };
     };
     responses: {


### PR DESCRIPTION
OutcomeCountPerThreshold doesn't accept filters.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [ ] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [ ] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [ ] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [ ] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
