### PR TITLE
Fix filtering aggregation modules without post-processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@ Released changes are shown in the
 
 ### Fixed
 - Fixed utterances table poorly showing ids greater than 9999.
+- Fixed filtering aggregation modules without post-processing.
 
 ### Security

--- a/azimuth/modules/base_classes/aggregation_module.py
+++ b/azimuth/modules/base_classes/aggregation_module.py
@@ -56,7 +56,12 @@ class FilterableModule(AggregationModule[ConfigScope], ExpirableMixin, ABC):
 
         """
         ds = super().get_dataset_split(name)
-        return filter_dataset_split(ds, filters=self.mod_options.filters, config=self.config)
+        return filter_dataset_split(
+            dataset_split=ds,
+            filters=self.mod_options.filters,
+            config=self.config,
+            without_postprocessing=self.mod_options.without_postprocessing,
+        )
 
     def _get_predictions_from_ds(self) -> List[int]:
         """Get predicted classes according to the module options (with or without postprocessing).

--- a/tests/test_modules/test_model_performance/test_metrics.py
+++ b/tests/test_modules/test_model_performance/test_metrics.py
@@ -251,6 +251,12 @@ def test_outcome_count_per_filter_without_postprocessing(tiny_text_config):
                 "otherwise the following test doesn't test much"
             )
 
+    # Regression test for bug https://github.com/ServiceNow/azimuth/issues/195
+    # If we pass without_postprocessing to the modules, but we forget to propagate it in
+    # FilterableModule.get_dataset_split(), utterances are mistakenly filtered based on their
+    # post-processed outcome, but then the response is counted using the model outcome. Here, some
+    # utterances that were IncorrectAndRejected with post-processing would be counted as a different
+    # model outcome. We verify that the counts are still 0 for the other outcomes.
     [res_without_postprocessing] = OutcomeCountPerFilterModule(
         DatasetSplitName.eval,
         config=tiny_text_config,


### PR DESCRIPTION
Resolve #195

## Description:

Easy to reproduce with clinc_dummy by selecting the outcome=IncorrectAndRejected filter or the prediction=NO_INTENT filter. In those two examples, there should not be any `CorrectAndPredicted` in the distribution bars, nor in the confusion matrix. Filtering of all aggregation modules ignore `without_postprocessing`. It doesn't show in the confidence histogram since the "filtering"/graying out happens in the front end, but if I use the back end the same thing happens. It doesn't affect the utterance table as its filtering is not done in an aggregation module.
![Image Pasted at 2022-8-3 06-08](https://user-images.githubusercontent.com/8386369/182600758-1f3f93e1-d736-4793-839a-ea28684ef684.png)
![Image Pasted at 2022-8-3 06-09](https://user-images.githubusercontent.com/8386369/182600773-d8f7c49d-89e0-4fb2-92b7-8ea234e14003.png)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
