### PR TITLE
Fix high_epistemic_uncertainty smart tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,6 @@ Released changes are shown in the
 ### Fixed
 - Fixed utterances table poorly showing ids greater than 9999.
 - Fixed filtering aggregation modules without post-processing.
+- Fixed high_epistemic_uncertainty smart tag which wasn't showing in the UI.
 
 ### Security

--- a/azimuth/modules/base_classes/indexable_module.py
+++ b/azimuth/modules/base_classes/indexable_module.py
@@ -2,6 +2,7 @@
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
 import abc
+import dataclasses
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Optional, Set, cast
 
@@ -211,6 +212,10 @@ class ModelContractModule(DatasetResultModule[ModelContractConfig], abc.ABC):
                     for idx, r in enumerate(res_casted)
                 }
                 dm.add_tags(high_epistemic, table_key=table_key)
+                # We also save with use_bma=False so the smart tag is saved in the
+                # main prediction table.
+                non_bma_table_key = dataclasses.replace(table_key, use_bma=False)
+                dm.add_tags(high_epistemic, table_key=non_bma_table_key)
             pred_tags = self.get_pred_tags(
                 label=dm.get_dataset_split(table_key=table_key)[self.config.columns.label],
                 model_predictions=dm.get_dataset_split(table_key=table_key)[

--- a/config/development/clinc_dummy/conf_bma.json
+++ b/config/development/clinc_dummy/conf_bma.json
@@ -1,0 +1,28 @@
+{
+  "name": "CLINC Dummy",
+  "pipelines": [
+    {
+      "model": {
+        "class_name": "loading_resources.load_hf_text_classif_pipeline",
+        "remote": "/azimuth_shr",
+        "kwargs": {
+          "checkpoint_path": "/azimuth_shr/files/clinc-demo/CLINC150_trained_model"
+        }
+      }
+    }
+  ],
+  "dataset": {
+    "class_name": "loading_resources.load_CLINC150_data",
+    "remote": "/azimuth_shr",
+    "kwargs": {
+      "python_loader": "/azimuth_shr/data/CLINC150.py",
+      "full_path": "/azimuth_shr/files/clinc-demo/oos-eval/data/clinc_data_dummy.json"
+    }
+  },
+  "saliency_layer": "distilbert.embeddings.word_embeddings",
+  "model_contract": "hf_text_classification",
+  "rejection_class": "NO_INTENT",
+  "uncertainty": {
+    "iterations": 20
+  }
+}

--- a/tests/test_modules/test_model_contracts/test_model_contract_module.py
+++ b/tests/test_modules/test_model_contracts/test_model_contract_module.py
@@ -100,9 +100,10 @@ def test_high_epistemic_tag(simple_text_config):
         sum(dm.get_dataset_split(simple_table_key_with_bma)[SmartTag.high_epistemic_uncertainty])
         == 10
     )
-    # With simple_table_key (use_bma is False), we still get 0
+    # With simple_table_key (use_bma is False), we should still get 10 so the smart tag is
+    # available in the main prediction table.
     simple_table_key = get_table_key(simple_text_config)
-    assert sum(dm.get_dataset_split(simple_table_key)[SmartTag.high_epistemic_uncertainty]) == 0
+    assert sum(dm.get_dataset_split(simple_table_key)[SmartTag.high_epistemic_uncertainty]) == 10
 
 
 def test_pred_smart_tags(clinc_text_config):

--- a/tests/test_modules/test_model_contracts/test_model_contract_module.py
+++ b/tests/test_modules/test_model_contracts/test_model_contract_module.py
@@ -93,15 +93,10 @@ def test_high_epistemic_tag(simple_text_config):
     # Set BMA
     mod.config.uncertainty.iterations = 20
     mod.mod_options.use_bma = True
-
-    # If BMA is set, we expect 10 tagged.
     mod.save_result(predictions, dm)
-    assert (
-        sum(dm.get_dataset_split(simple_table_key_with_bma)[SmartTag.high_epistemic_uncertainty])
-        == 10
-    )
-    # With simple_table_key (use_bma is False), we should still get 10 so the smart tag is
-    # available in the main prediction table.
+
+    # If BMA is set, we expect 10 tagged, and those tags to be found in the prediction table
+    # with the regular key, so they can be retrieved like the other tags.
     simple_table_key = get_table_key(simple_text_config)
     assert sum(dm.get_dataset_split(simple_table_key)[SmartTag.high_epistemic_uncertainty]) == 10
 


### PR DESCRIPTION
Resolve #181 

## Description:
The smart tag wasn't showing in the UI because the tag was not saved under the 'main' key.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
