### PR TITLE
Fix small typo in docs

### DIFF
--- a/docs/docs/development/dev-practices.md
+++ b/docs/docs/development/dev-practices.md
@@ -18,7 +18,7 @@ When hotfixes are merged into `main`, they should be ported back into `dev` as w
 We try to commit regularly, so it is easy to revert partial changes.
 
 ### Front End Types
-If you played with types and routes in the back end, remember to regenerate the front-ent types, using the following command from the webapp folder while the back end is running (see how to launch [here](launching.md)).
+If you played with types and routes in the back end, remember to regenerate the front-end types, using the following command from the webapp folder while the back end is running (see how to launch [here](launching.md)).
 ```
 cd webapp
 yarn types   # while the back end is runnnig


### PR DESCRIPTION
## Description:

As much as the accidental Tolkien-esque Ent reference made me laugh, I've been meaning to fix this typo for a while.  Now we ask folks to regenerate front-end types instead of front-ent types.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
