### PR TITLE
Fix log level ignored in app.py

### DIFF
--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -23,8 +23,6 @@ from azimuth.utils.logs import set_logger_config
 from azimuth.utils.project import load_dataset_split_managers_from_config
 from azimuth.utils.validation import assert_not_none
 
-log = structlog.getLogger(__name__)
-
 _dataset_split_managers: Dict[DatasetSplitName, Optional[DatasetSplitManager]] = {}
 _task_manager: Optional[TaskManager] = None
 _startup_tasks: Optional[Dict[str, Module]] = None
@@ -99,9 +97,13 @@ def create_app_with(config_path, debug=False, profile=False) -> FastAPI:
         ValueError: If no dataset_split in config.
     """
     global _dataset_split_managers, _task_manager, _startup_tasks, _azimuth_config, _ready_flag
-    log.info("🔭 Azimuth starting 🔭")
+
     level = logging.DEBUG if debug else logging.INFO
     set_logger_config(level)
+
+    log = structlog.get_logger(__name__)
+
+    log.info("🔭 Azimuth starting 🔭")
 
     azimuth_config = load_azimuth_config(config_path)
     if azimuth_config.dataset is None:


### PR DESCRIPTION
## Description:

Fix log level ignored in app.py by calling `log = structlog.get_logger(__name__)` only after `set_logger_config()` (which sets the log level).

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
