### PR TITLE
Fix unexpected visible scrollbars

### DIFF
--- a/webapp/src/components/Analysis/WarningsPreview.tsx
+++ b/webapp/src/components/Analysis/WarningsPreview.tsx
@@ -65,7 +65,7 @@ const WarningsPreview: React.FC<{ jobId: string }> = ({ jobId }) => {
               height: "100%",
               display: "flex",
               justifyContent: "center",
-              overflow: "scroll",
+              overflow: "visible auto",
             }}
           >
             {isFetching ? (

--- a/webapp/src/components/BasicLayout.tsx
+++ b/webapp/src/components/BasicLayout.tsx
@@ -10,7 +10,7 @@ type Props = {
 const BasicLayout: React.FC<Props> = ({ maxWidth = "xl", children }) => (
   <>
     <PageHeader />
-    <Box height="100%" display="flex" flexDirection="column" overflow="scroll">
+    <Box height="100%" display="flex" flexDirection="column" overflow="auto">
       <Container maxWidth={maxWidth} sx={{ flex: 1, padding: 2 }}>
         {children}
       </Container>

--- a/webapp/src/components/ConfusionMatrix.tsx
+++ b/webapp/src/components/ConfusionMatrix.tsx
@@ -190,7 +190,7 @@ const ConfusionMatrix: React.FC<Props> = ({
           gridTemplateRows={`${LABEL_LENGTH} repeat(${classOptions.length}, ${CELL_SIZE})`}
           height="100%"
           justifyItems="center"
-          overflow="scroll"
+          overflow="auto"
           width="100%"
           sx={{
             // Stops accidental navigation on horizontal scroll with touch pad

--- a/webapp/src/components/Metrics/Metrics.tsx
+++ b/webapp/src/components/Metrics/Metrics.tsx
@@ -86,7 +86,13 @@ const Metrics: React.FC<Props> = ({
   }, [metricsInfo]);
 
   return (
-    <Box display="flex" flexDirection="row" gap={4} overflow="auto visible">
+    <Box
+      display="flex"
+      flexDirection="row"
+      flexShrink={0}
+      gap={4}
+      overflow="auto visible"
+    >
       <MetricsCard rowCount={2}>
         {OUTCOMES.map((outcome) => (
           <Metric

--- a/webapp/src/components/Metrics/Metrics.tsx
+++ b/webapp/src/components/Metrics/Metrics.tsx
@@ -86,7 +86,7 @@ const Metrics: React.FC<Props> = ({
   }, [metricsInfo]);
 
   return (
-    <Box display="flex" flexDirection="row" gap={4} overflow="scroll">
+    <Box display="flex" flexDirection="row" gap={4} overflow="auto visible">
       <MetricsCard rowCount={2}>
         {OUTCOMES.map((outcome) => (
           <Metric


### PR DESCRIPTION
Fix #142

## Description:

Use `auto` instead of `scroll`, as with `scroll`
> [Browsers always display scrollbars whether or not any content is actually clipped](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#:~:text=Browsers%20always%20display%20scrollbars%20whether%20or%20not%20any%20content%20is%20actually%20clipped)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
