### PR TITLE
Add tooltip if filter selector is unavailable

### DIFF
--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -64,6 +64,7 @@ type Props = {
 type Query = {
   data?: CountPerFilterResponse;
   isFetching: boolean;
+  isSuccess: boolean;
 };
 
 const Controls: React.FC<Props> = ({
@@ -85,20 +86,23 @@ const Controls: React.FC<Props> = ({
   }>();
   const baseUrl = `/${jobId}/dataset_splits/${datasetSplitName}/${mainView}`;
 
-  const { data: countPerFilter, isFetching: isFetchingCountPerFilter }: Query =
-    isPipelineSelected(pipeline)
-      ? getOutcomeCountPerFilterEndpoint.useQuery({
-          jobId,
-          datasetSplitName,
-          ...filters,
-          ...pipeline,
-          ...postprocessing,
-        })
-      : getUtteranceCountPerFilterEndpoint.useQuery({
-          jobId,
-          datasetSplitName,
-          ...filters,
-        });
+  const {
+    data: countPerFilter,
+    isFetching: isFetchingCountPerFilter,
+    isSuccess: isSuccessCountPerFilter,
+  }: Query = isPipelineSelected(pipeline)
+    ? getOutcomeCountPerFilterEndpoint.useQuery({
+        jobId,
+        datasetSplitName,
+        ...filters,
+        ...pipeline,
+        ...postprocessing,
+      })
+    : getUtteranceCountPerFilterEndpoint.useQuery({
+        jobId,
+        datasetSplitName,
+        ...filters,
+      });
 
   const { data: datasetInfo } = getDatasetInfoEndpoint.useQuery({ jobId });
 
@@ -185,6 +189,7 @@ const Controls: React.FC<Props> = ({
     handleValueChange: getFilterChangeHandler(filter),
     filters: countPerFilter?.countPerFilter[filter],
     isFetching: isFetchingCountPerFilter,
+    isSuccess: isSuccessCountPerFilter,
   });
 
   const divider = (

--- a/webapp/src/components/Controls/FilterSelector.test.tsx
+++ b/webapp/src/components/Controls/FilterSelector.test.tsx
@@ -10,7 +10,8 @@ test("display loading state", async () => {
       searchValue=""
       selectedOptions={[]}
       handleValueChange={() => {}}
-      isFetching={true}
+      isFetching
+      isSuccess={false}
     />
   );
 
@@ -40,13 +41,16 @@ test("display reloading state", async () => {
           filterValue: "type1",
         },
       ]}
-      isFetching={true}
+      isFetching
+      isSuccess={false}
     />
   );
 
   await screen.findByText("type");
   await screen.findByRole("progressbar");
-  expect(await screen.queryByRole("figure")).not.toBeNull();
+  expect(screen.getByRole("figure").parentElement!.parentElement).toHaveStyle({
+    opacity: 0.38,
+  });
   expect(screen.getByLabelText("collapse-type")).not.toBeDisabled();
 });
 
@@ -59,6 +63,7 @@ test("display null state", async () => {
       selectedOptions={[]}
       handleValueChange={() => {}}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -66,6 +71,39 @@ test("display null state", async () => {
   expect(await screen.queryByRole("progressbar")).toBeNull();
   expect(await screen.queryByRole("figure")).toBeNull();
   expect(screen.getByLabelText("collapse-type")).toBeDisabled();
+});
+
+test("display error state", async () => {
+  renderWithTheme(
+    <FilterSelector
+      label="type"
+      maxCount={0}
+      searchValue=""
+      selectedOptions={[]}
+      handleValueChange={() => {}}
+      filters={[
+        {
+          outcomeCount: {
+            CorrectAndPredicted: 0,
+            CorrectAndRejected: 0,
+            IncorrectAndPredicted: 0,
+            IncorrectAndRejected: 0,
+          },
+          utteranceCount: 0,
+          filterValue: "type1",
+        },
+      ]}
+      isFetching={false}
+      isSuccess={false}
+    />
+  );
+
+  screen.getByText("type");
+  expect(screen.queryByRole("progressbar")).toBeNull();
+  expect(screen.getByRole("figure").parentElement!.parentElement).toHaveStyle({
+    opacity: 0.38,
+  });
+  expect(screen.getByLabelText("collapse-type")).not.toBeDisabled();
 });
 
 test("empty outcome count", async () => {
@@ -89,6 +127,7 @@ test("empty outcome count", async () => {
         },
       ]}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -98,6 +137,9 @@ test("empty outcome count", async () => {
 
   const distribution = await screen.findByRole("figure");
   expect(distribution).toHaveStyle("width: 0%");
+  expect(distribution.parentElement!.parentElement).not.toHaveStyle({
+    opacity: 0.38,
+  });
 
   expect(screen.getByLabelText("type1")).not.toBeDisabled();
 });
@@ -123,6 +165,7 @@ test("collapsible filter", async () => {
         },
       ]}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -175,6 +218,7 @@ test("multi filter order", async () => {
         },
       ]}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -224,6 +268,7 @@ test("see more", async () => {
         filterValue: `type${i + 1}`,
       }))}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -260,6 +305,7 @@ test("see more long list", async () => {
         filterValue: `type${i + 1}`,
       }))}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -316,6 +362,7 @@ test("selected options", async () => {
         },
       ]}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -364,6 +411,7 @@ test("select all options", async () => {
         },
       ]}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -412,6 +460,7 @@ test("unselect all options", async () => {
         },
       ]}
       isFetching={false}
+      isSuccess
     />
   );
 
@@ -498,6 +547,7 @@ test("filter by search", async () => {
         },
       ]}
       isFetching={false}
+      isSuccess
     />
   );
 

--- a/webapp/src/components/Controls/FilterSelector.test.tsx
+++ b/webapp/src/components/Controls/FilterSelector.test.tsx
@@ -16,10 +16,10 @@ test("display loading state", async () => {
     />
   );
 
-  await screen.findByText("type");
+  screen.getByText("type");
   expect(screen.queryByLabelText(PIPELINE_REQUIRED_TIP)).toBeNull();
-  await screen.findByRole("progressbar");
-  expect(await screen.queryByRole("figure")).toBeNull();
+  screen.getByRole("progressbar");
+  expect(screen.queryByRole("figure")).toBeNull();
   expect(screen.getByLabelText("collapse-type")).toBeDisabled();
 });
 
@@ -48,9 +48,9 @@ test("display reloading state", async () => {
     />
   );
 
-  await screen.findByText("type");
+  screen.getByText("type");
   expect(screen.queryByLabelText(PIPELINE_REQUIRED_TIP)).toBeNull();
-  await screen.findByRole("progressbar");
+  screen.getByRole("progressbar");
   expect(screen.getByRole("figure").parentElement!.parentElement).toHaveStyle({
     opacity: 0.38,
   });
@@ -70,10 +70,10 @@ test("display null state", async () => {
     />
   );
 
-  await screen.findByText("type");
+  screen.getByText("type");
   const label = screen.getByLabelText(PIPELINE_REQUIRED_TIP);
-  expect(await screen.queryByRole("progressbar")).toBeNull();
-  expect(await screen.queryByRole("figure")).toBeNull();
+  expect(screen.queryByRole("progressbar")).toBeNull();
+  expect(screen.queryByRole("figure")).toBeNull();
   expect(screen.getByLabelText("collapse-type")).toBeDisabled();
 
   fireEvent.mouseOver(label);
@@ -139,12 +139,12 @@ test("empty outcome count", async () => {
     />
   );
 
-  await screen.findByText("type");
-  const items = await screen.findAllByRole("listitem");
+  screen.getByText("type");
+  const items = screen.getAllByRole("listitem");
   expect(items).toHaveLength(1);
 
-  const distribution = await screen.findByRole("figure");
-  expect(distribution).toHaveStyle("width: 0%");
+  const distribution = screen.getByRole("figure");
+  expect(distribution).toHaveStyle({ width: "0%" });
   expect(distribution.parentElement!.parentElement).not.toHaveStyle({
     opacity: 0.38,
   });
@@ -177,12 +177,12 @@ test("collapsible filter", async () => {
     />
   );
 
-  const typeElement = await screen.findByLabelText("collapse-type");
-  await screen.findByText("type1");
+  const typeElement = screen.getByLabelText("collapse-type");
+  screen.getByText("type1");
   fireEvent.click(typeElement);
-  expect(await screen.queryByText("type1")).toBeNull();
+  expect(screen.queryByText("type1")).toBeNull();
   fireEvent.click(typeElement);
-  expect(await screen.queryByText("type1")).toBeVisible();
+  expect(screen.getByText("type1")).toBeVisible();
 });
 
 test("multi filter order", async () => {
@@ -230,8 +230,8 @@ test("multi filter order", async () => {
     />
   );
 
-  await screen.findByText("type");
-  const items = await screen.findAllByRole("listitem");
+  screen.getByText("type");
+  const items = screen.getAllByRole("listitem");
   expect(items).toHaveLength(3);
 
   const expectedOrder = ["type2", "type1", "type3"];
@@ -239,19 +239,17 @@ test("multi filter order", async () => {
     expect(item.textContent).toBe(expectedOrder[index]);
   });
 
-  const distributions = await screen.findAllByRole("figure");
+  const distributions = screen.getAllByRole("figure");
   const expectedProportions = [
     ["25%", "25%", "25%", "25%"],
     ["100%", "0%", "0%", "0%"],
     ["0%", "0%", "0%", "100%"],
   ];
-  await waitFor(() => {
-    distributions.forEach((distribution, distributionIndex) => {
-      const proportions = distribution.childNodes;
-      proportions.forEach((proportion, proportionIndex) => {
-        expect(proportion).toHaveStyle(
-          `width: ${expectedProportions[distributionIndex][proportionIndex]}`
-        );
+  distributions.forEach((distribution, distributionIndex) => {
+    const proportions = distribution.childNodes;
+    proportions.forEach((proportion, proportionIndex) => {
+      expect(proportion).toHaveStyle({
+        width: expectedProportions[distributionIndex][proportionIndex],
       });
     });
   });
@@ -280,18 +278,18 @@ test("see more", async () => {
     />
   );
 
-  const list = await screen.findByRole("list");
+  const list = screen.getByRole("list");
   await waitFor(() => {
     expect(list).toHaveStyle({ "max-height": `${5 * 28}px` });
   });
-  let seeMoreButton = await screen.findByText("See more (6)");
+  const seeMoreButton = screen.getByText("See more (6)");
 
   fireEvent.click(seeMoreButton);
   await waitFor(() => {
     expect(list).toHaveStyle({ "max-height": `${11 * 28}px` });
   });
   // TODO This doesn't test what we intend. Improve test.
-  expect(await screen.queryByText("See more")).toBeNull();
+  expect(screen.queryByText("See more")).toBeNull();
 });
 
 test("see more long list", async () => {
@@ -317,17 +315,17 @@ test("see more long list", async () => {
     />
   );
 
-  const list = await screen.findByRole("list");
+  const list = screen.getByRole("list");
   await waitFor(() => {
     expect(list).toHaveStyle({ "max-height": `${5 * 28}px` });
   });
-  let seeMoreButton = await screen.findByText("See more (15)");
+  let seeMoreButton = screen.getByText("See more (15)");
 
   fireEvent.click(seeMoreButton);
   await waitFor(() => {
     expect(list).toHaveStyle({ "max-height": `${20 * 28}px` });
   });
-  seeMoreButton = await screen.findByText("See more (1)");
+  seeMoreButton = screen.getByText("See more (1)");
 
   fireEvent.click(seeMoreButton);
   await waitFor(() => {
@@ -559,7 +557,7 @@ test("filter by search", async () => {
     />
   );
 
-  let items = await screen.findAllByRole("listitem");
+  const items = screen.getAllByRole("listitem");
   expect(items).toHaveLength(3);
 
   const expectedOrder = ["category1", "category2", "category3"];

--- a/webapp/src/components/Controls/FilterSelector.test.tsx
+++ b/webapp/src/components/Controls/FilterSelector.test.tsx
@@ -145,9 +145,7 @@ test("empty outcome count", async () => {
 
   const distribution = screen.getByRole("figure");
   expect(distribution).toHaveStyle({ width: "0%" });
-  expect(distribution.parentElement!.parentElement).not.toHaveStyle({
-    opacity: 0.38,
-  });
+  expect(distribution.parentElement!.parentElement).toHaveStyle({ opacity: 1 });
 
   expect(screen.getByLabelText("type1")).not.toBeDisabled();
 });

--- a/webapp/src/components/Controls/FilterSelector.test.tsx
+++ b/webapp/src/components/Controls/FilterSelector.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import FilterSelector from "components/Controls/FilterSelector";
 import { renderWithTheme } from "mocks/utils";
+import { PIPELINE_REQUIRED_TIP } from "utils/const";
 
 test("display loading state", async () => {
   renderWithTheme(
@@ -16,6 +17,7 @@ test("display loading state", async () => {
   );
 
   await screen.findByText("type");
+  expect(screen.queryByLabelText(PIPELINE_REQUIRED_TIP)).toBeNull();
   await screen.findByRole("progressbar");
   expect(await screen.queryByRole("figure")).toBeNull();
   expect(screen.getByLabelText("collapse-type")).toBeDisabled();
@@ -47,6 +49,7 @@ test("display reloading state", async () => {
   );
 
   await screen.findByText("type");
+  expect(screen.queryByLabelText(PIPELINE_REQUIRED_TIP)).toBeNull();
   await screen.findByRole("progressbar");
   expect(screen.getByRole("figure").parentElement!.parentElement).toHaveStyle({
     opacity: 0.38,
@@ -68,9 +71,13 @@ test("display null state", async () => {
   );
 
   await screen.findByText("type");
+  const label = screen.getByLabelText(PIPELINE_REQUIRED_TIP);
   expect(await screen.queryByRole("progressbar")).toBeNull();
   expect(await screen.queryByRole("figure")).toBeNull();
   expect(screen.getByLabelText("collapse-type")).toBeDisabled();
+
+  fireEvent.mouseOver(label);
+  await screen.findByText(PIPELINE_REQUIRED_TIP);
 });
 
 test("display error state", async () => {
@@ -99,6 +106,7 @@ test("display error state", async () => {
   );
 
   screen.getByText("type");
+  expect(screen.queryByLabelText(PIPELINE_REQUIRED_TIP)).toBeNull();
   expect(screen.queryByRole("progressbar")).toBeNull();
   expect(screen.getByRole("figure").parentElement!.parentElement).toHaveStyle({
     opacity: 0.38,

--- a/webapp/src/components/Controls/FilterSelector.tsx
+++ b/webapp/src/components/Controls/FilterSelector.tsx
@@ -87,6 +87,7 @@ type Props<FilterValue> = {
   handleValueChange: (selectedOptions: FilterValue[]) => void;
   filters?: CountPerFilterValue[] | null;
   isFetching: boolean;
+  isSuccess: boolean;
   prettyNames?: Record<string, string>;
 };
 
@@ -98,6 +99,7 @@ const FilterSelector = <FilterValue extends string>({
   handleValueChange,
   filters,
   isFetching,
+  isSuccess,
   prettyNames,
 }: Props<FilterValue>) => {
   const classes = useStyles();
@@ -172,9 +174,9 @@ const FilterSelector = <FilterValue extends string>({
             display="flex"
             height="100%"
             sx={{
-              opacity: isFetching
-                ? (theme) => theme.palette.action.disabledOpacity
-                : 1,
+              opacity: isSuccess
+                ? undefined
+                : (theme) => theme.palette.action.disabledOpacity,
             }}
           >
             <FilterDistribution maxCount={maxCount} filter={filter} />

--- a/webapp/src/components/Controls/FilterSelector.tsx
+++ b/webapp/src/components/Controls/FilterSelector.tsx
@@ -176,7 +176,7 @@ const FilterSelector = <FilterValue extends string>({
             height="100%"
             sx={{
               opacity: isSuccess
-                ? undefined
+                ? 1
                 : (theme) => theme.palette.action.disabledOpacity,
             }}
           >

--- a/webapp/src/components/Controls/FilterSelector.tsx
+++ b/webapp/src/components/Controls/FilterSelector.tsx
@@ -22,6 +22,7 @@ import { motion } from "framer-motion";
 import React from "react";
 import { TOOLTIP_ENTER_DELAY } from "styles/const";
 import { CountPerFilterValue } from "types/api";
+import { PIPELINE_REQUIRED_TIP } from "utils/const";
 
 const MotionArrowDropDownIcon = motion(ArrowDropDownIcon);
 
@@ -201,21 +202,23 @@ const FilterSelector = <FilterValue extends string>({
             className={classes.collapseIcon}
           />
         </Button>
-        <FormControlLabel
-          className={classes.checkboxGroup}
-          control={
-            <Checkbox
-              checked={someOptionsAreSelected}
-              className={classes.checkbox}
-              color="primary"
-              disabled={!filters} // so it can't be clicked before options are loaded
-              indeterminate={someOptionsAreSelected && !allOptionsAreSelected}
-              onChange={(_, checked) => handleSelectAll(checked)}
-            />
-          }
-          label={label}
-          componentsProps={{ typography: titleTypographyProps }}
-        />
+        <Tooltip title={isSuccess && !filters ? PIPELINE_REQUIRED_TIP : ""}>
+          <FormControlLabel
+            className={classes.checkboxGroup}
+            control={
+              <Checkbox
+                checked={someOptionsAreSelected}
+                className={classes.checkbox}
+                color="primary"
+                disabled={!filters} // so it can't be clicked before options are loaded
+                indeterminate={someOptionsAreSelected && !allOptionsAreSelected}
+                onChange={(_, checked) => handleSelectAll(checked)}
+              />
+            }
+            label={label}
+            componentsProps={{ typography: titleTypographyProps }}
+          />
+        </Tooltip>
         {filters && selectedOptions.length > 0 && (
           <Typography variant="body2" className={classes.selectedCount}>
             ({selectedOptions.length} selected)


### PR DESCRIPTION
Resolve #194

## Description:

3 commits to isolate from noise:
* Pass `isSuccess` to differentiate between successful data and data from before an error occurred.
* Add tooltip if filter selector is unavailable 
* Clean up unnecessary awaits

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
