### PR TITLE
Offer hiding columns from the Performance Analysis table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Released changes are shown in the
 ## [Not released]
 
 ### Added
-- A new toggle switch "Normalize" in the confusion matrix page
+- A new toggle switch "Normalize" in the confusion matrix page.
+- Possibility to hide columns from the Performance Analysis table.
 
 ### Changed
 - Show 20 similar utterances instead of 10 in the Utterance Detail page.

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -114,6 +114,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
     {
       width: 206,
       field: "filterValue",
+      headerName: OPTION_PRETTY_NAME[selectedMetricPerFilterOption],
       sortComparator: customSort,
       renderHeader: () => (
         <Select
@@ -233,6 +234,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
         rows={rows}
         loading={isFetching}
         pageSize={numberVisible}
+        disableColumnMenu={false}
         components={
           rows.length > INITIAL_NUMBER_VISIBLE
             ? {

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -105,6 +105,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
   };
 
   const NUMBER_COL_DEF = {
+    maxWidth: 221,
     type: "number",
     sortComparator: customSort,
   };
@@ -113,8 +114,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
     {
       field: "filterValue",
       headerName: OPTION_PRETTY_NAME[selectedMetricPerFilterOption],
-      flex: 1,
-      minWidth: 200,
+      width: 221,
       sortComparator: customSort,
       renderHeader: () => (
         <Select

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -224,9 +224,6 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
           "& .MuiDataGrid-columnHeaders": {
             borderBottom: "none",
           },
-          "& .MuiDataGrid-iconSeparator": {
-            display: "none",
-          },
           "& .total": {
             background: (theme) => theme.palette.grey[200],
           },

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import {
-  GridSortModel,
-  GridValueFormatterParams,
+  GridCellValue,
+  GridColumnMenuContainer,
+  GridColumnMenuProps,
+  GridColumnsMenuItem,
   GridRowSpacingParams,
   GridSortCellParams,
   GridSortDirection,
-  GridCellValue,
+  GridSortModel,
+  GridValueFormatterParams,
+  HideGridColMenuItem,
 } from "@mui/x-data-grid";
 import { Box, MenuItem, Select, Typography } from "@mui/material";
 
@@ -25,6 +29,17 @@ const ROW_HEIGHT = 35;
 const FOOTER_HEIGHT = 40;
 
 const OVERALL_ROW_ID = -1; // -1 so that the other rows can range from 0 - n-1
+
+const ColumnMenu = ({ hideMenu, currentColumn, open }: GridColumnMenuProps) => (
+  <GridColumnMenuContainer
+    hideMenu={hideMenu}
+    currentColumn={currentColumn}
+    open={open}
+  >
+    <HideGridColMenuItem onClick={hideMenu} column={currentColumn} />
+    <GridColumnsMenuItem onClick={hideMenu} column={currentColumn} />
+  </GridColumnMenuContainer>
+);
 
 const OPTIONS = ["label", "prediction", "smartTag"] as const;
 const OPTION_PRETTY_NAME = {
@@ -239,13 +254,14 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
         pageSize={numberVisible}
         disableColumnMenu={false}
         sortingOrder={["desc", "asc"]}
-        components={
-          rows.length > INITIAL_NUMBER_VISIBLE
+        components={{
+          ColumnMenu,
+          ...(rows.length > INITIAL_NUMBER_VISIBLE
             ? {
                 Footer,
               }
-            : {}
-        }
+            : {}),
+        }}
         initialState={{
           sorting: {
             sortModel: [{ field: columns[1].field, sort: "desc" }],

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -105,16 +105,16 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
   };
 
   const NUMBER_COL_DEF = {
-    width: 135,
     type: "number",
     sortComparator: customSort,
   };
 
   const columns: Column<Row>[] = [
     {
-      width: 206,
       field: "filterValue",
       headerName: OPTION_PRETTY_NAME[selectedMetricPerFilterOption],
+      flex: 1,
+      minWidth: 200,
       sortComparator: customSort,
       renderHeader: () => (
         <Select
@@ -147,15 +147,17 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
     },
     {
       ...NUMBER_COL_DEF,
-      width: 175,
       field: "utteranceCount",
-      headerName: "Nb. of Utterances",
-      description: "Number of Utterances", // tooltip
+      headerName: "Utterance Count",
+      flex: 1,
+      minWidth: 160,
     },
     ...ALL_OUTCOMES.map<Column<Row>>((outcome) => ({
       ...NUMBER_COL_DEF,
       field: outcome,
       headerName: OUTCOME_PRETTY_NAMES[outcome],
+      flex: 1,
+      minWidth: 160,
       valueGetter: ({ row }) => row.outcomeCount[outcome] / row.utteranceCount,
       valueFormatter: percentageFormatter,
     })),
@@ -163,6 +165,8 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
       ...NUMBER_COL_DEF,
       field: metricName,
       headerName: metricName,
+      flex: 1,
+      minWidth: 80,
       valueGetter: ({ row }) => row.customMetrics[metricName],
       valueFormatter: percentageFormatter,
     })),
@@ -170,6 +174,8 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
       ...NUMBER_COL_DEF,
       field: "ece",
       headerName: "ECE",
+      flex: 1,
+      minWidth: 80,
       valueFormatter: twoDigitFormatter,
     },
   ];

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -26,13 +26,13 @@ const FOOTER_HEIGHT = 40;
 
 const OVERALL_ROW_ID = -1; // -1 so that the other rows can range from 0 - n-1
 
-type FilterByViewOption = "label" | "prediction" | "smartTag";
-type DataOptions = {
-  [key in FilterByViewOption]: {
-    name: string;
-    metricsPerFilter: MetricsPerFilterValue[];
-  };
-};
+const OPTIONS = ["label", "prediction", "smartTag"] as const;
+const OPTION_PRETTY_NAME = {
+  label: "Label",
+  prediction: "Prediction",
+  smartTag: "Smart Tag",
+} as const;
+type FilterByViewOption = typeof OPTIONS[number];
 
 type Props = {
   jobId: string;
@@ -63,21 +63,6 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
   const handleSortModelChange = (model: GridSortModel) => {
     const [sortModel] = model;
     sortDirectionRef.current = sortModel?.sort;
-  };
-
-  const options: DataOptions = {
-    label: {
-      name: "Label",
-      metricsPerFilter: data?.metricsPerFilter.label || [],
-    },
-    prediction: {
-      name: "Prediction",
-      metricsPerFilter: data?.metricsPerFilter.prediction || [],
-    },
-    smartTag: {
-      name: "Smart Tag",
-      metricsPerFilter: data?.metricsPerFilter.smartTag || [],
-    },
   };
 
   const rows: Row[] = React.useMemo(() => {
@@ -151,9 +136,9 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
             )
           }
         >
-          {Object.entries(options).map(([key, option]) => (
+          {OPTIONS.map((key) => (
             <MenuItem key={key} value={key}>
-              {option.name}
+              {OPTION_PRETTY_NAME[key]}
             </MenuItem>
           ))}
         </Select>

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -238,6 +238,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
         loading={isFetching}
         pageSize={numberVisible}
         disableColumnMenu={false}
+        sortingOrder={["desc", "asc"]}
         components={
           rows.length > INITIAL_NUMBER_VISIBLE
             ? {
@@ -245,6 +246,11 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
               }
             : {}
         }
+        initialState={{
+          sorting: {
+            sortModel: [{ field: columns[1].field, sort: "desc" }],
+          },
+        }}
       />
     </Box>
   );

--- a/webapp/src/components/Table.tsx
+++ b/webapp/src/components/Table.tsx
@@ -69,6 +69,7 @@ export const Table = <Row extends { id: GridRowId }>({
   ...props
 }: Props<Row>) => (
   <DataGrid
+    disableColumnFilter
     disableColumnMenu
     disableSelectionOnClick
     hideFooter={!props.pagination && !components?.Footer}

--- a/webapp/src/styles/theme.tsx
+++ b/webapp/src/styles/theme.tsx
@@ -12,6 +12,10 @@ export const GlobalCss = withStyles({
     ".Toastify__toast--error": {
       background: "#c93c36",
     },
+    ".MuiDataGrid-menuList > li:nth-of-type(-n+3)": {
+      // Hide sort options since they are already available via the sorting button
+      display: "none",
+    },
   },
 })(() => null);
 

--- a/webapp/src/styles/theme.tsx
+++ b/webapp/src/styles/theme.tsx
@@ -12,10 +12,6 @@ export const GlobalCss = withStyles({
     ".Toastify__toast--error": {
       background: "#c93c36",
     },
-    ".MuiDataGrid-menuList > li:nth-of-type(-n+3)": {
-      // Hide sort options since they are already available via the sorting button
-      display: "none",
-    },
   },
 })(() => null);
 


### PR DESCRIPTION
Resolve #126

## Description:

* [Clean up](https://github.com/ServiceNow/azimuth/pull/129/commits/b473b5e930c0b4504cfa4f66cbb0ff0b1c1c35d5)
* [Offer hiding columns](https://github.com/ServiceNow/azimuth/pull/129/commits/04ad7e28206e0f4fafa834902ed9f5f0e684f27d) 
  - Hide filter options (with handy boolean attribute)
  - Hide sort options since they are already available via the sorting button (in global CSS, as `sx` doesn't work since the popover menu is not a child of the `DataGrid`)
* [Have columns flex](https://github.com/ServiceNow/azimuth/pull/129/commits/0f76cabf7346fe78bb258d661368e8b71c49f33c) to accommodate hiding columns. Also taking this opportunity to adjust the widths to new outcome names.
* [Show columns separator](https://github.com/ServiceNow/azimuth/pull/129/commits/ff78d66c16897b2f30f4131cc90fea316c6db04e) in headers to avoid ambiguity with which column the menu button belongs to.
* [Refine sorting](https://github.com/ServiceNow/azimuth/pull/129/commits/40237b9d36b0a83fc05da4974b103eb1094d3b52) 
  - Show the initial sort
  - Disable `sortingOrder=null` as it is redundant with sorting by `utteranceCount` `desc`
* [Set maxWidth](https://github.com/ServiceNow/azimuth/pull/129/commits/0fa7cff9e79826b3850d39ccfb89b9d4827124ee) so that columns stop getting wider going under 6 columns.

![image](https://user-images.githubusercontent.com/8386369/173072166-fd2c36db-7828-4fff-ad24-b1b4530d5758.png)

![image](https://user-images.githubusercontent.com/8386369/173072301-eb434156-ea8c-4913-b034-4d6a50bcf818.png)


## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
