### PR TITLE
Polish Performance Analysis table headers

### DIFF
--- a/webapp/src/components/Metrics/Metric.tsx
+++ b/webapp/src/components/Metrics/Metric.tsx
@@ -41,17 +41,14 @@ const Metric: React.FC<Props> = ({
   const classes = useStyles();
   const theme = useTheme();
 
+  const tooltip = description
+    .trim()
+    .split("\n")
+    .map((paragraph) => <Typography variant="inherit">{paragraph}</Typography>);
+
   return (
     <Box display="flex" justifyContent="flex-end">
-      <Tooltip
-        title={description
-          .trim()
-          .split("\n")
-          .map((paragraph) => (
-            <Typography variant="inherit">{paragraph}</Typography>
-          ))}
-        classes={{ popper: classes.popper }}
-      >
+      <Tooltip title={tooltip} classes={{ popper: classes.popper }}>
         <Box
           height="100%"
           paddingX={2.5}

--- a/webapp/src/components/Metrics/Metric.tsx
+++ b/webapp/src/components/Metrics/Metric.tsx
@@ -9,7 +9,6 @@ import {
   Skeleton,
   Tooltip,
   tooltipClasses,
-  TooltipProps,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -24,7 +23,7 @@ const useStyles = makeStyles(() => ({
 
 type Props = {
   name: string;
-  description: TooltipProps["title"];
+  description: string;
   isLoading: boolean;
   value?: string;
   color?: string;
@@ -44,7 +43,15 @@ const Metric: React.FC<Props> = ({
 
   return (
     <Box display="flex" justifyContent="flex-end">
-      <Tooltip title={description} classes={{ popper: classes.popper }}>
+      <Tooltip
+        title={description
+          .trim()
+          .split("\n")
+          .map((paragraph) => (
+            <Typography variant="inherit">{paragraph}</Typography>
+          ))}
+        classes={{ popper: classes.popper }}
+      >
         <Box
           height="100%"
           paddingX={2.5}

--- a/webapp/src/components/Metrics/Metric.tsx
+++ b/webapp/src/components/Metrics/Metric.tsx
@@ -10,7 +10,6 @@ import {
   Tooltip,
   tooltipClasses,
   Typography,
-  useTheme,
 } from "@mui/material";
 
 const useStyles = makeStyles(() => ({
@@ -39,7 +38,6 @@ const Metric: React.FC<Props> = ({
   flexDirection,
 }) => {
   const classes = useStyles();
-  const theme = useTheme();
 
   const tooltip = description
     .trim()
@@ -61,12 +59,12 @@ const Metric: React.FC<Props> = ({
           <Typography marginX={0.5} whiteSpace="nowrap">
             {name}
           </Typography>
-          <Typography marginX={0.5} variant="h6" sx={{ color }}>
+          <Typography align="center" variant="h6" width="5ch" sx={{ color }}>
+            {/* 5ch is wide enough for 100.0% */}
             {(!isLoading && value) || (
               <Skeleton
                 role="skeleton"
                 variant="text"
-                width={theme.spacing(7)}
                 animation={isLoading && undefined} // default animation when loading, false in case of an error
               />
             )}

--- a/webapp/src/components/Metrics/Metrics.tsx
+++ b/webapp/src/components/Metrics/Metrics.tsx
@@ -8,7 +8,7 @@ import {
   QueryPipelineState,
   QueryPostprocessingState,
 } from "types/models";
-import { OUTCOME_COLOR, OUTCOME_PRETTY_NAMES } from "utils/const";
+import { ECE_TOOLTIP, OUTCOME_COLOR, OUTCOME_PRETTY_NAMES } from "utils/const";
 import { formatRatioAsPercentageString } from "utils/format";
 import Metric from "./Metric";
 import MetricsCard from "./MetricsCard";
@@ -22,36 +22,14 @@ const OUTCOMES = [
 ] as const;
 
 const OUTCOME_DESCRIPTIONS = {
-  CorrectAndPredicted: (
-    <>
-      <Typography>
-        The predicted class matches the label and is not the rejection class.
-      </Typography>
-    </>
-  ),
-  CorrectAndRejected: (
-    <>
-      <Typography>
-        The predicted class and the label are the rejection class.
-      </Typography>
-    </>
-  ),
-  IncorrectAndRejected: (
-    <>
-      <Typography>
-        The predicted class is the rejection class, but not the label.
-      </Typography>
-    </>
-  ),
-  IncorrectAndPredicted: (
-    <>
-      <Typography>
-        The predicted class does not match the label and is not the rejection
-        class.
-      </Typography>
-      <Typography>The target is below 10%.</Typography>
-    </>
-  ),
+  CorrectAndPredicted:
+    "The predicted class matches the label and is not the rejection class.",
+  CorrectAndRejected:
+    "The predicted class and the label are the rejection class.",
+  IncorrectAndRejected:
+    "The predicted class is the rejection class, but not the label.",
+  IncorrectAndPredicted:
+    "The predicted class does not match the label and is not the rejection class.",
 };
 
 type Props = {
@@ -107,15 +85,9 @@ const Metrics: React.FC<Props> = ({
             }
             name={OUTCOME_PRETTY_NAMES[outcome]}
             description={
-              <>
-                {!isFetching && metrics && (
-                  <Typography>
-                    {`${metrics.outcomeCount[outcome]} out of
-            ${metrics.utteranceCount} utterances`}
-                  </Typography>
-                )}
-                {OUTCOME_DESCRIPTIONS[outcome]}
-              </>
+              !isFetching && metrics
+                ? `${metrics.outcomeCount[outcome]} out of ${metrics.utteranceCount} utterances\n${OUTCOME_DESCRIPTIONS[outcome]}`
+                : OUTCOME_DESCRIPTIONS[outcome]
             }
             color={theme.palette[OUTCOME_COLOR[outcome]].main}
           />
@@ -136,7 +108,7 @@ const Metrics: React.FC<Props> = ({
                 )
               }
               name={metricName}
-              description={<Typography>{description}</Typography>}
+              description={description}
             />
           ))}
         </MetricsCard>
@@ -165,18 +137,7 @@ const Metrics: React.FC<Props> = ({
           isLoading={isFetching}
           value={metrics?.ece.toFixed(2)}
           name="ECE"
-          description={
-            <>
-              <Typography>
-                The ECE measures the calibration of the model, meaning if the
-                confidence of the model matches its accuracy.
-              </Typography>
-              <Typography>
-                The lower the better. An ECE of 0 means perfect calibration.
-              </Typography>
-              <Typography>This ECE is computed using 20 bins.</Typography>
-            </>
-          }
+          description={ECE_TOOLTIP}
         />
       </MetricsCard>
     </Box>

--- a/webapp/src/components/Metrics/Metrics.tsx
+++ b/webapp/src/components/Metrics/Metrics.tsx
@@ -137,7 +137,11 @@ const Metrics: React.FC<Props> = ({
           isLoading={isFetching}
           value={metrics?.ece.toFixed(2)}
           name="ECE"
-          description={ECE_TOOLTIP}
+          description={
+            metrics?.ecePlot
+              ? `${ECE_TOOLTIP}\nThis ECE is computed using ${metrics?.ecePlot?.data[0].x.length} bins.`
+              : ECE_TOOLTIP
+          }
         />
       </MetricsCard>
     </Box>

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -137,11 +137,10 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
       return gridStringOrNumberComparator(v1, v2, param1, param2);
     };
 
-    const NUMBER_COL_DEF = {
+    const METRIC_COLUMN = {
       flex: 1,
       minWidth: 120,
       maxWidth: 220,
-      type: "number",
       sortComparator: customSort,
     };
 
@@ -189,13 +188,15 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
         ),
       },
       {
-        ...NUMBER_COL_DEF,
         field: "utteranceCount",
-        headerName: "Utterance Count",
-        minWidth: 146,
+        headerName: "Total",
+        description: "Total number of utterances",
+        width: 96,
+        align: "right",
+        sortComparator: customSort,
       },
       ...ALL_OUTCOMES.map<Column<Row>>((outcome) => ({
-        ...NUMBER_COL_DEF,
+        ...METRIC_COLUMN,
         field: outcome,
         headerName: OUTCOME_PRETTY_NAMES[outcome],
         renderHeader: () => OutcomeIcon({ outcome }),
@@ -210,7 +211,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
         ),
       })),
       ...customMetricNames.map<Column<Row>>((metricName) => ({
-        ...NUMBER_COL_DEF,
+        ...METRIC_COLUMN,
         field: metricName,
         headerName: metricName,
         valueGetter: ({ row }) => row.customMetrics[metricName],
@@ -223,7 +224,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
         ),
       })),
       {
-        ...NUMBER_COL_DEF,
+        ...METRIC_COLUMN,
         field: "ece",
         headerName: "ECE",
         renderCell: ({ value }: GridCellParams<number>) => (

--- a/webapp/src/utils/const.ts
+++ b/webapp/src/utils/const.ts
@@ -21,7 +21,6 @@ export const ID_TOOLTIP =
 export const ECE_TOOLTIP = `
 The ECE measures the calibration of the model, meaning if the confidence of the model matches its accuracy.
 The lower the better. An ECE of 0 means perfect calibration.
-This ECE is computed using 20 bins.
 `;
 
 export const PIPELINE_REQUIRED_TIP = "Unavailable without a pipeline";

--- a/webapp/src/utils/const.ts
+++ b/webapp/src/utils/const.ts
@@ -18,6 +18,12 @@ export const DATASET_SPLIT_PRETTY_NAMES = {
 export const ID_TOOLTIP =
   "This id created by Azimuth corresponds to the row_idx column in the dataset split export";
 
+export const ECE_TOOLTIP = `
+The ECE measures the calibration of the model, meaning if the confidence of the model matches its accuracy.
+The lower the better. An ECE of 0 means perfect calibration.
+This ECE is computed using 20 bins.
+`;
+
 export const PIPELINE_REQUIRED_TIP = "Unavailable without a pipeline";
 
 export const PAGE_SIZE = 10;


### PR DESCRIPTION
## Description:

Polish Performance Analysis table headers
* Align headers left
* Rename `Utterance Count` to `Total` to save 50 pixels
* Refactor metrics descriptions
  - Now expecting a string and supporting newlines to split into paragraphs. As a result, this now handles the newlines in the custom metrics descriptions.
* Add tooltips to metrics in Performance Analysis table headers
  - This also makes the memoized `columns` independent of `data`, so changing dataset split or pipeline doesn't require a `columns` redefinition.
* Avoid hardcoded number of bins for ECE
* Fix metrics width so that it doesn't vary when the numbers change

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
