### PR TITLE
Fix weight generation to avoid flaky test

### DIFF
--- a/tests/test_loading_resources.py
+++ b/tests/test_loading_resources.py
@@ -21,6 +21,7 @@ from transformers import (
 )
 
 from azimuth.config import AzimuthConfig
+from azimuth.utils.ml.seeding import RandomContext
 
 _CURRENT_DIR = "/tmp"
 _MAX_DATASET_LEN = 42
@@ -40,8 +41,10 @@ def load_hf_text_classif_pipeline(checkpoint_path: str, azimuth_config: AzimuthC
     try:
         model = DistilBertForSequenceClassification.from_pretrained(_CURRENT_DIR)
     except OSError:
-        model = DistilBertForSequenceClassification(DistilBertConfig())
-        model.save_pretrained(_CURRENT_DIR)
+        with RandomContext(seed=2022):
+            model = DistilBertForSequenceClassification(DistilBertConfig())
+            model.init_weights()
+            model.save_pretrained(_CURRENT_DIR)
     # As of Jan 6, 2021, pipelines didn't support fast tokenizers
     # See https://github.com/huggingface/transformers/issues/7735
     tokenizer = DistilBertTokenizer.from_pretrained(


### PR DESCRIPTION
## Description:

Fixes #110 

With random weights, we would sometime get 0.0 precision.
I preferred fixing the weights instead of patching the test as I thought the test was fine. 

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
