### PR TITLE
Fix losing collapsed state on filter selector

### DIFF
--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -178,21 +178,14 @@ const Controls: React.FC<Props> = ({
       : 0;
   }, [countPerFilter]);
 
-  const FilterCheckboxList: React.FC<{
-    filter: keyof QueryArrayFiltersState;
-    label: FormControlLabelProps["label"];
-    prettyNames?: Record<string, string>;
-  }> = ({ filter, ...props }) => (
-    <FilterSelector
-      maxCount={maxCount}
-      searchValue={searchValue}
-      selectedOptions={filters[filter] ?? []}
-      handleValueChange={getFilterChangeHandler(filter)}
-      filters={countPerFilter?.countPerFilter[filter]}
-      isFetching={isFetchingCountPerFilter}
-      {...props}
-    />
-  );
+  const getFilterSelectorProps = (filter: keyof QueryArrayFiltersState) => ({
+    maxCount: maxCount,
+    searchValue: searchValue,
+    selectedOptions: filters[filter] ?? [],
+    handleValueChange: getFilterChangeHandler(filter),
+    filters: countPerFilter?.countPerFilter[filter],
+    isFetching: isFetchingCountPerFilter,
+  });
 
   const divider = (
     <Box marginY={1} borderBottom="1px solid rgba(0, 0, 0, 0.12)" />
@@ -326,17 +319,23 @@ const Controls: React.FC<Props> = ({
           </Box>
           {divider}
           <Stack display="block" divider={divider} overflow="hidden auto">
-            <FilterCheckboxList
-              filter="outcome"
+            <FilterSelector
+              {...getFilterSelectorProps("outcome")}
               label="Prediction Outcome"
               prettyNames={OUTCOME_PRETTY_NAMES}
             />
-            <FilterCheckboxList filter="label" label="Label" />
-            <FilterCheckboxList filter="prediction" label="Prediction" />
+            <FilterSelector
+              {...getFilterSelectorProps("label")}
+              label="Label"
+            />
+            <FilterSelector
+              {...getFilterSelectorProps("prediction")}
+              label="Prediction"
+            />
             {SMART_TAG_FAMILIES.map((filterName) => (
-              <FilterCheckboxList
+              <FilterSelector
                 key={filterName}
-                filter={filterName}
+                {...getFilterSelectorProps(filterName)}
                 label={
                   <Stack direction="row" gap={1}>
                     {SMART_TAG_FAMILY_PRETTY_NAMES[filterName]}
@@ -345,7 +344,10 @@ const Controls: React.FC<Props> = ({
                 }
               />
             ))}
-            <FilterCheckboxList filter="dataAction" label="Proposed Action" />
+            <FilterSelector
+              {...getFilterSelectorProps("dataAction")}
+              label="Proposed Action"
+            />
           </Stack>
         </>
       )}

--- a/webapp/src/components/Controls/FilterSelector.tsx
+++ b/webapp/src/components/Controls/FilterSelector.tsx
@@ -247,4 +247,4 @@ const FilterSelector = <FilterValue extends string>({
   );
 };
 
-export default FilterSelector;
+export default React.memo(FilterSelector);


### PR DESCRIPTION
Resolve #204

## Description:

This issue is not present in any 2.2 release, so let's fix it before releasing 2.3. Ni vu ni connu. No need to log the change. I introduced that bug when I created the `FilterCheckboxList` wrapper. I can't define a React function component inside another function component, as React can't track their instances (they are new instances on every render). The `React.useState(false)` inside `FIlterSelector` was getting back to `false` on every render. There might have been some wizardry possible to fix this, but I think this `getFilterSelectorProps()` is cleaner anyway.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
