### PR TITLE
#87 Fix issue where data actions would not work

### DIFF
--- a/azimuth/dataset_split_manager.py
+++ b/azimuth/dataset_split_manager.py
@@ -307,7 +307,7 @@ class DatasetSplitManager:
             raise ValueError(f"Unknown tags {unknown_tag}")
 
         # Process base tags
-        base_tags_present = any(any(tag_values.values()) for tag_values in base_tags.values())
+        base_tags_present = any(len(tag_values) for tag_values in base_tags.values())
         if base_tags_present:
             self._base_dataset_split = self._add_tags_to(self._base_dataset_split, tags=base_tags)
             self._save_base_dataset_split()

--- a/azimuth/routers/v1/tags.py
+++ b/azimuth/routers/v1/tags.py
@@ -12,6 +12,7 @@ from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKe
 from azimuth.task_manager import TaskManager
 from azimuth.types import DatasetSplitName
 from azimuth.types.tag import (
+    DataAction,
     DataActionMapping,
     DataActionResponse,
     PostDataActionRequest,
@@ -53,6 +54,10 @@ def post_data_actions(
     task_manager: TaskManager = Depends(get_task_manager),
     pipeline_index: Optional[int] = Depends(query_pipeline_index),
 ) -> DataActionResponse:
+    # Remove NO_ACTION as it is only used in filtering.
+    for actions in request_data.data_actions.values():
+        actions.pop(DataAction.no_action, None)
+
     dataset = dataset_split_managers.get(request_data.dataset_split_name)
     if dataset is None:
         raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail="Dataset not found.")

--- a/tests/test_routers/test_tags.py
+++ b/tests/test_routers/test_tags.py
@@ -10,7 +10,7 @@ from starlette.testclient import TestClient
 def test_post_tags(app: FastAPI) -> None:
     client = TestClient(app)
 
-    request = {"data_actions": {0: {"remove": True}}}
+    request = {"data_actions": {0: {"remove": True, "NO_ACTION": False}}}
     resp = client.post("/tags", json=request)
     assert resp.status_code == HTTP_200_OK, resp.text
     data = resp.json()
@@ -20,6 +20,23 @@ def test_post_tags(app: FastAPI) -> None:
                 "relabel": False,
                 "considerNewClass": False,
                 "remove": True,
+                "augmentWithSimilar": False,
+                "investigate": False,
+            }
+        ]
+    }
+
+    # Reset tag to NO_ACTION
+    request = {"data_actions": {0: {"remove": False, "NO_ACTION": True}}}
+    resp = client.post("/tags", json=request)
+    assert resp.status_code == HTTP_200_OK, resp.text
+    data = resp.json()
+    assert data == {
+        "dataActions": [
+            {
+                "relabel": False,
+                "considerNewClass": False,
+                "remove": False,
                 "augmentWithSimilar": False,
                 "investigate": False,
             }


### PR DESCRIPTION
## Description:

Fixes #87 

We were supplying NO_DATA_ACTIONS to the route, we now filter it out as it is only used during filtering.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
