### PR TITLE
Add auto as an option for make launch

### DIFF
--- a/.app_env
+++ b/.app_env
@@ -1,6 +1,6 @@
 REGISTRY=servicenowdocker
 BACKEND_VERSION=latest
 FRONTEND_VERSION=latest
-DEVICE=auto
+DEVICE=cpu
 STAGE=production
 CFG_PATH=/config/examples/sst2/conf.json

--- a/.app_env
+++ b/.app_env
@@ -1,6 +1,6 @@
 REGISTRY=servicenowdocker
 BACKEND_VERSION=latest
 FRONTEND_VERSION=latest
-DEVICE=cpu
+DEVICE=auto
 STAGE=production
 CFG_PATH=/config/examples/sst2/conf.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Released changes are shown in the
 
 ### Changed
 - Renamed our docker images to use `servicenowdocker` registry on Docker Hub.
-- Add option DEVICE=auto to automatically run Azimuth on GPU is available.
+- Add option `DEVICE=auto` to automatically run Azimuth on GPU if available.
 
 ### Deprecated/Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Released changes are shown in the
 
 ### Changed
 - Renamed our docker images to use `servicenowdocker` registry on Docker Hub.
+- Add option DEVICE=auto to automatically run Azimuth on GPU is available.
 
 ### Deprecated/Breaking Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 REGISTRY = servicenowdocker
 IMAGE = azimuth
 TAG = latest
-DEVICE = cpu
+DEVICE = auto
 STAGE = production
 ENV_FILE = .app_env
 export DOCKER_BUILDKIT ?= 1
+
+ifeq ($(DEVICE),auto)
+	GPU_AVAILABLE=$(shell nvidia-smi 1>/dev/null 2>/dev/null && echo "success")
+	ifeq ($(GPU_AVAILABLE),success)
+		DEVICE=gpu
+	else
+		DEVICE=cpu
+	endif
+endif
 
 ifeq ($(STAGE),production)
     TAG_EXT=

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ export DOCKER_BUILDKIT ?= 1
 ifeq ($(DEVICE),auto)
 	GPU_AVAILABLE=$(shell nvidia-smi 1>/dev/null 2>/dev/null && echo "success")
 	ifeq ($(GPU_AVAILABLE),success)
-		DEVICE=gpu
+		export DEVICE=gpu
 	else
-		DEVICE=cpu
+		export DEVICE=cpu
 	endif
 endif
 

--- a/docs/docs/getting-started/b-basics.md
+++ b/docs/docs/getting-started/b-basics.md
@@ -80,7 +80,7 @@ running a demo.
 2. Run **our dummy or full demo** (option a. or b.), based on how much time you have. If it is the
    first time that you are running the command, it will take additional time to download the Docker
    image (~15 min). If you have access to GPUs, you can add to the command `DEVICE=gpu` (default
-   is `cpu`).
+   is `auto`).
     1. If you don't have a lot of time and just want to verify your setup, you can run our dummy
        CLINC demo (~2min):
        ```

--- a/docs/docs/getting-started/b-basics.md
+++ b/docs/docs/getting-started/b-basics.md
@@ -79,8 +79,7 @@ running a demo.
 
 2. Run **our dummy or full demo** (option a. or b.), based on how much time you have. If it is the
    first time that you are running the command, it will take additional time to download the Docker
-   image (~15 min). If you have access to GPUs, you can add to the command `DEVICE=gpu` (default
-   is `auto`).
+   image (~15 min).
     1. If you don't have a lot of time and just want to verify your setup, you can run our dummy
        CLINC demo (~2min):
        ```

--- a/docs/docs/getting-started/c-run.md
+++ b/docs/docs/getting-started/c-run.md
@@ -129,8 +129,8 @@ They are the following:
 * Disable behavioral tests and similarity by passing respectively `BEHAVIORAL_TESTING=null` and
   `SIMILARITY=null`.
 * Specify the name of the project, passing `NAME`.
-* You can specify the device on which to run Azimuth, with `DEVICE` being one of `gpu` or `cpu`. If
-  none is provided, `cpu` will be used. Ex: `DEVICE=gpu`.
+* You can specify the device on which to run Azimuth, with `DEVICE` being one of `auto`, `gpu` or `cpu`. If
+  none is provided, `auto` will be used. Ex: `DEVICE=gpu`.
 
 !!! note "Config file prevails over environment variables"
 


### PR DESCRIPTION
## Description:

Automatically detect if we can use GPUs before launching docker.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
