### PR TITLE
Singular filters

### DIFF
--- a/azimuth/modules/model_performance/metrics.py
+++ b/azimuth/modules/model_performance/metrics.py
@@ -284,13 +284,13 @@ class MetricsPerFilterModule(AggregationModule[AzimuthConfig]):
         """
         filter_copy = initial_filter.copy(deep=True)
         if label is not None:
-            filter_copy.labels.append(label)
+            filter_copy.label.append(label)
         if prediction is not None:
-            filter_copy.predictions.append(prediction)
+            filter_copy.prediction.append(prediction)
         if data_action is not None:
-            filter_copy.data_actions.append(data_action)
+            filter_copy.data_action.append(data_action)
         if outcome is not None:
-            filter_copy.outcomes.append(outcome)
+            filter_copy.outcome.append(outcome)
         if smart_tag is not None:
             filter_copy.smart_tags.update(smart_tag)
         return filter_copy

--- a/azimuth/types/general/module_options.py
+++ b/azimuth/types/general/module_options.py
@@ -15,29 +15,29 @@ from azimuth.types.tag import DataAction
 class AbsDatasetFilters(AliasModel):
     confidence_min: float = 0
     confidence_max: float = 1
-    data_actions: List[DataAction] = []
-    outcomes: List[OutcomeName] = []
+    data_action: List[DataAction] = []
+    outcome: List[OutcomeName] = []
     smart_tags: Dict[str, List[str]] = {}
     utterance: Optional[str]  # Must contain this subset.
 
 
 class DatasetFilters(AbsDatasetFilters):
-    labels: List[int] = []
-    predictions: List[int] = []
+    label: List[int] = []
+    prediction: List[int] = []
 
 
 class NamedDatasetFilters(AbsDatasetFilters):
-    labels: List[str] = []
-    predictions: List[str] = []
+    label: List[str] = []
+    prediction: List[str] = []
 
     def to_dataset_filters(self, class_names: List[str]) -> DatasetFilters:
         return DatasetFilters(
             confidence_min=self.confidence_min,
             confidence_max=self.confidence_max,
-            labels=[class_names.index(cl) for cl in self.labels],
-            predictions=[class_names.index(cl) for cl in self.predictions],
-            data_actions=self.data_actions,
-            outcomes=self.outcomes,
+            label=[class_names.index(cl) for cl in self.label],
+            prediction=[class_names.index(cl) for cl in self.prediction],
+            data_action=self.data_action,
+            outcome=self.outcome,
             smart_tags=self.smart_tags,
             utterance=self.utterance,
         )

--- a/azimuth/utils/filtering.py
+++ b/azimuth/utils/filtering.py
@@ -52,14 +52,14 @@ def filter_dataset_split(
         dataset_split = dataset_split.filter(
             lambda x: filters.confidence_min <= x[confidence_column][0] <= filters.confidence_max
         )
-    if len(filters.labels) > 0:
+    if len(filters.label) > 0:
         verify_column_is_present(config.columns.label, dataset_split)
-        dataset_split = dataset_split.filter(lambda x: x[config.columns.label] in filters.labels)
+        dataset_split = dataset_split.filter(lambda x: x[config.columns.label] in filters.label)
     if filters.utterance is not None:
         verify_column_is_present(config.columns.text_input, dataset_split)
         by = filters.utterance.lower()
         dataset_split = dataset_split.filter(lambda x: by in x[config.columns.text_input].lower())
-    if len(filters.predictions) > 0:
+    if len(filters.prediction) > 0:
         prediction_column = (
             DatasetColumn.model_predictions
             if without_postprocessing
@@ -68,21 +68,21 @@ def filter_dataset_split(
         verify_column_is_present(prediction_column, dataset_split)
         if without_postprocessing:
             dataset_split = dataset_split.filter(
-                lambda x: x[DatasetColumn.model_predictions][0] in filters.predictions
+                lambda x: x[DatasetColumn.model_predictions][0] in filters.prediction
             )
         else:
             dataset_split = dataset_split.filter(
-                lambda x: x[DatasetColumn.postprocessed_prediction] in filters.predictions
+                lambda x: x[DatasetColumn.postprocessed_prediction] in filters.prediction
             )
-    if len(filters.data_actions) > 0:
+    if len(filters.data_action) > 0:
         # We do OR for data_action tags.
         dataset_split = dataset_split.filter(
             lambda x: any(
                 ((not any(x[v] for v in ALL_DATA_ACTIONS)) if v == DataAction.no_action else x[v])
-                for v in filters.data_actions
+                for v in filters.data_action
             )
         )
-    if len(filters.outcomes) > 0:
+    if len(filters.outcome) > 0:
         outcome_column = (
             DatasetColumn.model_outcome
             if without_postprocessing
@@ -90,7 +90,7 @@ def filter_dataset_split(
         )
         verify_column_is_present(outcome_column, dataset_split)
         # We do OR for outcomes.
-        dataset_split = dataset_split.filter(lambda x: x[outcome_column] in filters.outcomes)
+        dataset_split = dataset_split.filter(lambda x: x[outcome_column] in filters.outcome)
     for key, tags_in_family in filters.smart_tags.items():
         # For each smart tag family, we do OR, but AND between families
         # If None, it is none of them.

--- a/azimuth/utils/routers.py
+++ b/azimuth/utils/routers.py
@@ -37,8 +37,8 @@ def get_last_update(dataset_split_managers: List[Optional[DatasetSplitManager]])
 def build_named_dataset_filters(
     confidence_min: float = Query(0, title="Minimum confidence", alias="confidenceMin"),
     confidence_max: float = Query(1, title="Maximum confidence", alias="confidenceMax"),
-    labels: List[str] = Query([], title="Label"),
-    predictions: List[str] = Query([], title="Prediction"),
+    label: List[str] = Query([], title="Label"),
+    prediction: List[str] = Query([], title="Prediction"),
     extreme_length: List[SmartTag] = Query([], title="Extreme length", alias="extremeLength"),
     partial_syntax: List[SmartTag] = Query([], title="Partial syntax", alias="partialSyntax"),
     dissimilar: List[SmartTag] = Query([], title="Dissimilar"),
@@ -48,8 +48,8 @@ def build_named_dataset_filters(
     ),
     pipeline_comparison: List[SmartTag] = Query([], title="Pipeline comparison"),
     uncertain: List[SmartTag] = Query([], title="Uncertain"),
-    data_actions: List[DataAction] = Query([], title="Data action tags", alias="dataActions"),
-    outcomes: List[OutcomeName] = Query([], title="Outcomes", alias="outcomes"),
+    data_action: List[DataAction] = Query([], title="Data action tags", alias="dataAction"),
+    outcome: List[OutcomeName] = Query([], title="Outcomes"),
     utterance: Optional[str] = Query(None, title="Utterance"),
 ) -> NamedDatasetFilters:
     """Build the named filter component used by many tasks. Intended as a FastAPI endpoint dependency.
@@ -57,8 +57,8 @@ def build_named_dataset_filters(
     Args:
         confidence_min: The desired minimum confidence
         confidence_max: The desired maximum confidence
-        labels: The desired class labels
-        predictions: The desired class predictions
+        label: The desired class labels
+        prediction: The desired class predictions
         extreme_length: The desired `extreme_length` smart tags
         partial_syntax: The desired `partial_syntax` smart tags
         dissimilar: The desired `dissimilar` smart tags
@@ -66,8 +66,8 @@ def build_named_dataset_filters(
         behavioral_testing: The desired `behavioral_testing` smart tags
         pipeline_comparison: The desired `pipeline_comparison` smart tags
         uncertain: The desired `uncertain` smart tags
-        data_actions: The desired data_action tags
-        outcomes: The desired outcomes
+        data_action: The desired data_action tags
+        outcome: The desired outcomes
         utterance: The substring desired in each utterance
 
     Returns:
@@ -77,8 +77,8 @@ def build_named_dataset_filters(
     return NamedDatasetFilters(
         confidence_min=confidence_min,
         confidence_max=confidence_max,
-        labels=labels,
-        predictions=predictions,
+        label=label,
+        prediction=prediction,
         smart_tags={
             SmartTagFamily.extreme_length: extreme_length,
             SmartTagFamily.partial_syntax: partial_syntax,
@@ -88,9 +88,9 @@ def build_named_dataset_filters(
             SmartTagFamily.pipeline_comparison: pipeline_comparison,
             SmartTagFamily.uncertain: uncertain,
         },
-        data_actions=data_actions,
+        data_action=data_action,
         utterance=utterance,
-        outcomes=outcomes,
+        outcome=outcome,
     )
 
 

--- a/tests/test_modules/test_caching.py
+++ b/tests/test_modules/test_caching.py
@@ -73,13 +73,13 @@ def test_module_cache_with_options(simple_text_config):
     original_mod = FilterableModule(
         DatasetSplitName.eval,
         simple_text_config,
-        mod_options=ModuleOptions(filters=DatasetFilters(labels=[0]), pipeline_index=0),
+        mod_options=ModuleOptions(filters=DatasetFilters(label=[0]), pipeline_index=0),
     )
 
     modified_mod = FilterableModule(
         DatasetSplitName.eval,
         simple_text_config,
-        mod_options=ModuleOptions(filters=DatasetFilters(labels=[1]), pipeline_index=0),
+        mod_options=ModuleOptions(filters=DatasetFilters(label=[1]), pipeline_index=0),
     )
 
     assert original_mod.name != modified_mod.name
@@ -89,7 +89,7 @@ def test_module_cache_with_options(simple_text_config):
         Module(
             DatasetSplitName.eval,
             simple_text_config,
-            mod_options=ModuleOptions(filters=DatasetFilters(labels=[0]), pipeline_index=0),
+            mod_options=ModuleOptions(filters=DatasetFilters(label=[0]), pipeline_index=0),
         )
 
 

--- a/tests/test_modules/test_model_performance/test_confidence_binning.py
+++ b/tests/test_modules/test_model_performance/test_confidence_binning.py
@@ -81,7 +81,7 @@ def test_confidence_histogram_empty(simple_text_config, apply_mocked_startup_tas
     mod = ConfidenceHistogramModule(
         DatasetSplitName.eval,
         simple_text_config,
-        mod_options=ModuleOptions(filters=DatasetFilters(labels=UNKNOWN_TARGET), pipeline_index=0),
+        mod_options=ModuleOptions(filters=DatasetFilters(label=UNKNOWN_TARGET), pipeline_index=0),
     )
     out = mod.compute_on_dataset_split()[0].bins
 

--- a/tests/test_modules/test_model_performance/test_confusion_matrix.py
+++ b/tests/test_modules/test_model_performance/test_confusion_matrix.py
@@ -29,7 +29,7 @@ def test_confusion_matrix(tiny_text_config):
     mod_filter = ConfusionMatrixModule(
         DatasetSplitName.eval,
         tiny_text_config,
-        mod_options=ModuleOptions(filters=DatasetFilters(labels=[0]), pipeline_index=0),
+        mod_options=ModuleOptions(filters=DatasetFilters(label=[0]), pipeline_index=0),
     )
     [json_output_filter] = mod_filter.compute_on_dataset_split()
 

--- a/tests/test_modules/test_model_performance/test_metrics.py
+++ b/tests/test_modules/test_model_performance/test_metrics.py
@@ -55,7 +55,7 @@ def test_metrics(tiny_text_config):
     metrics_mod_filters = MetricsModule(
         DatasetSplitName.eval,
         tiny_text_config,
-        mod_options=ModuleOptions(filters=DatasetFilters(predictions=[1]), pipeline_index=0),
+        mod_options=ModuleOptions(filters=DatasetFilters(prediction=[1]), pipeline_index=0),
     )
     [metrics_res_filters] = metrics_mod_filters.compute_on_dataset_split()
 
@@ -120,7 +120,7 @@ def test_empty_ds(tiny_text_config):
     mod = MetricsModule(
         DatasetSplitName.eval,
         tiny_text_config,
-        mod_options=ModuleOptions(filters=DatasetFilters(labels=[42]), pipeline_index=0),
+        mod_options=ModuleOptions(filters=DatasetFilters(label=[42]), pipeline_index=0),
     )
     _ = mod.get_dataset_split()
     [json_output] = mod.compute_on_dataset_split()
@@ -177,7 +177,7 @@ def test_outcome_count_per_filter(tiny_text_config):
     mod_filter_0 = OutcomeCountPerFilterModule(
         DatasetSplitName.eval,
         config=tiny_text_config,
-        mod_options=ModuleOptions(filters=DatasetFilters(labels=[0]), pipeline_index=0),
+        mod_options=ModuleOptions(filters=DatasetFilters(label=[0]), pipeline_index=0),
     )
 
     [res_filter_0] = mod_filter_0.compute_on_dataset_split()

--- a/tests/test_routers/test_model_performance/test_utterance_count.py
+++ b/tests/test_routers/test_model_performance/test_utterance_count.py
@@ -31,7 +31,7 @@ def test_get_utterance_count_per_filter(app: FastAPI) -> None:
     assert "prediction" not in metrics and "outcome" not in metrics and "uncertain" not in metrics
 
     resp = client.get(
-        "/dataset_splits/eval/utterance_count/per_filter?pipelineIndex=0&labels=positive"
+        "/dataset_splits/eval/utterance_count/per_filter?pipelineIndex=0&label=positive"
     )
     assert resp.status_code == HTTP_200_OK, resp.text
     data = resp.json()

--- a/tests/test_utils/test_dataset_filtering.py
+++ b/tests/test_utils/test_dataset_filtering.py
@@ -31,24 +31,24 @@ def test_dataset_filtering(simple_text_config):
 
     def filtered_len(tf: DatasetFilters) -> int:
         ds_filtered = filter_dataset_split(ds, tf, config=dm.config)
-        ds_len[(tuple(tf.labels), tuple(tf.predictions))] = len(ds_filtered)
+        ds_len[(tuple(tf.label), tuple(tf.prediction))] = len(ds_filtered)
         return len(ds_filtered)
 
     assert filtered_len(DatasetFilters()) == len(ds)
     assert filtered_len(DatasetFilters(confidence_min=0.5)) == 0.9 * len(ds) // 2
     assert filtered_len(DatasetFilters(confidence_max=0.5)) == len(ds) - 0.9 * len(ds) // 2
-    assert filtered_len(DatasetFilters(labels=[0])) == 22
-    assert filtered_len(DatasetFilters(data_actions=[DataAction.relabel])) == 1
-    assert filtered_len(DatasetFilters(outcomes=[OutcomeName.IncorrectAndRejected])) == 33
+    assert filtered_len(DatasetFilters(label=[0])) == 22
+    assert filtered_len(DatasetFilters(data_action=[DataAction.relabel])) == 1
+    assert filtered_len(DatasetFilters(outcome=[OutcomeName.IncorrectAndRejected])) == 33
     assert (
         filtered_len(DatasetFilters(smart_tags={SmartTagFamily.extreme_length: [SmartTag.short]}))
         == 1
     )
     assert filtered_len(DatasetFilters(utterance="some")) == 2
-    assert filtered_len(DatasetFilters(predictions=[1])) == 5
+    assert filtered_len(DatasetFilters(prediction=[1])) == 5
 
     # We can filter by combinations of filter
-    combination_len = filtered_len(DatasetFilters(labels=[0], predictions=[1]))
+    combination_len = filtered_len(DatasetFilters(label=[0], prediction=[1]))
     assert combination_len == 3
     assert combination_len < min(ds_len[((), (1,))], ds_len[((0,), ())])
 
@@ -63,7 +63,7 @@ def test_dataset_filtering_errors(simple_text_config):
     ds = ds.rename_column(DatasetColumn.postprocessed_confidences, "col5")
 
     with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(ds, DatasetFilters(predictions=[0]), config=dm.config)
+        _ = filter_dataset_split(ds, DatasetFilters(prediction=[0]), config=dm.config)
     assert DatasetColumn.postprocessed_prediction in str(e.value)
 
     with pytest.raises(ValueError) as e:
@@ -71,13 +71,13 @@ def test_dataset_filtering_errors(simple_text_config):
     assert "utterance" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        _ = filter_dataset_split(ds, DatasetFilters(labels=[1]), config=dm.config)
+        _ = filter_dataset_split(ds, DatasetFilters(label=[1]), config=dm.config)
     assert "label" in str(e.value)
 
     with pytest.raises(ValueError) as e:
         _ = filter_dataset_split(
             ds,
-            DatasetFilters(outcomes=[OutcomeName.IncorrectAndRejected]),
+            DatasetFilters(outcome=[OutcomeName.IncorrectAndRejected]),
             config=dm.config,
         )
     assert DatasetColumn.postprocessed_outcome in str(e.value)
@@ -98,11 +98,11 @@ def test_dataset_filtering_multi(simple_text_config):
     assert len(ds_filtered) == len(ds)
 
     # We can filter by multiple targets ie does nothing in this case.
-    ds_filtered = filter_dataset_split(ds, DatasetFilters(labels=[0, 1]), config=dm.config)
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(label=[0, 1]), config=dm.config)
     assert len(ds) == len(ds_filtered)
 
     # We can filter by multiple preds, will remove the rejection class from preds
-    ds_filtered = filter_dataset_split(ds, DatasetFilters(predictions=[0, 1]), config=dm.config)
+    ds_filtered = filter_dataset_split(ds, DatasetFilters(prediction=[0, 1]), config=dm.config)
     num_rejection_class = sum(
         p != dm.rejection_class_idx
         for p in dm.get_dataset_split(simple_table_key)[DatasetColumn.postprocessed_prediction]
@@ -191,12 +191,12 @@ def test_dataset_filtering_without_postprocessing(simple_text_config):
     ds = dm.get_dataset_split(get_table_key(simple_text_config))
     ds_filtered_with_postprocessing = filter_dataset_split(
         ds,
-        DatasetFilters(predictions=[0]),
+        DatasetFilters(prediction=[0]),
         config=dm.config,
     )
     ds_filtered_without_postprocessing = filter_dataset_split(
         ds,
-        DatasetFilters(predictions=[0]),
+        DatasetFilters(prediction=[0]),
         config=dm.config,
         without_postprocessing=True,
     )

--- a/tests/test_utils/test_task_running.py
+++ b/tests/test_utils/test_task_running.py
@@ -16,7 +16,7 @@ task_name = SupportedModule.PerturbationTestingSummary
 dataset_split_name = DatasetSplitName.train
 indices = [1, 2, 3]
 mod_options = ModuleOptions(
-    threshold=0.6, filters=DatasetFilters(labels=[0]), pipeline_index=0
+    threshold=0.6, filters=DatasetFilters(label=[0]), pipeline_index=0
 )  # example
 custom_query = {"custom_key1": 1, "custom_key2": "two"}
 

--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -279,7 +279,7 @@ const UtterancesTable: React.FC<Props> = ({
       renderHeader: () =>
         renderHeaderWithFilter(
           "Label",
-          filters.labels !== undefined,
+          filters.label !== undefined,
           AdjustIcon
         ),
       flex: 1,
@@ -292,7 +292,7 @@ const UtterancesTable: React.FC<Props> = ({
       renderHeader: () =>
         renderHeaderWithFilter(
           "Prediction",
-          filters.predictions !== undefined,
+          filters.prediction !== undefined,
           MultilineChartIcon
         ),
       flex: 1,
@@ -339,7 +339,7 @@ const UtterancesTable: React.FC<Props> = ({
       renderHeader: () =>
         renderHeaderWithFilter(
           "Proposed Action",
-          filters.dataActions !== undefined
+          filters.dataAction !== undefined
         ),
       renderCell: renderDataAction,
       width: 155,

--- a/webapp/src/components/ConfidenceHistogramTopWords.tsx
+++ b/webapp/src/components/ConfidenceHistogramTopWords.tsx
@@ -42,7 +42,7 @@ const ConfidenceHistogramTopWords: React.FC<Props> = ({
   }>();
 
   const {
-    outcomes = ALL_OUTCOMES,
+    outcome = ALL_OUTCOMES,
     confidenceMin = 0,
     confidenceMax = 1,
     ...filtersWithoutBins
@@ -81,7 +81,7 @@ const ConfidenceHistogramTopWords: React.FC<Props> = ({
         data={bins}
         confidenceMin={confidenceMin}
         confidenceMax={confidenceMax}
-        filteredOutcomes={outcomes}
+        filteredOutcomes={outcome}
       />
       <Box
         display="grid"

--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -104,10 +104,6 @@ const Controls: React.FC<Props> = ({
     `${datasetSplitName}ClassDistribution`
   ].reduce((a, b) => a + b);
 
-  const selectedLabels = filters.labels || [];
-  const selectedPredictions = filters.predictions || [];
-  const selectedDataActions = filters.dataActions || [];
-
   const handleCollapseFilters = () => {
     setIsCollapsed(!isCollapsed);
   };
@@ -317,8 +313,8 @@ const Controls: React.FC<Props> = ({
                 label="Prediction Outcome"
                 maxCount={maxCount}
                 searchValue={searchValue}
-                selectedOptions={filters.outcomes || []}
-                handleValueChange={handleFilterSelectorChange("outcomes")}
+                selectedOptions={filters.outcome ?? []}
+                handleValueChange={handleFilterSelectorChange("outcome")}
                 filters={countPerFilter?.countPerFilter.outcome}
                 isFetching={isFetchingCountPerFilter}
                 prettyNames={OUTCOME_PRETTY_NAMES}
@@ -328,8 +324,8 @@ const Controls: React.FC<Props> = ({
                 label="Label"
                 maxCount={maxCount}
                 searchValue={searchValue}
-                selectedOptions={selectedLabels}
-                handleValueChange={handleFilterSelectorChange("labels")}
+                selectedOptions={filters.label ?? []}
+                handleValueChange={handleFilterSelectorChange("label")}
                 filters={countPerFilter?.countPerFilter.label}
                 isFetching={isFetchingCountPerFilter}
               />
@@ -338,8 +334,8 @@ const Controls: React.FC<Props> = ({
                 label="Prediction"
                 maxCount={maxCount}
                 searchValue={searchValue}
-                selectedOptions={selectedPredictions}
-                handleValueChange={handleFilterSelectorChange("predictions")}
+                selectedOptions={filters.prediction ?? []}
+                handleValueChange={handleFilterSelectorChange("prediction")}
                 filters={countPerFilter?.countPerFilter.prediction}
                 isFetching={isFetchingCountPerFilter}
               />
@@ -370,8 +366,8 @@ const Controls: React.FC<Props> = ({
                 label="Proposed Action"
                 maxCount={maxCount}
                 searchValue={searchValue}
-                selectedOptions={selectedDataActions}
-                handleValueChange={handleFilterSelectorChange("dataActions")}
+                selectedOptions={filters.dataAction ?? []}
+                handleValueChange={handleFilterSelectorChange("dataAction")}
                 filters={countPerFilter?.countPerFilter.dataAction}
                 isFetching={isFetchingCountPerFilter}
               />

--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   CircularProgress,
   FormControlLabel,
+  FormControlLabelProps,
   IconButton,
   InputAdornment,
   OutlinedInput,
@@ -19,6 +20,7 @@ import {
   QueryPipelineState,
   QueryPostprocessingState,
   QueryConfusionMatrixState,
+  QueryArrayFiltersState,
 } from "types/models";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { motion } from "framer-motion";
@@ -138,7 +140,7 @@ const Controls: React.FC<Props> = ({
       })}`
     );
 
-  const handleFilterSelectorChange =
+  const getFilterChangeHandler =
     <FilterName extends keyof QueryFilterState>(filterName: FilterName) =>
     (filterValue: QueryFilterState[FilterName]) =>
       handleFilterChange({ ...filters, [filterName]: filterValue });
@@ -175,6 +177,22 @@ const Controls: React.FC<Props> = ({
         )
       : 0;
   }, [countPerFilter]);
+
+  const FilterCheckboxList: React.FC<{
+    filter: keyof QueryArrayFiltersState;
+    label: FormControlLabelProps["label"];
+    prettyNames?: Record<string, string>;
+  }> = ({ filter, ...props }) => (
+    <FilterSelector
+      maxCount={maxCount}
+      searchValue={searchValue}
+      selectedOptions={filters[filter] ?? []}
+      handleValueChange={getFilterChangeHandler(filter)}
+      filters={countPerFilter?.countPerFilter[filter]}
+      isFetching={isFetchingCountPerFilter}
+      {...props}
+    />
+  );
 
   const divider = (
     <Box marginY={1} borderBottom="1px solid rgba(0, 0, 0, 0.12)" />
@@ -273,7 +291,7 @@ const Controls: React.FC<Props> = ({
             label="Utterance"
             placeholder="Search utterances"
             filterValue={filters.utterance}
-            setFilterValue={handleFilterSelectorChange("utterance")}
+            setFilterValue={getFilterChangeHandler("utterance")}
           />
           {divider}
           <FilterSlider
@@ -307,72 +325,28 @@ const Controls: React.FC<Props> = ({
             />
           </Box>
           {divider}
-          <Box marginTop={1} sx={{ overflowY: "auto", overflowX: "hidden" }}>
-            <>
-              <FilterSelector
-                label="Prediction Outcome"
-                maxCount={maxCount}
-                searchValue={searchValue}
-                selectedOptions={filters.outcome ?? []}
-                handleValueChange={handleFilterSelectorChange("outcome")}
-                filters={countPerFilter?.countPerFilter.outcome}
-                isFetching={isFetchingCountPerFilter}
-                prettyNames={OUTCOME_PRETTY_NAMES}
+          <Stack display="block" divider={divider} overflow="hidden auto">
+            <FilterCheckboxList
+              filter="outcome"
+              label="Prediction Outcome"
+              prettyNames={OUTCOME_PRETTY_NAMES}
+            />
+            <FilterCheckboxList filter="label" label="Label" />
+            <FilterCheckboxList filter="prediction" label="Prediction" />
+            {SMART_TAG_FAMILIES.map((filterName) => (
+              <FilterCheckboxList
+                key={filterName}
+                filter={filterName}
+                label={
+                  <Stack direction="row" gap={1}>
+                    {SMART_TAG_FAMILY_PRETTY_NAMES[filterName]}
+                    {React.createElement(SMART_TAG_FAMILY_ICONS[filterName])}
+                  </Stack>
+                }
               />
-              {divider}
-              <FilterSelector
-                label="Label"
-                maxCount={maxCount}
-                searchValue={searchValue}
-                selectedOptions={filters.label ?? []}
-                handleValueChange={handleFilterSelectorChange("label")}
-                filters={countPerFilter?.countPerFilter.label}
-                isFetching={isFetchingCountPerFilter}
-              />
-              {divider}
-              <FilterSelector
-                label="Prediction"
-                maxCount={maxCount}
-                searchValue={searchValue}
-                selectedOptions={filters.prediction ?? []}
-                handleValueChange={handleFilterSelectorChange("prediction")}
-                filters={countPerFilter?.countPerFilter.prediction}
-                isFetching={isFetchingCountPerFilter}
-              />
-              {SMART_TAG_FAMILIES.map((filterName) => (
-                <React.Fragment key={filterName}>
-                  {divider}
-                  <FilterSelector
-                    label={
-                      <Stack direction="row" gap={1}>
-                        {SMART_TAG_FAMILY_PRETTY_NAMES[filterName]}
-                        {React.createElement(
-                          SMART_TAG_FAMILY_ICONS[filterName],
-                          {}
-                        )}
-                      </Stack>
-                    }
-                    maxCount={maxCount}
-                    searchValue={searchValue}
-                    selectedOptions={filters[filterName] ?? []}
-                    handleValueChange={handleFilterSelectorChange(filterName)}
-                    filters={countPerFilter?.countPerFilter[filterName]}
-                    isFetching={isFetchingCountPerFilter}
-                  />
-                </React.Fragment>
-              ))}
-              {divider}
-              <FilterSelector
-                label="Proposed Action"
-                maxCount={maxCount}
-                searchValue={searchValue}
-                selectedOptions={filters.dataAction ?? []}
-                handleValueChange={handleFilterSelectorChange("dataAction")}
-                filters={countPerFilter?.countPerFilter.dataAction}
-                isFetching={isFetchingCountPerFilter}
-              />
-            </>
-          </Box>
+            ))}
+            <FilterCheckboxList filter="dataAction" label="Proposed Action" />
+          </Stack>
         </>
       )}
     </Stack>

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -243,19 +243,13 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
     };
   }, []);
 
-  const filterName = (
-    BASIC_FILTER_OPTIONS as readonly FilterByViewOption[]
-  ).includes(selectedMetricPerFilterOption)
-    ? `${selectedMetricPerFilterOption}s`
-    : selectedMetricPerFilterOption;
-
   const RowLink = (props: RowProps<Row>) => (
     <Link
       style={{ color: "unset", textDecoration: "unset" }}
       to={`/${jobId}/dataset_splits/${selectedDatasetSplit}/performance_overview${constructSearchString(
         {
           ...(props.row.id !== OVERALL_ROW_ID && {
-            [filterName]: [props.row.filterValue],
+            [selectedMetricPerFilterOption]: [props.row.filterValue],
           }),
           ...pipeline,
         }

--- a/webapp/src/pages/Exploration.tsx
+++ b/webapp/src/pages/Exploration.tsx
@@ -154,8 +154,8 @@ const Exploration = () => {
                     filters={filters}
                     pipeline={pipeline}
                     classOptions={classOptions}
-                    predictionFilters={filters.predictions}
-                    labelFilters={filters.labels}
+                    predictionFilters={filters.prediction}
+                    labelFilters={filters.label}
                     postprocessing={postprocessing}
                   />
                 </>

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -874,8 +874,8 @@ export interface operations {
         pipelineIndex: number;
         confidenceMin?: number;
         confidenceMax?: number;
-        labels?: string[];
-        predictions?: string[];
+        label?: string[];
+        prediction?: string[];
         extremeLength?: components["schemas"]["SmartTag"][];
         partialSyntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
@@ -883,8 +883,8 @@ export interface operations {
         behavioralTesting?: components["schemas"]["SmartTag"][];
         pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataActions?: components["schemas"]["DataAction"][];
-        outcomes?: components["schemas"]["OutcomeName"][];
+        dataAction?: components["schemas"]["DataAction"][];
+        outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
     };
@@ -925,8 +925,8 @@ export interface operations {
         pipelineIndex: number;
         confidenceMin?: number;
         confidenceMax?: number;
-        labels?: string[];
-        predictions?: string[];
+        label?: string[];
+        prediction?: string[];
         extremeLength?: components["schemas"]["SmartTag"][];
         partialSyntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
@@ -934,8 +934,8 @@ export interface operations {
         behavioralTesting?: components["schemas"]["SmartTag"][];
         pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataActions?: components["schemas"]["DataAction"][];
-        outcomes?: components["schemas"]["OutcomeName"][];
+        dataAction?: components["schemas"]["DataAction"][];
+        outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
     };
@@ -1015,8 +1015,8 @@ export interface operations {
         pipelineIndex: number;
         confidenceMin?: number;
         confidenceMax?: number;
-        labels?: string[];
-        predictions?: string[];
+        label?: string[];
+        prediction?: string[];
         extremeLength?: components["schemas"]["SmartTag"][];
         partialSyntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
@@ -1024,8 +1024,8 @@ export interface operations {
         behavioralTesting?: components["schemas"]["SmartTag"][];
         pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataActions?: components["schemas"]["DataAction"][];
-        outcomes?: components["schemas"]["OutcomeName"][];
+        dataAction?: components["schemas"]["DataAction"][];
+        outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
     };
@@ -1053,8 +1053,8 @@ export interface operations {
       query: {
         confidenceMin?: number;
         confidenceMax?: number;
-        labels?: string[];
-        predictions?: string[];
+        label?: string[];
+        prediction?: string[];
         extremeLength?: components["schemas"]["SmartTag"][];
         partialSyntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
@@ -1062,8 +1062,8 @@ export interface operations {
         behavioralTesting?: components["schemas"]["SmartTag"][];
         pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataActions?: components["schemas"]["DataAction"][];
-        outcomes?: components["schemas"]["OutcomeName"][];
+        dataAction?: components["schemas"]["DataAction"][];
+        outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
     };
@@ -1095,8 +1095,8 @@ export interface operations {
         withoutPostprocessing?: boolean;
         confidenceMin?: number;
         confidenceMax?: number;
-        labels?: string[];
-        predictions?: string[];
+        label?: string[];
+        prediction?: string[];
         extremeLength?: components["schemas"]["SmartTag"][];
         partialSyntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
@@ -1104,8 +1104,8 @@ export interface operations {
         behavioralTesting?: components["schemas"]["SmartTag"][];
         pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataActions?: components["schemas"]["DataAction"][];
-        outcomes?: components["schemas"]["OutcomeName"][];
+        dataAction?: components["schemas"]["DataAction"][];
+        outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
         pipelineIndex?: number;
         limit?: number;
@@ -1297,8 +1297,8 @@ export interface operations {
         pipelineIndex: number;
         confidenceMin?: number;
         confidenceMax?: number;
-        labels?: string[];
-        predictions?: string[];
+        label?: string[];
+        prediction?: string[];
         extremeLength?: components["schemas"]["SmartTag"][];
         partialSyntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
@@ -1306,8 +1306,8 @@ export interface operations {
         behavioralTesting?: components["schemas"]["SmartTag"][];
         pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataActions?: components["schemas"]["DataAction"][];
-        outcomes?: components["schemas"]["OutcomeName"][];
+        dataAction?: components["schemas"]["DataAction"][];
+        outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
     };
@@ -1338,8 +1338,8 @@ export interface operations {
         pipelineIndex: number;
         confidenceMin?: number;
         confidenceMax?: number;
-        labels?: string[];
-        predictions?: string[];
+        label?: string[];
+        prediction?: string[];
         extremeLength?: components["schemas"]["SmartTag"][];
         partialSyntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
@@ -1347,8 +1347,8 @@ export interface operations {
         behavioralTesting?: components["schemas"]["SmartTag"][];
         pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataActions?: components["schemas"]["DataAction"][];
-        outcomes?: components["schemas"]["OutcomeName"][];
+        dataAction?: components["schemas"]["DataAction"][];
+        outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
     };

--- a/webapp/src/types/models.ts
+++ b/webapp/src/types/models.ts
@@ -5,9 +5,7 @@ import {
   UtterancesSortableColumn,
 } from "types/api";
 
-export type QueryFilterState = {
-  confidenceMin?: number;
-  confidenceMax?: number;
+export type QueryArrayFiltersState = {
   label?: string[];
   prediction?: string[];
   extremeLength?: SmartTag[];
@@ -19,6 +17,11 @@ export type QueryFilterState = {
   uncertain?: SmartTag[];
   dataAction?: DataAction[];
   outcome?: Outcome[];
+};
+
+export type QueryFilterState = QueryArrayFiltersState & {
+  confidenceMin?: number;
+  confidenceMax?: number;
   utterance?: string;
 };
 

--- a/webapp/src/types/models.ts
+++ b/webapp/src/types/models.ts
@@ -8,8 +8,8 @@ import {
 export type QueryFilterState = {
   confidenceMin?: number;
   confidenceMax?: number;
-  labels?: string[];
-  predictions?: string[];
+  label?: string[];
+  prediction?: string[];
   extremeLength?: SmartTag[];
   partialSyntax?: SmartTag[];
   dissimilar?: SmartTag[];
@@ -17,8 +17,8 @@ export type QueryFilterState = {
   behavioralTesting?: SmartTag[];
   pipelineComparison?: SmartTag[];
   uncertain?: SmartTag[];
-  dataActions?: DataAction[];
-  outcomes?: Outcome[];
+  dataAction?: DataAction[];
+  outcome?: Outcome[];
   utterance?: string;
 };
 

--- a/webapp/src/utils/helpers.test.ts
+++ b/webapp/src/utils/helpers.test.ts
@@ -8,8 +8,8 @@ test("convertSearchParamsToFilterState", () => {
   expect(parseSearchString("").filters).toStrictEqual({
     confidenceMin: undefined,
     confidenceMax: undefined,
-    labels: undefined,
-    predictions: undefined,
+    label: undefined,
+    prediction: undefined,
     extremeLength: undefined,
     partialSyntax: undefined,
     dissimilar: undefined,
@@ -17,20 +17,20 @@ test("convertSearchParamsToFilterState", () => {
     behavioralTesting: undefined,
     pipelineComparison: undefined,
     uncertain: undefined,
-    dataActions: undefined,
-    outcomes: undefined,
+    dataAction: undefined,
+    outcome: undefined,
     utterance: undefined,
   });
 
   expect(
     parseSearchString(
-      "?labels=1,2&predictions=3,4&partialSyntax=missing_obj,missing_subj&dataActions=remove,relabel&outcomes=CorrectAndPredicted,IncorrectAndRejected"
+      "?label=1,2&prediction=3,4&partialSyntax=missing_obj,missing_subj&dataAction=remove,relabel&outcome=CorrectAndPredicted,IncorrectAndRejected"
     ).filters
   ).toStrictEqual({
     confidenceMin: undefined,
     confidenceMax: undefined,
-    labels: ["1", "2"],
-    predictions: ["3", "4"],
+    label: ["1", "2"],
+    prediction: ["3", "4"],
     extremeLength: undefined,
     partialSyntax: ["missing_obj", "missing_subj"],
     dissimilar: undefined,
@@ -38,16 +38,16 @@ test("convertSearchParamsToFilterState", () => {
     behavioralTesting: undefined,
     pipelineComparison: undefined,
     uncertain: undefined,
-    dataActions: ["remove", "relabel"],
-    outcomes: ["CorrectAndPredicted", "IncorrectAndRejected"],
+    dataAction: ["remove", "relabel"],
+    outcome: ["CorrectAndPredicted", "IncorrectAndRejected"],
     utterance: undefined,
   });
 
-  expect(parseSearchString("predictions=3").filters).toStrictEqual({
+  expect(parseSearchString("prediction=3").filters).toStrictEqual({
     confidenceMin: undefined,
     confidenceMax: undefined,
-    labels: undefined,
-    predictions: ["3"],
+    label: undefined,
+    prediction: ["3"],
     extremeLength: undefined,
     partialSyntax: undefined,
     dissimilar: undefined,
@@ -55,16 +55,16 @@ test("convertSearchParamsToFilterState", () => {
     behavioralTesting: undefined,
     pipelineComparison: undefined,
     uncertain: undefined,
-    dataActions: undefined,
-    outcomes: undefined,
+    dataAction: undefined,
+    outcome: undefined,
     utterance: undefined,
   });
 
   expect(parseSearchString("confidenceMin=0").filters).toStrictEqual({
     confidenceMin: 0,
     confidenceMax: undefined,
-    labels: undefined,
-    predictions: undefined,
+    label: undefined,
+    prediction: undefined,
     extremeLength: undefined,
     partialSyntax: undefined,
     dissimilar: undefined,
@@ -72,24 +72,24 @@ test("convertSearchParamsToFilterState", () => {
     behavioralTesting: undefined,
     pipelineComparison: undefined,
     uncertain: undefined,
-    dataActions: undefined,
-    outcomes: undefined,
+    dataAction: undefined,
+    outcome: undefined,
     utterance: undefined,
   });
 });
 
 test("constructSearchString", () => {
   expect(constructSearchString({})).toBe("");
-  expect(constructSearchString({ outcomes: [] })).toBe("");
+  expect(constructSearchString({ outcome: [] })).toBe("");
   expect(
     constructSearchString({
       confidenceMin: undefined,
       confidenceMax: undefined,
-      labels: undefined,
-      predictions: undefined,
+      label: undefined,
+      prediction: undefined,
       partialSyntax: undefined,
-      dataActions: undefined,
-      outcomes: undefined,
+      dataAction: undefined,
+      outcome: undefined,
       utterance: undefined,
     })
   ).toBe("");
@@ -97,21 +97,21 @@ test("constructSearchString", () => {
     constructSearchString({
       confidenceMin: 0.4,
       confidenceMax: 0.6,
-      labels: ["1", "2"],
-      predictions: ["3", "4"],
+      label: ["1", "2"],
+      prediction: ["3", "4"],
       partialSyntax: ["missing_obj", "missing_subj"],
-      dataActions: ["remove", "relabel"],
-      outcomes: ["CorrectAndPredicted", "IncorrectAndRejected"],
+      dataAction: ["remove", "relabel"],
+      outcome: ["CorrectAndPredicted", "IncorrectAndRejected"],
       utterance: undefined,
     })
   ).toBe(
-    "?confidenceMin=0.4&confidenceMax=0.6&labels=1,2&predictions=3,4&partialSyntax=missing_obj,missing_subj&dataActions=remove,relabel&outcomes=CorrectAndPredicted,IncorrectAndRejected"
+    "?confidenceMin=0.4&confidenceMax=0.6&label=1,2&prediction=3,4&partialSyntax=missing_obj,missing_subj&dataAction=remove,relabel&outcome=CorrectAndPredicted,IncorrectAndRejected"
   );
   expect(
     constructSearchString({
-      predictions: ["3"],
+      prediction: ["3"],
     })
-  ).toBe("?predictions=3");
+  ).toBe("?prediction=3");
 });
 
 describe("constructApiSearchString", () => {
@@ -120,7 +120,7 @@ describe("constructApiSearchString", () => {
   });
 
   it("ignores empty arrays", () => {
-    expect(constructApiSearchString({ outcomes: [] })).toBe("");
+    expect(constructApiSearchString({ outcome: [] })).toBe("");
   });
 
   it("supports numbers", () => {
@@ -165,14 +165,14 @@ describe("constructApiSearchString", () => {
         pipelineIndex: 1,
         confidenceMin: 0.4,
         confidenceMax: 0.6,
-        labels: ["class1", "class2"],
-        predictions: ["class2", "class3"],
+        label: ["class1", "class2"],
+        prediction: ["class2", "class3"],
         partialSyntax: ["missing_subj", "missing_obj"],
-        dataActions: ["remove", "relabel"],
-        outcomes: ["CorrectAndPredicted", "IncorrectAndRejected"],
+        dataAction: ["remove", "relabel"],
+        outcome: ["CorrectAndPredicted", "IncorrectAndRejected"],
       })
     ).toBe(
-      "?pipelineIndex=1&confidenceMin=0.4&confidenceMax=0.6&labels=class1&labels=class2&predictions=class2&predictions=class3&partialSyntax=missing_subj&partialSyntax=missing_obj&dataActions=remove&dataActions=relabel&outcomes=CorrectAndPredicted&outcomes=IncorrectAndRejected"
+      "?pipelineIndex=1&confidenceMin=0.4&confidenceMax=0.6&label=class1&label=class2&prediction=class2&prediction=class3&partialSyntax=missing_subj&partialSyntax=missing_obj&dataAction=remove&dataAction=relabel&outcome=CorrectAndPredicted&outcome=IncorrectAndRejected"
     );
   });
 });

--- a/webapp/src/utils/helpers.ts
+++ b/webapp/src/utils/helpers.ts
@@ -44,8 +44,8 @@ export const parseSearchString = (searchString: string) => {
     filters: convertSearchParams<QueryFilterState>(q, {
       confidenceMin: convertNumber,
       confidenceMax: convertNumber,
-      labels: convertStringArray,
-      predictions: convertStringArray,
+      label: convertStringArray,
+      prediction: convertStringArray,
       extremeLength: convertStringArray,
       partialSyntax: convertStringArray,
       dissimilar: convertStringArray,
@@ -53,8 +53,8 @@ export const parseSearchString = (searchString: string) => {
       behavioralTesting: convertStringArray,
       pipelineComparison: convertStringArray,
       uncertain: convertStringArray,
-      dataActions: convertStringArray,
-      outcomes: convertStringArray,
+      dataAction: convertStringArray,
+      outcome: convertStringArray,
       utterance: convertString,
     }),
     pagination: convertSearchParams<QueryPaginationState>(q, {


### PR DESCRIPTION
## Description:

The "problem" is that our metrics per filter are returned for singular `label` and `prediction`. To tie the two together in the Performance Analysis table, we have to implement a dodgy logic for when to add a `s` and when not (for example: not for smart tags families). This could lead to unnoticed errors if one day we add a filter that pluralizes as `y` :arrow_right: `ies` for example.

Here's why putting all filters singular makes sense to me (as opposed to putting everything plural): Even though the value of the query parameter is an array of multiple **labels**, what it means as a filter is that the **label** or each utterance (and each utterance has only one label) is one of those values. I would read `label=A,B` as "label is A or B".

* Rename filters to singular
* Refactor controls now that filters and counts per filter align

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
