### PR TITLE
Cache tokenizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ dask-worker-space/
 
 azimuth_shr/cached_models
 azimuth_shr/files
+azimuth_shr/huggingface_cache
 azimuth_shr/local_files
 azimuth_shr/sentence_transformers
-azimuth_shr/sentence_transformers_cache
 azimuth_shr/tf_hub/

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,5 @@ azimuth_shr/cached_models
 azimuth_shr/files
 azimuth_shr/local_files
 azimuth_shr/sentence_transformers
+azimuth_shr/sentence_transformers_cache
 azimuth_shr/tf_hub/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: ${REGISTRY}/azimuth:${BACKEND_VERSION}_${DEVICE}
     environment:
       - "CFG_PATH=${CFG_PATH}"
+      - "HF_HOME=/azimuth_shr/huggingface_cache"
       - "SENTENCE_TRANSFORMERS_HOME=/azimuth_shr/sentence_transformers"
-      - "TRANSFORMERS_CACHE=/azimuth_shr/sentence_transformers_cache"
       - "TFHUB_CACHE_DIR=/azimuth_shr/tf_hub"
       - "TH"
       - "TEMP"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       - "CFG_PATH=${CFG_PATH}"
       - "SENTENCE_TRANSFORMERS_HOME=/azimuth_shr/sentence_transformers"
+      - "TRANSFORMERS_CACHE=/azimuth_shr/sentence_transformers_cache"
       - "TFHUB_CACHE_DIR=/azimuth_shr/tf_hub"
       - "TH"
       - "TEMP"


### PR DESCRIPTION
## Description:

Cache Hugging Face files when using Docker Compose. Hugging Face cache includes tokenizer in `transformers`, as well as `datasets`, `metrics` and `modules`. The default value is `~/.cache/hugginface`. Instead, we set it to `/azimuth_shr/huggingface_cache`, which is mounted.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
