### PR TITLE
Add progress info during startup

### DIFF
--- a/webapp/src/components/StatusCheck.tsx
+++ b/webapp/src/components/StatusCheck.tsx
@@ -1,13 +1,42 @@
-import { Box, Typography } from "@mui/material";
+import { Box, capitalize, Stack, Typography } from "@mui/material";
 import noData from "assets/launch.svg";
 import React from "react";
 import { useParams } from "react-router-dom";
 import { getStatusEndpoint } from "services/api";
 import Loading from "./Loading";
+import Grid from "@mui/material/Grid";
+import Paper from "@mui/material/Paper";
+import CheckIcon from "./Icons/Check";
+import ErrorIcon from "@mui/icons-material/Error";
+import PendingOutlinedIcon from "@mui/icons-material/PendingOutlined";
 
 type Props = {
   children: React.ReactNode;
 };
+
+interface StringByString {
+  [key: string]: any;
+}
+
+const STATUS_ICON_MAPPING: StringByString = {
+  finished: <CheckIcon />,
+  not_started: <CheckIcon />,
+  pending: <PendingOutlinedIcon />,
+  error: <ErrorIcon />,
+  lost: <ErrorIcon />,
+};
+
+const render_cell = (task_name: string, task_status: string) => (
+  <Grid item xs={1.5}>
+    <Paper variant="outlined">
+      <Box display="flex" alignItems="center" gap={1}>
+        <Typography>
+          {`${task_name.split("_").map(capitalize).join(" ")} `} {STATUS_ICON_MAPPING[task_status]}
+        </Typography>
+      </Box>
+    </Paper>
+  </Grid>
+);
 
 const StatusCheck: React.FC<Props> = ({ children }) => {
   const { jobId } = useParams<{ jobId: string }>();
@@ -31,20 +60,25 @@ const StatusCheck: React.FC<Props> = ({ children }) => {
         justifyContent="center"
         alignItems="center"
         width="100%"
-        height="75vh"
+        height="100vh"
       >
         <Box
           display="flex"
           flexDirection="column"
           alignItems="center"
           gap={4}
-          width={600}
+          width={700}
         >
           <img src={noData} alt="Startup tasks still in progress" width={400} />
           <Typography variant="h2" align="center">
             The startup tasks are still in progress. Grab a coffee and we will
             auto-refresh for you.
           </Typography>
+          <Grid container spacing={2} columnSpacing={3} columns={3}>
+            {Object.entries(status.startupTasksStatus).map(
+              ([task_name, task_status]) => render_cell(task_name, task_status)
+            )}
+          </Grid>
         </Box>
       </Box>
     );

--- a/webapp/src/components/StatusCheck.tsx
+++ b/webapp/src/components/StatusCheck.tsx
@@ -31,7 +31,8 @@ const render_cell = (task_name: string, task_status: string) => (
     <Paper variant="outlined">
       <Box display="flex" alignItems="center" gap={1}>
         <Typography>
-          {`${task_name.split("_").map(capitalize).join(" ")} `} {STATUS_ICON_MAPPING[task_status]}
+          {`${task_name.split("_").map(capitalize).join(" ")}  `}
+          {STATUS_ICON_MAPPING[task_status]}
         </Typography>
       </Box>
     </Paper>


### PR DESCRIPTION
Resolve #135 

## Description:

Add progress info during startup.
I would need someone help to get a SVG of the progress icon. I got one from Material UI, but I would like to see 3 dots waving.


Looks like:
![image](https://user-images.githubusercontent.com/8976546/181381924-841eb985-5559-4497-9885-ddf0b29a19c8.png)


## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
