### PR TITLE
Separate data and presentation

### DIFF
--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   CircularProgress,
   FormControlLabel,
-  FormControlLabelProps,
   IconButton,
   InputAdornment,
   OutlinedInput,
@@ -245,6 +244,7 @@ const Controls: React.FC<Props> = ({
         <>
           <Box margin={1}>
             <DatasetSplitToggler
+              availableDatasetSplits={datasetInfo?.availableDatasetSplits}
               value={datasetSplitName}
               onChange={handleDatasetSplitChange}
             />

--- a/webapp/src/components/Controls/DatasetSplitToggler.tsx
+++ b/webapp/src/components/Controls/DatasetSplitToggler.tsx
@@ -15,36 +15,28 @@ const DatasetSplitToggler: React.FC<Props> = ({
   availableDatasetSplits,
   value,
   onChange,
-}) => {
-  const handleSelectionChange = (newValue: DatasetSplitName | null) => {
-    if (newValue !== null) {
-      onChange(newValue);
-    }
-  };
-
-  return (
-    <ToggleButtonGroup
-      color="secondary"
-      exclusive
-      fullWidth
-      size="small"
-      value={value}
-      onChange={(_, value) => handleSelectionChange(value)}
-    >
-      {DATASET_SPLIT_NAMES.map((datasetSplitName) => (
-        <ToggleButton
-          key={datasetSplitName}
-          sx={{ gap: 1, whiteSpace: "nowrap" }}
-          value={datasetSplitName}
-          disabled={!availableDatasetSplits?.[datasetSplitName]}
-        >
-          {datasetSplitName === "eval" && <SpeedIcon />}
-          {datasetSplitName === "train" && <ModelTrainingIcon />}
-          {DATASET_SPLIT_PRETTY_NAMES[datasetSplitName]} Set
-        </ToggleButton>
-      ))}
-    </ToggleButtonGroup>
-  );
-};
+}) => (
+  <ToggleButtonGroup
+    color="secondary"
+    exclusive
+    fullWidth
+    size="small"
+    value={value}
+    onChange={(_, value: DatasetSplitName | null) => value && onChange(value)}
+  >
+    {DATASET_SPLIT_NAMES.map((datasetSplitName) => (
+      <ToggleButton
+        key={datasetSplitName}
+        sx={{ gap: 1, whiteSpace: "nowrap" }}
+        value={datasetSplitName}
+        disabled={!availableDatasetSplits?.[datasetSplitName]}
+      >
+        {datasetSplitName === "eval" && <SpeedIcon />}
+        {datasetSplitName === "train" && <ModelTrainingIcon />}
+        {DATASET_SPLIT_PRETTY_NAMES[datasetSplitName]} Set
+      </ToggleButton>
+    ))}
+  </ToggleButtonGroup>
+);
 
 export default React.memo(DatasetSplitToggler);

--- a/webapp/src/components/Controls/DatasetSplitToggler.tsx
+++ b/webapp/src/components/Controls/DatasetSplitToggler.tsx
@@ -1,21 +1,21 @@
 import React from "react";
-import { useParams } from "react-router-dom";
-import { getDatasetInfoEndpoint } from "services/api";
-import { DatasetSplitName } from "types/api";
+import { AvailableDatasetSplits, DatasetSplitName } from "types/api";
 import { DATASET_SPLIT_NAMES, DATASET_SPLIT_PRETTY_NAMES } from "utils/const";
 import { ToggleButtonGroup, ToggleButton } from "@mui/material";
 import SpeedIcon from "@mui/icons-material/Speed";
 import ModelTrainingIcon from "@mui/icons-material/ModelTraining";
 
 type Props = {
+  availableDatasetSplits: AvailableDatasetSplits | undefined;
   value: DatasetSplitName;
   onChange: (value: DatasetSplitName) => void;
 };
 
-const DatasetSplitToggler: React.FC<Props> = ({ value, onChange }) => {
-  const { jobId } = useParams<{ jobId: string }>();
-  const { data: datasetInfo } = getDatasetInfoEndpoint.useQuery({ jobId });
-
+const DatasetSplitToggler: React.FC<Props> = ({
+  availableDatasetSplits,
+  value,
+  onChange,
+}) => {
   const handleSelectionChange = (newValue: DatasetSplitName | null) => {
     if (newValue !== null) {
       onChange(newValue);
@@ -36,7 +36,7 @@ const DatasetSplitToggler: React.FC<Props> = ({ value, onChange }) => {
           key={datasetSplitName}
           sx={{ gap: 1, whiteSpace: "nowrap" }}
           value={datasetSplitName}
-          disabled={!datasetInfo?.availableDatasetSplits[datasetSplitName]}
+          disabled={!availableDatasetSplits?.[datasetSplitName]}
         >
           {datasetSplitName === "eval" && <SpeedIcon />}
           {datasetSplitName === "train" && <ModelTrainingIcon />}

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -33,7 +33,11 @@ import {
   getCustomMetricInfoEndpoint,
   getMetricsPerFilterEndpoint,
 } from "services/api";
-import { DatasetSplitName, MetricsPerFilterValue } from "types/api";
+import {
+  AvailableDatasetSplits,
+  DatasetSplitName,
+  MetricsPerFilterValue,
+} from "types/api";
 import { QueryPipelineState } from "types/models";
 import {
   ALL_OUTCOMES,
@@ -76,11 +80,16 @@ type FilterByViewOption =
 type Props = {
   jobId: string;
   pipeline: Required<QueryPipelineState>;
+  availableDatasetSplits: AvailableDatasetSplits | undefined;
 };
 
 type Row = MetricsPerFilterValue & { id: number };
 
-const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
+const PerformanceAnalysis: React.FC<Props> = ({
+  jobId,
+  pipeline,
+  availableDatasetSplits,
+}) => {
   const [selectedDatasetSplit, setSelectedDatasetSplit] =
     React.useState<DatasetSplitName>("eval");
   const [selectedMetricPerFilterOption, setSelectedMetricPerFilterOption] =
@@ -290,6 +299,7 @@ const PerformanceAnalysis: React.FC<Props> = ({ jobId, pipeline }) => {
       <Box marginBottom={1} display="flex" justifyContent="start">
         <Box width={340}>
           <DatasetSplitToggler
+            availableDatasetSplits={availableDatasetSplits}
             value={selectedDatasetSplit}
             onChange={setSelectedDatasetSplit}
           />

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -90,7 +90,11 @@ const Dashboard = () => {
             />
           }
         >
-          <PerformanceAnalysis jobId={jobId} pipeline={pipeline} />
+          <PerformanceAnalysis
+            jobId={jobId}
+            pipeline={pipeline}
+            availableDatasetSplits={data?.availableDatasetSplits}
+          />
         </PreviewCard>
       )}
       {isPipelineSelected(pipeline) && data?.perturbationTestingAvailable && (

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -22,9 +22,11 @@ const Dashboard = () => {
   const { jobId } = useParams<{ jobId: string }>();
   const { pipeline, searchString } = useQueryState();
 
-  const { data, error, isFetching } = getDatasetInfoEndpoint.useQuery({
-    jobId,
-  });
+  const {
+    data: datasetInfo,
+    error,
+    isFetching,
+  } = getDatasetInfoEndpoint.useQuery({ jobId });
 
   if (isFetching) {
     <Loading />;
@@ -64,7 +66,7 @@ const Dashboard = () => {
           Go to exploration space
         </Button>
       </Box>
-      {data?.availableDatasetSplits.train && (
+      {datasetInfo?.availableDatasetSplits.train && (
         <PreviewCard
           title="Dataset Class Distribution Analysis"
           to={`/${jobId}/dataset_class_distribution_analysis${searchString}`}
@@ -93,27 +95,28 @@ const Dashboard = () => {
           <PerformanceAnalysis
             jobId={jobId}
             pipeline={pipeline}
-            availableDatasetSplits={data?.availableDatasetSplits}
+            availableDatasetSplits={datasetInfo?.availableDatasetSplits}
           />
         </PreviewCard>
       )}
-      {isPipelineSelected(pipeline) && data?.perturbationTestingAvailable && (
-        <PreviewCard
-          title="Behavioral Testing"
-          to={`/${jobId}/behavioral_testing_summary${searchString}`}
-          description={behavioralTestingDescription}
-        >
-          <Box height={DEFAULT_PREVIEW_CONTENT_HEIGHT}>
-            <PerturbationTestingPreview
-              jobId={jobId}
-              pipeline={pipeline}
-              availableDatasetSplits={data.availableDatasetSplits}
-            />
-          </Box>
-        </PreviewCard>
-      )}
       {isPipelineSelected(pipeline) &&
-        data?.postprocessingEditable?.[pipeline.pipelineIndex] && (
+        datasetInfo?.perturbationTestingAvailable && (
+          <PreviewCard
+            title="Behavioral Testing"
+            to={`/${jobId}/behavioral_testing_summary${searchString}`}
+            description={behavioralTestingDescription}
+          >
+            <Box height={DEFAULT_PREVIEW_CONTENT_HEIGHT}>
+              <PerturbationTestingPreview
+                jobId={jobId}
+                pipeline={pipeline}
+                availableDatasetSplits={datasetInfo.availableDatasetSplits}
+              />
+            </Box>
+          </PreviewCard>
+        )}
+      {isPipelineSelected(pipeline) &&
+        datasetInfo?.postprocessingEditable?.[pipeline.pipelineIndex] && (
           <PreviewCard
             title="Post-processing Analysis"
             to={`/${jobId}/thresholds${searchString}`}

--- a/webapp/src/pages/UtteranceDetail.tsx
+++ b/webapp/src/pages/UtteranceDetail.tsx
@@ -277,6 +277,7 @@ export const UtteranceDetail = () => {
         {view === "similarity" && (
           <Box width={280}>
             <DatasetSplitToggler
+              availableDatasetSplits={datasetInfo?.availableDatasetSplits}
               value={neighborsDatasetSplitName}
               onChange={(value) => value && setNeighborsDatasetSplitName(value)}
             />


### PR DESCRIPTION
Related to #179

## Description:

* Pass `AvailableDatasetSplits` to `DatasetSplitToggler` so it doesn't need to fetch `datasetInfo`. All 3 callers, or their callers, already had it at hand. That way, we don't need to mock the API to unit-test `DatasetSplitToggler`.
  * I'm inviting @nandhinibsn to review and rebase her work on top if this, as well as @christyler3030 as I know he'll love it. 😆 
* Clean up

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
