### PR TITLE
Various fixes before releasing

### DIFF
--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -260,7 +260,7 @@ const UtterancesTable: React.FC<Props> = ({
       description:
         "Utterances from dataset are overlaid with saliency maps, highlighting the most important tokens for the model's prediction.",
       flex: 5,
-      minWidth: 406,
+      minWidth: 413,
       renderCell: renderUtterance,
     },
     {
@@ -342,7 +342,7 @@ const UtterancesTable: React.FC<Props> = ({
           filters.dataActions !== undefined
         ),
       renderCell: renderDataAction,
-      width: 192,
+      width: 155,
     },
   ];
 

--- a/webapp/src/components/Analysis/UtterancesTableFooter.tsx
+++ b/webapp/src/components/Analysis/UtterancesTableFooter.tsx
@@ -31,12 +31,17 @@ const UtterancesTableFooter: React.FC<Props> = ({
       <Typography variant="body2" sx={{ marginRight: 1 }}>
         Apply proposed action on {selectedIds.length} rows:
       </Typography>
-      <UtteranceDataAction
-        utteranceIds={selectedIds}
-        confirmationButton
-        allDataActions={allDataActions || []}
-        getUtterancesQueryState={getUtterancesQueryState}
-      />
+      <Box
+        display="flex"
+        width={277} // Width with the longest option augment_with_similar
+      >
+        <UtteranceDataAction
+          utteranceIds={selectedIds}
+          confirmationButton
+          allDataActions={allDataActions || []}
+          getUtterancesQueryState={getUtterancesQueryState}
+        />
+      </Box>
     </Box>
     <CustomPagination />
   </Box>

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -14,6 +14,7 @@ import {
   GridRowSpacingParams,
   GridSortCellParams,
   GridSortModel,
+  gridStringOrNumberComparator,
   HideGridColMenuItem,
 } from "@mui/x-data-grid";
 import DatasetSplitToggler from "components/Controls/DatasetSplitToggler";
@@ -122,9 +123,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
     if ((param2.id as number) === OVERALL_ROW_ID) return -sign;
 
     // Fall back to default sort
-    return (v1?.toLocaleString() || "").localeCompare(
-      v2?.toLocaleString() || ""
-    );
+    return gridStringOrNumberComparator(v1, v2, param1, param2);
   };
 
   const NUMBER_COL_DEF = {

--- a/webapp/src/components/Utterance/UtteranceDataAction.tsx
+++ b/webapp/src/components/Utterance/UtteranceDataAction.tsx
@@ -49,7 +49,7 @@ const UtteranceDataAction: React.FC<Props> = ({
         onChange={(e) => setMenuValue(e.target.value as DataAction)}
         onClose={(e) => e.preventDefault()}
         size="small"
-        sx={{ width: 172 }}
+        fullWidth
       >
         {menuItems.map((tag) => (
           <MenuItem key={tag} value={tag} onClick={(e) => e.preventDefault()}>

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import React from "react";
 import { Link, useParams } from "react-router-dom";
 import { getDatasetInfoEndpoint } from "services/api";
 import { isPipelineSelected } from "utils/helpers";
+import { behavioralTestingDescription } from "./PerturbationTestingSummary";
 
 const DEFAULT_PREVIEW_CONTENT_HEIGHT = 502;
 
@@ -95,12 +96,7 @@ const Dashboard = () => {
         <PreviewCard
           title="Behavioral Testing"
           to={`/${jobId}/behavioral_testing_summary${searchString}`}
-          description={
-            <Description
-              text="Perturbation Tests asses your model's robustness, or how it handles things like misspellings or punctuation changes."
-              link="/behavioral-testing-summary/"
-            />
-          }
+          description={behavioralTestingDescription}
         >
           <Box height={DEFAULT_PREVIEW_CONTENT_HEIGHT}>
             <PerturbationTestingPreview

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import { Link, useParams } from "react-router-dom";
 import { getDatasetInfoEndpoint } from "services/api";
 import { isPipelineSelected } from "utils/helpers";
 import { behavioralTestingDescription } from "./PerturbationTestingSummary";
+import { postprocessingDescription } from "./Threshold";
 
 const DEFAULT_PREVIEW_CONTENT_HEIGHT = 502;
 
@@ -112,12 +113,7 @@ const Dashboard = () => {
           <PreviewCard
             title="Post-processing Analysis"
             to={`/${jobId}/thresholds${searchString}`}
-            description={
-              <Description
-                text="View prediction distribution for multiple thresholds to find the optimal one. You can change the confidence threshold in the config file."
-                link="/post-processing-analysis/"
-              />
-            }
+            description={postprocessingDescription}
           >
             <Box height={DEFAULT_PREVIEW_CONTENT_HEIGHT}>
               <ThresholdPlot jobId={jobId} pipeline={pipeline} />

--- a/webapp/src/pages/PerturbationTestingSummary.tsx
+++ b/webapp/src/pages/PerturbationTestingSummary.tsx
@@ -8,6 +8,13 @@ import { getDatasetInfoEndpoint } from "services/api";
 import { PIPELINE_REQUIRED_TIP } from "utils/const";
 import { isPipelineSelected } from "utils/helpers";
 
+export const behavioralTestingDescription = (
+  <Description
+    text="Assess if your model is robust to small modifications."
+    link="/behavioral-testing-summary/"
+  />
+);
+
 const PerturbationTestingSummary = () => {
   const { jobId } = useParams<{ jobId: string }>();
   const { pipeline } = useQueryState();
@@ -18,10 +25,7 @@ const PerturbationTestingSummary = () => {
   return (
     <Box display="flex" flexDirection="column" height="100%">
       <Typography variant="h4">Behavioral Testing Summary</Typography>
-      <Description
-        text="Perturbation Tests asses your model's robustness, or how it handles things like misspellings or punctuation changes."
-        link="/behavioral-testing-summary/"
-      />
+      {behavioralTestingDescription}
       {isPipelineSelected(pipeline) ? (
         <PerturbationTestingSummaryTable
           jobId={jobId}

--- a/webapp/src/pages/Threshold.tsx
+++ b/webapp/src/pages/Threshold.tsx
@@ -1,4 +1,5 @@
-import { Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import Description from "components/Description";
 import ThresholdPlot from "components/ThresholdPlot";
 import useQueryState from "hooks/useQueryState";
 import React from "react";
@@ -6,14 +7,29 @@ import { useParams } from "react-router-dom";
 import { PIPELINE_REQUIRED_TIP } from "utils/const";
 import { isPipelineSelected } from "utils/helpers";
 
+export const postprocessingDescription = (
+  <Description
+    text="View prediction distribution for multiple thresholds to find the optimal one. You can change the confidence threshold in the config file."
+    link="/post-processing-analysis/"
+  />
+);
+
 const Threshold = () => {
   const { jobId } = useParams<{ jobId: string }>();
   const { pipeline } = useQueryState();
 
-  return isPipelineSelected(pipeline) ? (
-    <ThresholdPlot jobId={jobId} pipeline={pipeline} />
-  ) : (
-    <Typography>{PIPELINE_REQUIRED_TIP}</Typography>
+  return (
+    <Box display="flex" flexDirection="column" height="100%">
+      <Typography variant="h4">Post-processing Analysis</Typography>
+      {postprocessingDescription}
+      <Box marginTop={4} flex={1}>
+        {isPipelineSelected(pipeline) ? (
+          <ThresholdPlot jobId={jobId} pipeline={pipeline} />
+        ) : (
+          <Typography>{PIPELINE_REQUIRED_TIP}</Typography>
+        )}
+      </Box>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Description:

* Dashboard
  - [Fix sorting numbers as strings](https://github.com/ServiceNow/azimuth/pull/163/commits/fa80e32a7f002922e93b9b49cfa479b1c2c64046)
* One-line descriptions
  - [Shorten behavioral testing description](https://github.com/ServiceNow/azimuth/pull/163/commits/5d9db67d9754bd76b06e0949d939227086ec9e30) and remove duplication
  - [Add description to Post-processing Analysis page](https://github.com/ServiceNow/azimuth/pull/163/commits/dd2d2770ade9ff7a9c5288278496a3d7c07d99c5)
* Utterances table
  - [Make proposed action selector wider in footer and narrower in column](https://github.com/ServiceNow/azimuth/pull/163/commits/a7973c11224f52360d37c193e7685507239dc3d2), making everything fit on a MacBook Pro 17.
  - The width of the selector in the table column is no longer hardcoded thanks to the `fullWidth` prop. The width in the table footer still needs to be fixed though, so I set it to the longest option "augment_with_similar".

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge
it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
