### PR TITLE
Use launch instead of compose to get image from DockerHub

### DIFF
--- a/.github/workflows/docker_cd.yml
+++ b/.github/workflows/docker_cd.yml
@@ -1,0 +1,26 @@
+name: Docker
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  docker-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - run: |
+         make DEVICE=gpu build push
+         make DEVICE=cpu build push
+         make TAG=$VERSION DEVICE=gpu build push
+         make TAG=$VERSION DEVICE=cpu build push
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ in [Learn Basics](https://servicenow.github.io/azimuth/getting-started/b-basics/
 ```
 pip install gdown
 make download_demo
-make CFG_PATH=/config/development/clinc/conf.json compose
+make CFG_PATH=/config/development/clinc/conf.json launch
 ```
 
 Once the startup tasks are completed, you will be able to access Azimuth at `http://0.0.0.0:8080`.

--- a/docs/docs/development/launching.md
+++ b/docs/docs/development/launching.md
@@ -94,6 +94,6 @@ yarn start
 ### Launch Using Docker
 * Docker compose will build the images and connect them, using the following command.
   ```
-  make CFG_PATH=/config/examples/.../conf.json compose
+  make CFG_PATH=/config/examples/.../conf.json launch
   ```
   _Note that the path starts with `/config` as we mount `./config:/config`._

--- a/docs/docs/getting-started/b-basics.md
+++ b/docs/docs/getting-started/b-basics.md
@@ -84,11 +84,11 @@ running a demo.
     1. If you don't have a lot of time and just want to verify your setup, you can run our dummy
        CLINC demo (~2min):
        ```
-       make CFG_PATH=/config/development/clinc_dummy/conf.json compose
+       make CFG_PATH=/config/development/clinc_dummy/conf.json launch
        ```
     2. If you have a bit more time, run our full CLINC demo (~10min):
        ```
-       make CFG_PATH=/config/development/clinc/conf.json compose
+       make CFG_PATH=/config/development/clinc/conf.json launch
        ```
 
 3. The **app will be accessible** at [http://0.0.0.0:8080](http://0.0.0.0:8080) after a few minutes

--- a/docs/docs/getting-started/c-run.md
+++ b/docs/docs/getting-started/c-run.md
@@ -103,7 +103,7 @@ dataset and model are available in `config/examples` (`CLINC` is also shown belo
       container at the root.
 3. Execute the following **command**:
     ```
-    make compose
+    make launch
     ```
 4. The **app will be accessible** at `http://0.0.0.0:8080` after a few minutes of waiting. The
    start-up tasks will start.


### PR DESCRIPTION
## Description:

Our users can now take images from DockerHub instead of building manually.
This PR tries to automate the process.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [ ] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [ ] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [ ] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [ ] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
