### PR TITLE
Support infinitely large utterance ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ Released changes are shown in the
 ### Removed
 
 ### Fixed
+- Fixed utterances table poorly showing ids greater than 9999.
 
 ### Security

--- a/webapp/src/components/Analysis/HoverableDataCell.tsx
+++ b/webapp/src/components/Analysis/HoverableDataCell.tsx
@@ -1,31 +1,18 @@
 import React from "react";
 import { Box, Paper, Popper } from "@mui/material";
 import { makeStyles } from "@mui/styles";
+import { gridClasses } from "@mui/x-data-grid";
 
 function isOverflown(element: Element) {
   return element.scrollWidth > element.clientWidth;
 }
 
 type GridCellExpandProps = {
+  autoWidth?: boolean;
   children: React.ReactNode;
 };
 
-const MIN_CELL_WIDTH = 100;
-
 const useStyles = makeStyles((theme) => ({
-  root: {
-    alignItems: "center",
-    width: "100%",
-    height: "100%",
-    position: "relative",
-    display: "flex",
-    "& .cellValue": {
-      whiteSpace: "nowrap",
-      wordBreak: "break-all",
-      overflow: "hidden",
-      textOverflow: "ellipsis",
-    },
-  },
   contentWrapper: {
     padding: theme.spacing(2),
     wordBreak: "break-all",
@@ -33,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const HoverableDataCell = (props: GridCellExpandProps) => {
-  const { children } = props;
+  const { autoWidth = false, children } = props;
 
   const wrapper = React.useRef<HTMLDivElement | null>(null);
   const cellDiv = React.useRef(null);
@@ -73,30 +60,29 @@ const HoverableDataCell = (props: GridCellExpandProps) => {
   }, [setShowFullCell, showFullCell]);
 
   return (
-    <div
-      ref={wrapper}
-      className={classes.root}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      <Box
-        ref={cellDiv}
-        height={0}
-        width="100%"
-        display="block"
-        position="absolute"
-        top={-1} // compensate row border
-      />
-      <div ref={cellValue} className="cellValue">
+    <>
+      <div ref={cellValue} className={gridClasses.cellContent}>
         {children}
       </div>
+      <Box
+        ref={wrapper}
+        height="100%"
+        width="100%"
+        position="absolute"
+        top={0}
+        left={0}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <Box ref={cellDiv} />
+      </Box>
       {showPopper && (
         <Popper
           open={showFullCell && anchorEl !== null}
+          placement="bottom-start"
           anchorEl={anchorEl}
           style={{
-            width: anchorEl ? anchorEl.clientWidth + 20 : MIN_CELL_WIDTH,
-            minWidth: MIN_CELL_WIDTH,
+            ...(!autoWidth && { width: wrapper.current!.offsetWidth }),
             pointerEvents: "none", // Because of that, avoid nesting anything
             // that relies on pointer events like click, hover or scroll.
           }}
@@ -112,7 +98,7 @@ const HoverableDataCell = (props: GridCellExpandProps) => {
           </Paper>
         </Popper>
       )}
-    </div>
+    </>
   );
 };
 

--- a/webapp/src/components/Analysis/HoverableDataCell.tsx
+++ b/webapp/src/components/Analysis/HoverableDataCell.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Box, Paper, Popper } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import { gridClasses } from "@mui/x-data-grid";
 
 function isOverflown(element: Element) {
@@ -12,13 +11,6 @@ type GridCellExpandProps = {
   children: React.ReactNode;
 };
 
-const useStyles = makeStyles((theme) => ({
-  contentWrapper: {
-    padding: theme.spacing(2),
-    wordBreak: "break-all",
-  },
-}));
-
 const HoverableDataCell = (props: GridCellExpandProps) => {
   const { autoWidth = false, children } = props;
 
@@ -26,7 +18,6 @@ const HoverableDataCell = (props: GridCellExpandProps) => {
   const cellDiv = React.useRef(null);
   const cellValue = React.useRef(null);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const classes = useStyles();
   const [showFullCell, setShowFullCell] = React.useState(false);
   const [showPopper, setShowPopper] = React.useState(false);
 
@@ -88,10 +79,20 @@ const HoverableDataCell = (props: GridCellExpandProps) => {
           }}
         >
           <Paper
-            className={classes.contentWrapper}
             elevation={2}
             sx={{
-              minHeight: wrapper.current!.offsetHeight - 3,
+              minHeight: wrapper.current!.offsetHeight,
+              padding: "10px",
+              paddingBottom: "12px",
+              display: "flex",
+              alignItems: "center",
+              // Replicate some style normally inherited from DataGrid's root.
+              // Unfortunately, gridClasses.root doesn't work, so duplicating:
+              fontSize: 14,
+              fontWeight: 500,
+              lineHeight: 1.55,
+              fontFamily: "Gilroy",
+              outline: "none",
             }}
           >
             {children}

--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -49,6 +49,9 @@ import { constructSearchString, isPipelineSelected } from "utils/helpers";
 const SMART_TAG_WIDTH = 30;
 
 const useStyles = makeStyles((theme) => ({
+  hoverableDataCell: {
+    position: "relative",
+  },
   gridContainer: {
     width: "100%",
     height: "100%",
@@ -190,7 +193,7 @@ const UtterancesTable: React.FC<Props> = ({
   );
 
   const renderHoverableDataCell = ({ value }: GridCellParams) => (
-    <HoverableDataCell>{value}</HoverableDataCell>
+    <HoverableDataCell autoWidth>{value}</HoverableDataCell>
   );
 
   const getPrediction = ({ row }: GridValueGetterParams<undefined, Row>) => {
@@ -251,6 +254,8 @@ const UtterancesTable: React.FC<Props> = ({
       sortable: false,
       align: "center",
       headerAlign: "center",
+      cellClassName: classes.hoverableDataCell,
+      renderCell: renderHoverableDataCell,
     },
     {
       field: "utterance",
@@ -260,6 +265,7 @@ const UtterancesTable: React.FC<Props> = ({
         "Utterances from dataset are overlaid with saliency maps, highlighting the most important tokens for the model's prediction.",
       flex: 5,
       minWidth: 398,
+      cellClassName: classes.hoverableDataCell,
       renderCell: renderUtterance,
     },
     {
@@ -283,6 +289,7 @@ const UtterancesTable: React.FC<Props> = ({
         ),
       flex: 1,
       minWidth: 120,
+      cellClassName: classes.hoverableDataCell,
       renderCell: renderHoverableDataCell,
     },
     {
@@ -297,6 +304,7 @@ const UtterancesTable: React.FC<Props> = ({
       flex: 1,
       minWidth: 120,
       valueGetter: getPrediction,
+      cellClassName: classes.hoverableDataCell,
       renderCell: renderHoverableDataCell,
     },
     {


### PR DESCRIPTION
## Description:

* Use `HoverableDataCell` in case utterance id overflows
  - Add an `autoWidth` feature that lets cell content overflow the cell width.
  - Refactor cell content out of `wrapper` to honor column definitions such as `align="center"`.
* Fix popper font being different from cell content

Before
![Screen Shot 2022-07-25 at 2 48 00 PM](https://user-images.githubusercontent.com/8386369/180851891-57b24c70-4393-469e-a236-d4e9a33a8d61.png)
![Screen Shot 2022-07-25 at 2 48 03 PM](https://user-images.githubusercontent.com/8386369/180851899-757d8e12-b233-4b8e-aa99-19e1b72f3b74.png)
After:
![Screen Shot 2022-07-25 at 2 46 28 PM](https://user-images.githubusercontent.com/8386369/180851910-747eb4aa-a2e7-412b-9feb-b71ac0208ee3.png)
![Screen Shot 2022-07-25 at 2 46 31 PM](https://user-images.githubusercontent.com/8386369/180851915-b1c978e1-3062-4238-b129-99662cced2fa.png)
![Screen Shot 2022-07-25 at 2 46 34 PM](https://user-images.githubusercontent.com/8386369/180851928-d3c71799-bba4-4186-a764-d14beb916a2d.png)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
