### PR TITLE
Improve Dockerfile to reduce Frontend image size

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -31,7 +31,7 @@ FROM builder as production
 WORKDIR /app
 ENV NODE_ENV=production
 
-COPY --from=prod_builder /app/build/ /app/build
+COPY --from=prod_builder /app/build /app/build
 COPY --from=prod_builder /app/server.js /app/server.js
 
 RUN npm install express http-proxy-middleware cors

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -13,7 +13,7 @@ COPY . /app
 RUN yarn --production=false;
 
 
-FROM builder as production
+FROM builder as prod_builder
 
 ENV NODE_ENV=production
 
@@ -26,3 +26,13 @@ RUN yarn --production=false;
 COPY . /app
 
 RUN yarn --production=false;yarn build;
+
+FROM builder as production
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=prod_builder /app/build/ /app/build
+COPY --from=prod_builder /app/server.js /app/server.js
+
+RUN npm install express http-proxy-middleware cors
+CMD node server.js


### PR DESCRIPTION
## Description:

Fixes #138 

By copying the `build` folder in a clean image, we save ~1Gb in the image size.

```bash
Before:   1.98GB
After     977MB
```

Tested quickly on my computer and `server.js` loads correctly.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
