### PR TITLE
Use snake_case query parameters

### DIFF
--- a/azimuth/routers/v1/model_performance/confidence_histogram.py
+++ b/azimuth/routers/v1/model_performance/confidence_histogram.py
@@ -38,9 +38,7 @@ def get_confidence_histogram(
     task_manager: TaskManager = Depends(get_task_manager),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
-    without_postprocessing: bool = Query(
-        False, title="Without Postprocessing", alias="withoutPostprocessing"
-    ),
+    without_postprocessing: bool = Query(False, title="Without Postprocessing"),
 ) -> ConfidenceHistogramResponse:
     mod_options = ModuleOptions(
         filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),

--- a/azimuth/routers/v1/model_performance/confusion_matrix.py
+++ b/azimuth/routers/v1/model_performance/confusion_matrix.py
@@ -38,9 +38,7 @@ def get_confusion_matrix(
     task_manager: TaskManager = Depends(get_task_manager),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
-    without_postprocessing: bool = Query(
-        False, title="Without Postprocessing", alias="withoutPostprocessing"
-    ),
+    without_postprocessing: bool = Query(False, title="Without Postprocessing"),
     normalized: bool = Query(True, title="Normalized"),
 ) -> ConfusionMatrixResponse:
     mod_options = ModuleOptions(

--- a/azimuth/routers/v1/model_performance/metrics.py
+++ b/azimuth/routers/v1/model_performance/metrics.py
@@ -46,9 +46,7 @@ def get_metrics(
     task_manager: TaskManager = Depends(get_task_manager),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
-    without_postprocessing: bool = Query(
-        False, title="Without Postprocessing", alias="withoutPostprocessing"
-    ),
+    without_postprocessing: bool = Query(False, title="Without Postprocessing"),
 ) -> MetricsAPIResponse:
     mod_options = ModuleOptions(
         filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),

--- a/azimuth/routers/v1/model_performance/outcome_count.py
+++ b/azimuth/routers/v1/model_performance/outcome_count.py
@@ -76,9 +76,7 @@ def get_outcome_count_per_filter(
     task_manager: TaskManager = Depends(get_task_manager),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
-    without_postprocessing: bool = Query(
-        False, title="Without Postprocessing", alias="withoutPostprocessing"
-    ),
+    without_postprocessing: bool = Query(False, title="Without Postprocessing"),
 ) -> OutcomeCountPerFilterResponse:
     mod_options = ModuleOptions(
         filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),

--- a/azimuth/routers/v1/top_words.py
+++ b/azimuth/routers/v1/top_words.py
@@ -38,9 +38,7 @@ def get_top_words(
     task_manager: TaskManager = Depends(get_task_manager),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
-    without_postprocessing: bool = Query(
-        False, title="Without Postprocessing", alias="withoutPostprocessing"
-    ),
+    without_postprocessing: bool = Query(False, title="Without Postprocessing"),
 ) -> TopWordsResponse:
 
     mod_options = ModuleOptions(

--- a/azimuth/routers/v1/utterances.py
+++ b/azimuth/routers/v1/utterances.py
@@ -108,9 +108,7 @@ def get_utterances(
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: Optional[int] = Depends(query_pipeline_index),
     pagination: Optional[PaginationParams] = Depends(get_pagination),
-    without_postprocessing: bool = Query(
-        False, title="Without Postprocessing", alias="withoutPostprocessing"
-    ),
+    without_postprocessing: bool = Query(False, title="Without Postprocessing"),
 ) -> GetUtterancesResponse:
     if (
         sort_by in {UtterancesSortableColumn.confidence, UtterancesSortableColumn.prediction}
@@ -314,7 +312,7 @@ def get_similar(
     index: int,
     limit: int = Query(20, title="Limit"),
     neighbors_dataset_split_name: Optional[DatasetSplitName] = Query(
-        None, title="Neighbors dataset split", alias="neighborsDatasetSplitName"
+        None, title="Neighbors dataset split"
     ),
     # the source dataset
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),

--- a/azimuth/utils/routers.py
+++ b/azimuth/utils/routers.py
@@ -35,22 +35,18 @@ def get_last_update(dataset_split_managers: List[Optional[DatasetSplitManager]])
 
 
 def build_named_dataset_filters(
-    confidence_min: float = Query(0, title="Minimum confidence", alias="confidenceMin"),
-    confidence_max: float = Query(1, title="Maximum confidence", alias="confidenceMax"),
+    confidence_min: float = Query(0, title="Minimum confidence"),
+    confidence_max: float = Query(1, title="Maximum confidence"),
     label: List[str] = Query([], title="Label"),
     prediction: List[str] = Query([], title="Prediction"),
-    extreme_length: List[SmartTag] = Query([], title="Extreme length", alias="extremeLength"),
-    partial_syntax: List[SmartTag] = Query([], title="Partial syntax", alias="partialSyntax"),
+    extreme_length: List[SmartTag] = Query([], title="Extreme length"),
+    partial_syntax: List[SmartTag] = Query([], title="Partial syntax"),
     dissimilar: List[SmartTag] = Query([], title="Dissimilar"),
-    almost_correct: List[SmartTag] = Query([], title="Almost correct", alias="almostCorrect"),
-    behavioral_testing: List[SmartTag] = Query(
-        [], title="Behavioral testing", alias="behavioralTesting"
-    ),
-    pipeline_comparison: List[SmartTag] = Query(
-        [], title="Pipeline comparison", alias="pipelineComparison"
-    ),
+    almost_correct: List[SmartTag] = Query([], title="Almost correct"),
+    behavioral_testing: List[SmartTag] = Query([], title="Behavioral testing"),
+    pipeline_comparison: List[SmartTag] = Query([], title="Pipeline comparison"),
     uncertain: List[SmartTag] = Query([], title="Uncertain"),
-    data_action: List[DataAction] = Query([], title="Data action tags", alias="dataAction"),
+    data_action: List[DataAction] = Query([], title="Data action tags"),
     outcome: List[OutcomeName] = Query([], title="Outcomes"),
     utterance: Optional[str] = Query(None, title="Utterance"),
 ) -> NamedDatasetFilters:
@@ -166,14 +162,14 @@ def get_custom_task_result(
 
 
 def require_pipeline_index(
-    pipeline_index: int = Query(..., title="Pipeline index", alias="pipelineIndex"),
+    pipeline_index: int = Query(..., title="Pipeline index"),
     config: AzimuthConfig = Depends(get_config),
 ):
     return query_pipeline_index(pipeline_index, config)
 
 
 def query_pipeline_index(
-    pipeline_index: Optional[int] = Query(None, title="Pipeline index", alias="pipelineIndex"),
+    pipeline_index: Optional[int] = Query(None, title="Pipeline index"),
     config: AzimuthConfig = Depends(get_config),
 ) -> Optional[int]:
     """Get and validate the pipeline index from query parameters.

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -51,7 +51,7 @@ const DatasetSplitRedirect = () => {
 
   return (
     <Redirect
-      to={`/${jobId}/dataset_splits/${datasetSplitName}/performance_overview?pipelineIndex=0`}
+      to={`/${jobId}/dataset_splits/${datasetSplitName}/performance_overview?pipeline_index=0`}
     />
   );
 };
@@ -70,7 +70,7 @@ export default class App extends React.Component<Props> {
                 <ErrorBoundary>
                   <Switch>
                     <Route exact path="/">
-                      <Redirect to="/local?pipelineIndex=0" />
+                      <Redirect to="/local?pipeline_index=0" />
                     </Route>
                     <Route path="/:jobId">
                       <StatusCheck>

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -785,7 +785,7 @@ export interface operations {
   get_perturbation_testing_summary_perturbation_testing_summary_get: {
     parameters: {
       query: {
-        pipelineIndex: number;
+        pipeline_index: number;
       };
     };
     responses: {
@@ -840,7 +840,7 @@ export interface operations {
   post_data_actions_tags_post: {
     parameters: {
       query: {
-        pipelineIndex?: number;
+        pipeline_index?: number;
       };
     };
     responses: {
@@ -870,20 +870,20 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        withoutPostprocessing?: boolean;
-        pipelineIndex: number;
-        confidenceMin?: number;
-        confidenceMax?: number;
+        without_postprocessing?: boolean;
+        pipeline_index: number;
+        confidence_min?: number;
+        confidence_max?: number;
         label?: string[];
         prediction?: string[];
-        extremeLength?: components["schemas"]["SmartTag"][];
-        partialSyntax?: components["schemas"]["SmartTag"][];
+        extreme_length?: components["schemas"]["SmartTag"][];
+        partial_syntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
-        almostCorrect?: components["schemas"]["SmartTag"][];
-        behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipelineComparison?: components["schemas"]["SmartTag"][];
+        almost_correct?: components["schemas"]["SmartTag"][];
+        behavioral_testing?: components["schemas"]["SmartTag"][];
+        pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataAction?: components["schemas"]["DataAction"][];
+        data_action?: components["schemas"]["DataAction"][];
         outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
@@ -921,20 +921,20 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        withoutPostprocessing?: boolean;
-        pipelineIndex: number;
-        confidenceMin?: number;
-        confidenceMax?: number;
+        without_postprocessing?: boolean;
+        pipeline_index: number;
+        confidence_min?: number;
+        confidence_max?: number;
         label?: string[];
         prediction?: string[];
-        extremeLength?: components["schemas"]["SmartTag"][];
-        partialSyntax?: components["schemas"]["SmartTag"][];
+        extreme_length?: components["schemas"]["SmartTag"][];
+        partial_syntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
-        almostCorrect?: components["schemas"]["SmartTag"][];
-        behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipelineComparison?: components["schemas"]["SmartTag"][];
+        almost_correct?: components["schemas"]["SmartTag"][];
+        behavioral_testing?: components["schemas"]["SmartTag"][];
+        pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataAction?: components["schemas"]["DataAction"][];
+        data_action?: components["schemas"]["DataAction"][];
         outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
@@ -961,7 +961,7 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        pipelineIndex: number;
+        pipeline_index: number;
       };
     };
     responses: {
@@ -986,7 +986,7 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        pipelineIndex: number;
+        pipeline_index: number;
       };
     };
     responses: {
@@ -1011,20 +1011,20 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        withoutPostprocessing?: boolean;
-        pipelineIndex: number;
-        confidenceMin?: number;
-        confidenceMax?: number;
+        without_postprocessing?: boolean;
+        pipeline_index: number;
+        confidence_min?: number;
+        confidence_max?: number;
         label?: string[];
         prediction?: string[];
-        extremeLength?: components["schemas"]["SmartTag"][];
-        partialSyntax?: components["schemas"]["SmartTag"][];
+        extreme_length?: components["schemas"]["SmartTag"][];
+        partial_syntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
-        almostCorrect?: components["schemas"]["SmartTag"][];
-        behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipelineComparison?: components["schemas"]["SmartTag"][];
+        almost_correct?: components["schemas"]["SmartTag"][];
+        behavioral_testing?: components["schemas"]["SmartTag"][];
+        pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataAction?: components["schemas"]["DataAction"][];
+        data_action?: components["schemas"]["DataAction"][];
         outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
@@ -1051,18 +1051,18 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        confidenceMin?: number;
-        confidenceMax?: number;
+        confidence_min?: number;
+        confidence_max?: number;
         label?: string[];
         prediction?: string[];
-        extremeLength?: components["schemas"]["SmartTag"][];
-        partialSyntax?: components["schemas"]["SmartTag"][];
+        extreme_length?: components["schemas"]["SmartTag"][];
+        partial_syntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
-        almostCorrect?: components["schemas"]["SmartTag"][];
-        behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipelineComparison?: components["schemas"]["SmartTag"][];
+        almost_correct?: components["schemas"]["SmartTag"][];
+        behavioral_testing?: components["schemas"]["SmartTag"][];
+        pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataAction?: components["schemas"]["DataAction"][];
+        data_action?: components["schemas"]["DataAction"][];
         outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
@@ -1092,22 +1092,22 @@ export interface operations {
         indices?: number[];
         sort?: components["schemas"]["UtterancesSortableColumn"];
         descending?: boolean;
-        withoutPostprocessing?: boolean;
-        confidenceMin?: number;
-        confidenceMax?: number;
+        without_postprocessing?: boolean;
+        confidence_min?: number;
+        confidence_max?: number;
         label?: string[];
         prediction?: string[];
-        extremeLength?: components["schemas"]["SmartTag"][];
-        partialSyntax?: components["schemas"]["SmartTag"][];
+        extreme_length?: components["schemas"]["SmartTag"][];
+        partial_syntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
-        almostCorrect?: components["schemas"]["SmartTag"][];
-        behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipelineComparison?: components["schemas"]["SmartTag"][];
+        almost_correct?: components["schemas"]["SmartTag"][];
+        behavioral_testing?: components["schemas"]["SmartTag"][];
+        pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataAction?: components["schemas"]["DataAction"][];
+        data_action?: components["schemas"]["DataAction"][];
         outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
-        pipelineIndex?: number;
+        pipeline_index?: number;
         limit?: number;
         offset?: number;
       };
@@ -1135,7 +1135,7 @@ export interface operations {
         index: number;
       };
       query: {
-        pipelineIndex: number;
+        pipeline_index: number;
       };
     };
     responses: {
@@ -1162,8 +1162,8 @@ export interface operations {
       };
       query: {
         limit?: number;
-        neighborsDatasetSplitName?: components["schemas"]["DatasetSplitName"];
-        pipelineIndex?: number;
+        neighbors_dataset_split_name?: components["schemas"]["DatasetSplitName"];
+        pipeline_index?: number;
       };
     };
     responses: {
@@ -1188,7 +1188,7 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        pipelineIndex?: number;
+        pipeline_index?: number;
       };
     };
     responses: {
@@ -1206,7 +1206,7 @@ export interface operations {
   get_export_perturbation_testing_summary_export_perturbation_testing_summary_get: {
     parameters: {
       query: {
-        pipelineIndex: number;
+        pipeline_index: number;
       };
     };
     responses: {
@@ -1227,7 +1227,7 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        pipelineIndex: number;
+        pipeline_index: number;
       };
     };
     responses: {
@@ -1268,7 +1268,7 @@ export interface operations {
     parameters: {
       query: {
         utterances?: string[];
-        pipelineIndex: number;
+        pipeline_index: number;
       };
     };
     responses: {
@@ -1293,20 +1293,20 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        withoutPostprocessing?: boolean;
-        pipelineIndex: number;
-        confidenceMin?: number;
-        confidenceMax?: number;
+        without_postprocessing?: boolean;
+        pipeline_index: number;
+        confidence_min?: number;
+        confidence_max?: number;
         label?: string[];
         prediction?: string[];
-        extremeLength?: components["schemas"]["SmartTag"][];
-        partialSyntax?: components["schemas"]["SmartTag"][];
+        extreme_length?: components["schemas"]["SmartTag"][];
+        partial_syntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
-        almostCorrect?: components["schemas"]["SmartTag"][];
-        behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipelineComparison?: components["schemas"]["SmartTag"][];
+        almost_correct?: components["schemas"]["SmartTag"][];
+        behavioral_testing?: components["schemas"]["SmartTag"][];
+        pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataAction?: components["schemas"]["DataAction"][];
+        data_action?: components["schemas"]["DataAction"][];
         outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };
@@ -1333,21 +1333,21 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
-        withoutPostprocessing?: boolean;
+        without_postprocessing?: boolean;
         normalized?: boolean;
-        pipelineIndex: number;
-        confidenceMin?: number;
-        confidenceMax?: number;
+        pipeline_index: number;
+        confidence_min?: number;
+        confidence_max?: number;
         label?: string[];
         prediction?: string[];
-        extremeLength?: components["schemas"]["SmartTag"][];
-        partialSyntax?: components["schemas"]["SmartTag"][];
+        extreme_length?: components["schemas"]["SmartTag"][];
+        partial_syntax?: components["schemas"]["SmartTag"][];
         dissimilar?: components["schemas"]["SmartTag"][];
-        almostCorrect?: components["schemas"]["SmartTag"][];
-        behavioralTesting?: components["schemas"]["SmartTag"][];
-        pipelineComparison?: components["schemas"]["SmartTag"][];
+        almost_correct?: components["schemas"]["SmartTag"][];
+        behavioral_testing?: components["schemas"]["SmartTag"][];
+        pipeline_comparison?: components["schemas"]["SmartTag"][];
         uncertain?: components["schemas"]["SmartTag"][];
-        dataAction?: components["schemas"]["DataAction"][];
+        data_action?: components["schemas"]["DataAction"][];
         outcome?: components["schemas"]["OutcomeName"][];
         utterance?: string;
       };

--- a/webapp/src/utils/api.ts
+++ b/webapp/src/utils/api.ts
@@ -26,7 +26,7 @@ type OperationArgs<Operation> = {
   ? { [Key in keyof PathParameters as CamelCase<Key>]: PathParameters[Key] }
   : {}) &
   (Operation extends OperationWithQueryParameters<infer QueryParameters>
-    ? QueryParameters
+    ? { [Key in keyof QueryParameters as CamelCase<Key>]: QueryParameters[Key] }
     : {}) &
   (Operation extends OperationWithJSONRequestBody<infer JSONRequestBody>
     ? { body: JSONRequestBody }

--- a/webapp/src/utils/helpers.test.ts
+++ b/webapp/src/utils/helpers.test.ts
@@ -24,7 +24,7 @@ test("convertSearchParamsToFilterState", () => {
 
   expect(
     parseSearchString(
-      "?label=1,2&prediction=3,4&partialSyntax=missing_obj,missing_subj&dataAction=remove,relabel&outcome=CorrectAndPredicted,IncorrectAndRejected"
+      "?label=1,2&prediction=3,4&partial_syntax=missing_obj,missing_subj&data_action=remove,relabel&outcome=CorrectAndPredicted,IncorrectAndRejected"
     ).filters
   ).toStrictEqual({
     confidenceMin: undefined,
@@ -60,7 +60,7 @@ test("convertSearchParamsToFilterState", () => {
     utterance: undefined,
   });
 
-  expect(parseSearchString("confidenceMin=0").filters).toStrictEqual({
+  expect(parseSearchString("confidence_min=0").filters).toStrictEqual({
     confidenceMin: 0,
     confidenceMax: undefined,
     label: undefined,
@@ -105,7 +105,7 @@ test("constructSearchString", () => {
       utterance: undefined,
     })
   ).toBe(
-    "?confidenceMin=0.4&confidenceMax=0.6&label=1,2&prediction=3,4&partialSyntax=missing_obj,missing_subj&dataAction=remove,relabel&outcome=CorrectAndPredicted,IncorrectAndRejected"
+    "?confidence_min=0.4&confidence_max=0.6&label=1,2&prediction=3,4&partial_syntax=missing_obj,missing_subj&data_action=remove,relabel&outcome=CorrectAndPredicted,IncorrectAndRejected"
   );
   expect(
     constructSearchString({
@@ -130,7 +130,7 @@ describe("constructApiSearchString", () => {
         limit: 10,
         offset: 0,
       })
-    ).toBe("?pipelineIndex=1&limit=10&offset=0");
+    ).toBe("?pipeline_index=1&limit=10&offset=0");
   });
 
   it("ignores undefined", () => {
@@ -172,7 +172,7 @@ describe("constructApiSearchString", () => {
         outcome: ["CorrectAndPredicted", "IncorrectAndRejected"],
       })
     ).toBe(
-      "?pipelineIndex=1&confidenceMin=0.4&confidenceMax=0.6&label=class1&label=class2&prediction=class2&prediction=class3&partialSyntax=missing_subj&partialSyntax=missing_obj&dataAction=remove&dataAction=relabel&outcome=CorrectAndPredicted&outcome=IncorrectAndRejected"
+      "?pipeline_index=1&confidence_min=0.4&confidence_max=0.6&label=class1&label=class2&prediction=class2&prediction=class3&partial_syntax=missing_subj&partial_syntax=missing_obj&data_action=remove&data_action=relabel&outcome=CorrectAndPredicted&outcome=IncorrectAndRejected"
     );
   });
 });

--- a/webapp/src/utils/helpers.ts
+++ b/webapp/src/utils/helpers.ts
@@ -19,6 +19,9 @@ export const raiseSuccessToast = (message: string) => {
   toast.success(message);
 };
 
+const camelToSnakeCase = (s: string) =>
+  s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+
 const convertNumber = (s: string | null) =>
   s === null ? undefined : Number(s);
 
@@ -31,7 +34,7 @@ const convertStringArray = <T extends string>(s: string | null) =>
 const convertSearchParams = <T>(
   q: URLSearchParams,
   conversions: Required<{ [Key in keyof T]: (key: string | null) => T[Key] }>
-): T => _.mapValues(conversions, (convert, name) => convert(q.get(name))) as T;
+): T => _.mapValues(conversions, (c, k) => c(q.get(camelToSnakeCase(k)))) as T;
 
 // This function is dangerous and should be memoized.
 // It is still used in unit tests.
@@ -75,10 +78,10 @@ const joinSearchString = (q: string[]) => (q.length ? `?${q.join("&")}` : "");
 
 export const constructSearchString = (query: Partial<QueryState>): string =>
   joinSearchString(
-    Object.entries(query).flatMap(([filter, value]) =>
+    Object.entries(query).flatMap(([key, value]) =>
       value === undefined || (Array.isArray(value) && value.length === 0)
         ? []
-        : [`${filter}=${value}`]
+        : [`${camelToSnakeCase(key)}=${value}`]
     )
   );
 
@@ -87,7 +90,7 @@ export const constructApiSearchString = (query: object): string =>
     Object.entries(query).flatMap(([key, value]) =>
       value === undefined
         ? []
-        : (Array.isArray(value) ? value : [value]).map((v) => `${key}=${v}`)
+        : [value].flat().map((v) => `${camelToSnakeCase(key)}=${v}`)
     )
   );
 


### PR DESCRIPTION
Resolve #176

## Description:

* Remove all query parameters' camelCase aliases
  - Use regular expression to replace all `,\n? +alias="\w+[A-Z]\w+"` with ``.
  - Not having to define `alias`es to our query parameters will avoid bugs when we forgot to define one, like #175 last week and multiple other bugs in the past.
* Convert query parameters to and from snake_case in front end

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
