### PR TITLE
Fix filtering dataset with pipeline filters

### DIFF
--- a/azimuth/modules/dataset_analysis/syntax_tagging.py
+++ b/azimuth/modules/dataset_analysis/syntax_tagging.py
@@ -12,7 +12,12 @@ from azimuth.config import CommonFieldsConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.base_classes import DatasetResultModule
 from azimuth.types import DatasetColumn, ModuleResponse
-from azimuth.types.tag import ALL_SYNTAX_TAGS, SmartTag, TaggingResponse
+from azimuth.types.tag import (
+    SMART_TAGS_FAMILY_MAPPING,
+    SmartTag,
+    SmartTagFamily,
+    TaggingResponse,
+)
 
 
 class SyntaxTaggingModule(DatasetResultModule[CommonFieldsConfig]):
@@ -55,7 +60,11 @@ class SyntaxTaggingModule(DatasetResultModule[CommonFieldsConfig]):
         records: List[TaggingResponse] = []
 
         for tokens, utterance in zip(batch_tokens, utterances):
-            tag: Dict[SmartTag, bool] = {smart_tag: False for smart_tag in ALL_SYNTAX_TAGS}
+            tag: Dict[SmartTag, bool] = {
+                smart_tag: False
+                for family in [SmartTagFamily.extreme_length, SmartTagFamily.partial_syntax]
+                for smart_tag in SMART_TAGS_FAMILY_MAPPING[family]
+            }
             adds = {}
 
             # Syntax

--- a/azimuth/routers/v1/model_performance/utterance_count.py
+++ b/azimuth/routers/v1/model_performance/utterance_count.py
@@ -65,7 +65,7 @@ def get_count_per_filter(
         tag_family: Counter(
             **{
                 SmartTag.no_smart_tag: sum(
-                    ds.to_pandas()[set(tags).intersection(ds.column_names)]  # type: ignore
+                    ds.to_pandas()[list(set(tags).intersection(ds.column_names))]  # type: ignore
                     .to_numpy()
                     .sum(1)
                     == 0

--- a/azimuth/types/tag.py
+++ b/azimuth/types/tag.py
@@ -86,24 +86,6 @@ ALL_SMART_TAG_FILTERS = [a.value for a in SmartTag]
 ALL_SMART_TAGS = [a for a in ALL_SMART_TAG_FILTERS if a != SmartTag.no_smart_tag]
 
 ALL_TAGS = ALL_SMART_TAGS + ALL_DATA_ACTIONS
-ALL_SYNTAX_TAGS = [
-    SmartTag.multi_sent,
-    SmartTag.short,
-    SmartTag.long,
-    SmartTag.no_verb,
-    SmartTag.no_subj,
-    SmartTag.no_obj,
-]
-ALL_PREDICTION_TAGS = [
-    SmartTag.failed_punctuation.value,
-    SmartTag.failed_fuzzy_matching.value,
-    SmartTag.correct_low_conf,
-    SmartTag.correct_top_3,
-    SmartTag.high_epistemic_uncertainty,
-    SmartTag.pipeline_disagreement,
-    SmartTag.incorrect_for_all_pipelines,
-]
-ALL_STANDARD_TAGS = list(set(ALL_TAGS) - set(ALL_PREDICTION_TAGS))
 
 SMART_TAGS_FAMILY_MAPPING = {
     SmartTagFamily.extreme_length: [
@@ -138,6 +120,15 @@ SMART_TAGS_FAMILY_MAPPING = {
         SmartTag.high_epistemic_uncertainty,
     ],
 }
+
+ALL_SYNTAX_TAGS = [
+    *SMART_TAGS_FAMILY_MAPPING[SmartTagFamily.extreme_length],
+    *SMART_TAGS_FAMILY_MAPPING[SmartTagFamily.partial_syntax],
+]
+ALL_PREDICTION_TAGS: List[Tag] = [
+    tag for family in PIPELINE_SMART_TAG_FAMILIES for tag in SMART_TAGS_FAMILY_MAPPING[family]
+]
+ALL_STANDARD_TAGS = list(set(ALL_TAGS) - set(ALL_PREDICTION_TAGS))
 
 
 class TaggingResponse(ModuleResponse):

--- a/azimuth/types/tag.py
+++ b/azimuth/types/tag.py
@@ -121,10 +121,6 @@ SMART_TAGS_FAMILY_MAPPING = {
     ],
 }
 
-ALL_SYNTAX_TAGS = [
-    *SMART_TAGS_FAMILY_MAPPING[SmartTagFamily.extreme_length],
-    *SMART_TAGS_FAMILY_MAPPING[SmartTagFamily.partial_syntax],
-]
 ALL_PREDICTION_TAGS: List[Tag] = [
     tag for family in PIPELINE_SMART_TAG_FAMILIES for tag in SMART_TAGS_FAMILY_MAPPING[family]
 ]

--- a/docs/docs/development/setup.md
+++ b/docs/docs/development/setup.md
@@ -67,7 +67,7 @@ Docker is needed for different tasks such as releasing and updating the document
 * Set the memory to at least 9 GB in Docker > Preference > Resources.
 
 ### Front End
-- Install [`Node.js`](https://nodejs.org) version 16. If you need to use different versions of Node on your machine, you may be interested in [NVM](https://github.com/nvm-sh/nvm). Otherwise, the simplest way to install Node on you Mac is to use `Homebrew` (and follow directions to add this version 
+- Install [`Node.js`](https://nodejs.org) version 16. If you need to use different versions of Node on your machine, you may be interested in [NVM](https://github.com/nvm-sh/nvm). Otherwise, the simplest way to install Node on you Mac is to use `Homebrew` (and follow directions to add this version
   to your PATH).
 
     ```shell

--- a/tests/test_utils/test_dataset_filtering.py
+++ b/tests/test_utils/test_dataset_filtering.py
@@ -53,7 +53,7 @@ def test_dataset_filtering(simple_text_config):
     assert combination_len < min(ds_len[((), (1,))], ds_len[((0,), ())])
 
 
-def test_dataset_filtering_errors(simple_text_config):
+def test_dataset_filtering_columns_not_in_dataset(simple_text_config):
     dm = generate_mocked_dm(simple_text_config)
     ds = dm.get_dataset_split(get_table_key(simple_text_config))
     ds = ds.rename_column(DatasetColumn.postprocessed_prediction, "col1")
@@ -62,29 +62,21 @@ def test_dataset_filtering_errors(simple_text_config):
     ds = ds.rename_column(DatasetColumn.postprocessed_outcome, "col4")
     ds = ds.rename_column(DatasetColumn.postprocessed_confidences, "col5")
 
-    with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(ds, DatasetFilters(prediction=[0]), config=dm.config)
-    assert DatasetColumn.postprocessed_prediction in str(e.value)
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(prediction=[0]), config=dm.config)
+    assert len(ds_filtered) == len(ds)
 
-    with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(ds, DatasetFilters(utterance="substring"), config=dm.config)
-    assert "utterance" in str(e.value)
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(utterance="substring"), config=dm.config)
+    assert len(ds_filtered) == len(ds)
 
-    with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(ds, DatasetFilters(label=[1]), config=dm.config)
-    assert "label" in str(e.value)
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(label=[1]), config=dm.config)
+    assert len(ds_filtered) == len(ds)
 
-    with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(
-            ds,
-            DatasetFilters(outcome=[OutcomeName.IncorrectAndRejected]),
-            config=dm.config,
-        )
-    assert DatasetColumn.postprocessed_outcome in str(e.value)
+    outcome = [OutcomeName.IncorrectAndRejected]
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(outcome=outcome), config=dm.config)
+    assert len(ds_filtered) == len(ds)
 
-    with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(ds, DatasetFilters(confidence_max=0.5), config=dm.config)
-    assert DatasetColumn.postprocessed_confidences in str(e.value)
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(confidence_max=0.5), config=dm.config)
+    assert len(ds_filtered) == len(ds)
 
 
 def test_dataset_filtering_multi(simple_text_config):

--- a/tests/test_utils/test_dataset_filtering.py
+++ b/tests/test_utils/test_dataset_filtering.py
@@ -8,6 +8,8 @@ from azimuth.types import DatasetColumn, DatasetFilters
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import (
     ALL_SMART_TAGS,
+    DATASET_SMART_TAG_FAMILIES,
+    PIPELINE_SMART_TAG_FAMILIES,
     SMART_TAGS_FAMILY_MAPPING,
     DataAction,
     SmartTag,
@@ -21,6 +23,12 @@ def test_all_smart_tags_have_a_family():
     assert sorted(
         tag.value for family in SMART_TAGS_FAMILY_MAPPING.values() for tag in family
     ) == sorted(ALL_SMART_TAGS)
+
+
+def test_all_smart_tag_families_are_dataset_or_pipeline():
+    assert sorted(SMART_TAGS_FAMILY_MAPPING.keys()) == sorted(
+        DATASET_SMART_TAG_FAMILIES + PIPELINE_SMART_TAG_FAMILIES
+    )
 
 
 def test_dataset_filtering(simple_text_config):

--- a/webapp/src/components/Controls/FilterSelector.test.tsx
+++ b/webapp/src/components/Controls/FilterSelector.test.tsx
@@ -17,6 +17,36 @@ test("display loading state", async () => {
   await screen.findByText("type");
   await screen.findByRole("progressbar");
   expect(await screen.queryByRole("figure")).toBeNull();
+  expect(screen.getByLabelText("collapse-type")).toBeDisabled();
+});
+
+test("display reloading state", async () => {
+  renderWithTheme(
+    <FilterSelector
+      label="type"
+      maxCount={0}
+      searchValue=""
+      selectedOptions={[]}
+      handleValueChange={() => {}}
+      filters={[
+        {
+          outcomeCount: {
+            CorrectAndPredicted: 0,
+            CorrectAndRejected: 0,
+            IncorrectAndPredicted: 0,
+            IncorrectAndRejected: 0,
+          },
+          utteranceCount: 0,
+          filterValue: "type1",
+        },
+      ]}
+      isFetching={true}
+    />
+  );
+
+  await screen.findByText("type");
+  await screen.findByRole("progressbar");
+  expect(await screen.queryByRole("figure")).not.toBeNull();
   expect(screen.getByLabelText("collapse-type")).not.toBeDisabled();
 });
 

--- a/webapp/src/components/Controls/FilterSelector.tsx
+++ b/webapp/src/components/Controls/FilterSelector.tsx
@@ -191,10 +191,10 @@ const FilterSelector = <FilterValue extends string>({
           onClick={() => setIsCollapsed(!isCollapsed)}
           aria-label={`collapse-${label}`}
           sx={{ padding: 0, minWidth: 0 }}
-          disabled={!filters && !isFetching}
+          disabled={!filters}
         >
           <MotionArrowDropDownIcon
-            animate={{ rotate: isCollapsed ? -90 : 0 }}
+            animate={{ rotate: isCollapsed || !filters ? -90 : 0 }}
             transition={transition}
             className={classes.collapseIcon}
           />
@@ -214,15 +214,20 @@ const FilterSelector = <FilterValue extends string>({
           label={label}
           componentsProps={{ typography: titleTypographyProps }}
         />
-        {selectedOptions.length > 0 && (
+        {filters && selectedOptions.length > 0 && (
           <Typography variant="body2" className={classes.selectedCount}>
             ({selectedOptions.length} selected)
           </Typography>
         )}
+        {isFetching && (
+          <Box flex="1" display="flex" justifyContent="end" marginRight={1}>
+            <CircularProgress size="1em" />
+          </Box>
+        )}
       </div>
       {!isCollapsed && (
         <>
-          {options ? (
+          {options && (
             <motion.ul
               className={classes.options}
               animate={{
@@ -232,8 +237,6 @@ const FilterSelector = <FilterValue extends string>({
             >
               {options.map(renderOption)}
             </motion.ul>
-          ) : (
-            isFetching && <CircularProgress />
           )}
           {numberOfOptions > INITIAL_NUMBER_VISIBLE && (
             <SeeMoreLess {...seeMoreLessProps} />


### PR DESCRIPTION
Resolve #132

## Description:

* Fix filtering dataset with pipeline filters
  - This happens if you check some filters while a pipeline is selected (for example predictions, outcomes, pipeline smart tags, etc.) and then unselect the pipeline (dataset analysis).
  - I think it's good to keep the filters in the query parameters so that they are preserved if you come back to selecting a pipeline. We can revisit that later.
  - So in that case, I think the pipeline filters should simply be ignored (instead of erroring out), similar to if `?potato=happiness` is provided.
* Resolve deprecation warning
* Test that all smart tag families are classified as a dataset or a pipeline family
* Remove duplicated information about which smart tags need predictions by basing `ALL_PREDICTION_TAGS` off of `PIPELINE_SMART_TAG_FAMILIES`

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
