### PR TITLE
Fix pipeline comparison smart tag family not working as a filter on the Exploration space

### DIFF
--- a/azimuth/utils/routers.py
+++ b/azimuth/utils/routers.py
@@ -46,7 +46,9 @@ def build_named_dataset_filters(
     behavioral_testing: List[SmartTag] = Query(
         [], title="Behavioral testing", alias="behavioralTesting"
     ),
-    pipeline_comparison: List[SmartTag] = Query([], title="Pipeline comparison"),
+    pipeline_comparison: List[SmartTag] = Query(
+        [], title="Pipeline comparison", alias="pipelineComparison"
+    ),
     uncertain: List[SmartTag] = Query([], title="Uncertain"),
     data_actions: List[DataAction] = Query([], title="Data action tags", alias="dataActions"),
     outcomes: List[OutcomeName] = Query([], title="Outcomes", alias="outcomes"),

--- a/docs/docs/getting-started/changelog.md
+++ b/docs/docs/getting-started/changelog.md
@@ -1,5 +1,11 @@
 # Releases
 
+## [2.2.1] - 2022-07-15
+
+### Fixed
+
+- Fixed pipeline comparison smart tag family not working as a filter on the Exploration space.
+
 ## [2.2.0] - 2022-07-08
 
 ### Added
@@ -18,7 +24,6 @@
 - Columns can be temporarily hidden.
 - Use outcomes' icons as headers instead of the outcomes' full names.
 - Added visual bars, so it is easier to analyze the model's performance.
-
 
 ## [2.1.1] - 2022-06-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azimuth"
-version = "2.2.0"
+version = "2.2.1"
 description = "Azimuth provides an unified error analysis experience to data scientists."
 readme = "README.md"
 authors = ["Butter-ball team <xaicaps@servicenow.com>"]

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -881,7 +881,7 @@ export interface operations {
         dissimilar?: components["schemas"]["SmartTag"][];
         almostCorrect?: components["schemas"]["SmartTag"][];
         behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipeline_comparison?: components["schemas"]["SmartTag"][];
+        pipelineComparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
         dataActions?: components["schemas"]["DataAction"][];
         outcomes?: components["schemas"]["OutcomeName"][];
@@ -932,7 +932,7 @@ export interface operations {
         dissimilar?: components["schemas"]["SmartTag"][];
         almostCorrect?: components["schemas"]["SmartTag"][];
         behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipeline_comparison?: components["schemas"]["SmartTag"][];
+        pipelineComparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
         dataActions?: components["schemas"]["DataAction"][];
         outcomes?: components["schemas"]["OutcomeName"][];
@@ -1022,7 +1022,7 @@ export interface operations {
         dissimilar?: components["schemas"]["SmartTag"][];
         almostCorrect?: components["schemas"]["SmartTag"][];
         behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipeline_comparison?: components["schemas"]["SmartTag"][];
+        pipelineComparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
         dataActions?: components["schemas"]["DataAction"][];
         outcomes?: components["schemas"]["OutcomeName"][];
@@ -1060,7 +1060,7 @@ export interface operations {
         dissimilar?: components["schemas"]["SmartTag"][];
         almostCorrect?: components["schemas"]["SmartTag"][];
         behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipeline_comparison?: components["schemas"]["SmartTag"][];
+        pipelineComparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
         dataActions?: components["schemas"]["DataAction"][];
         outcomes?: components["schemas"]["OutcomeName"][];
@@ -1102,7 +1102,7 @@ export interface operations {
         dissimilar?: components["schemas"]["SmartTag"][];
         almostCorrect?: components["schemas"]["SmartTag"][];
         behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipeline_comparison?: components["schemas"]["SmartTag"][];
+        pipelineComparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
         dataActions?: components["schemas"]["DataAction"][];
         outcomes?: components["schemas"]["OutcomeName"][];
@@ -1304,7 +1304,7 @@ export interface operations {
         dissimilar?: components["schemas"]["SmartTag"][];
         almostCorrect?: components["schemas"]["SmartTag"][];
         behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipeline_comparison?: components["schemas"]["SmartTag"][];
+        pipelineComparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
         dataActions?: components["schemas"]["DataAction"][];
         outcomes?: components["schemas"]["OutcomeName"][];
@@ -1345,7 +1345,7 @@ export interface operations {
         dissimilar?: components["schemas"]["SmartTag"][];
         almostCorrect?: components["schemas"]["SmartTag"][];
         behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipeline_comparison?: components["schemas"]["SmartTag"][];
+        pipelineComparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
         dataActions?: components["schemas"]["DataAction"][];
         outcomes?: components["schemas"]["OutcomeName"][];


### PR DESCRIPTION
## Description:

It was missing a camelCase `alias="pipelineComparison"`.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
