### PR TITLE
Rename `PerturbationTestingScope` to `PerturbationTestingConfig`

### DIFF
--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -287,7 +287,7 @@ class ModelContractConfig(CommonFieldsConfig):
         return pipeline_definitions
 
 
-class PerturbationTestingScope(ModelContractConfig):
+class PerturbationTestingConfig(ModelContractConfig):
     # Perturbation Testing configuration to define which test and with which params to run.
     behavioral_testing: Optional[BehavioralTestingOptions] = Field(
         BehavioralTestingOptions(), env="BEHAVIORAL_TESTING"
@@ -310,7 +310,7 @@ class SyntaxConfig(CommonFieldsConfig):
 
 
 class AzimuthConfig(
-    PerturbationTestingScope,
+    PerturbationTestingConfig,
     SimilarityConfig,
     DatasetWarningConfig,
     SyntaxConfig,

--- a/azimuth/modules/perturbation_testing/perturbation_testing.py
+++ b/azimuth/modules/perturbation_testing/perturbation_testing.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple, cast
 import numpy as np
 from datasets import Dataset
 
-from azimuth.config import PerturbationTestingScope
+from azimuth.config import PerturbationTestingConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.base_classes import DatasetResultModule
 from azimuth.modules.model_contract_task_mapping import model_contract_task_mapping
@@ -44,7 +44,7 @@ from azimuth.utils.ml.seeding import RandomContext
 from azimuth.utils.validation import assert_not_none
 
 
-class PerturbationTestingModule(DatasetResultModule[PerturbationTestingScope]):
+class PerturbationTestingModule(DatasetResultModule[PerturbationTestingConfig]):
     """
     This module generates perturbed utterances based on a list of perturbation tests and
     provides detailed results on the prediction results for the new perturbed utterances.
@@ -62,7 +62,7 @@ class PerturbationTestingModule(DatasetResultModule[PerturbationTestingScope]):
     def __init__(
         self,
         dataset_split_name: DatasetSplitName,
-        config: PerturbationTestingScope,
+        config: PerturbationTestingConfig,
         mod_options: Optional[ModuleOptions] = None,
     ):
 

--- a/azimuth/modules/perturbation_testing/perturbation_testing_summary.py
+++ b/azimuth/modules/perturbation_testing/perturbation_testing_summary.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 import pandas as pd
 
-from azimuth.config import PerturbationTestingScope
+from azimuth.config import PerturbationTestingConfig
 from azimuth.modules.base_classes import ComparisonModule
 from azimuth.modules.perturbation_testing import PerturbationTestingModule
 from azimuth.modules.task_execution import get_task_result
@@ -42,7 +42,7 @@ class PerturbedUtteranceNeededInfo:
 PERTURBATION_TEST_GROUPING = ["family", "name", "perturbation_type", "dataset_split_name"]
 
 
-class PerturbationTestingSummaryModule(ComparisonModule[PerturbationTestingScope]):
+class PerturbationTestingSummaryModule(ComparisonModule[PerturbationTestingConfig]):
     """Summary of perturbation tests per dataset split."""
 
     def compute_on_dataset_split(  # type: ignore

--- a/azimuth/utils/ml/perturbation_functions.py
+++ b/azimuth/utils/ml/perturbation_functions.py
@@ -6,7 +6,7 @@ from typing import List
 
 import nlpaug.augmenter.char as nac
 
-from azimuth.config import PerturbationTestingScope
+from azimuth.config import PerturbationTestingConfig
 from azimuth.types.perturbation_testing import (
     PerturbationType,
     PerturbedUtteranceDetails,
@@ -61,7 +61,7 @@ def add_neutral_token(
 
 
 def neutral_prefix(
-    original: str, config: PerturbationTestingScope
+    original: str, config: PerturbationTestingConfig
 ) -> List[PerturbedUtteranceDetails]:
     """Add a neutral prefix to an utterance.
 
@@ -80,7 +80,7 @@ def neutral_prefix(
 
 
 def neutral_suffix(
-    original: str, config: PerturbationTestingScope
+    original: str, config: PerturbationTestingConfig
 ) -> List[PerturbedUtteranceDetails]:
     """Add a neutral suffix to an utterance.
 
@@ -99,7 +99,7 @@ def neutral_suffix(
 
 
 def add_all_neutral_tokens(
-    original: str, config: PerturbationTestingScope
+    original: str, config: PerturbationTestingConfig
 ) -> List[PerturbedUtteranceDetails]:
     """Add neutral tokens at the beginning and the end of the utterance.
 
@@ -155,7 +155,7 @@ def remove_or_add_final_punctuation(
 
 
 def remove_or_add_final_period(
-    original: str, config: PerturbationTestingScope
+    original: str, config: PerturbationTestingConfig
 ) -> List[PerturbedUtteranceDetails]:
     """Remove or add period at the end of an utterance.
 
@@ -171,7 +171,7 @@ def remove_or_add_final_period(
 
 
 def remove_or_add_final_question_mark(
-    original: str, config: PerturbationTestingScope
+    original: str, config: PerturbationTestingConfig
 ) -> List[PerturbedUtteranceDetails]:
     """Remove or add question mark at the end of an perturbed_utterance.
 
@@ -230,7 +230,7 @@ def remove_or_add_inside_punctuation(
 
 
 def remove_or_add_inside_comma(
-    original: str, config: PerturbationTestingScope
+    original: str, config: PerturbationTestingConfig
 ) -> List[PerturbedUtteranceDetails]:
     """Remove or add a comma inside an utterance (not at the end).
 
@@ -246,7 +246,7 @@ def remove_or_add_inside_comma(
 
 
 def remove_or_add_inside_period(
-    original: str, config: PerturbationTestingScope
+    original: str, config: PerturbationTestingConfig
 ) -> List[PerturbedUtteranceDetails]:
     """Remove or add a period inside an utterance (not at the end).
 
@@ -266,7 +266,7 @@ def get_utterances_diff(original_utterance: str, perturbed_utterance: str) -> Li
     return list(set(perturbed_utterance.split()).difference(set(original_utterance.split())))
 
 
-def typo(original: str, config: PerturbationTestingScope) -> List[PerturbedUtteranceDetails]:
+def typo(original: str, config: PerturbationTestingConfig) -> List[PerturbedUtteranceDetails]:
     """Create different types of typos in an utterance.
 
     It uses the nlpaug package for this test and introduce mistakes raised by OCR, keyboard typo,
@@ -322,7 +322,7 @@ def typo(original: str, config: PerturbationTestingScope) -> List[PerturbedUtter
 
 
 def remove_or_add_contractions(
-    original: str, config: PerturbationTestingScope
+    original: str, config: PerturbationTestingConfig
 ) -> List[PerturbedUtteranceDetails]:
     """Expand or contract relevant expressions when present in the utterance.
 

--- a/azimuth/utils/ml/perturbation_test.py
+++ b/azimuth/utils/ml/perturbation_test.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple
 
-from azimuth.config import PerturbationTestingScope
+from azimuth.config import PerturbationTestingConfig
 from azimuth.types.perturbation_testing import (
     PerturbationTestClass,
     PerturbationTestFailureReason,
@@ -23,7 +23,7 @@ class PerturbationTest:
 
     name: PerturbationTestName
     family: PerturbationTestFamily
-    test_fn: Callable[[str, PerturbationTestingScope], List[PerturbedUtteranceDetails]]
+    test_fn: Callable[[str, PerturbationTestingConfig], List[PerturbedUtteranceDetails]]
     test_type: PerturbationTestType
     test_class: PerturbationTestClass
     conf_delta_threshold: float  # Delta in confidence which will fail the test.

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -9,7 +9,7 @@ from datasets import DatasetDict
 from azimuth.config import (
     AzimuthConfig,
     ModelContractConfig,
-    PerturbationTestingScope,
+    PerturbationTestingConfig,
     SimilarityConfig,
 )
 from azimuth.dataset_split_manager import DatasetSplitManager
@@ -91,7 +91,7 @@ def similarity_available(config: SimilarityConfig) -> bool:
     return config.similarity is not None
 
 
-def perturbation_testing_available(config: PerturbationTestingScope) -> bool:
+def perturbation_testing_available(config: PerturbationTestingConfig) -> bool:
     correct_model_contract = config.model_contract in [
         SupportedModelContract.hf_text_classification,
         SupportedModelContract.custom_text_classification,

--- a/docs/docs/reference/configuration/analyses/index.md
+++ b/docs/docs/reference/configuration/analyses/index.md
@@ -6,7 +6,7 @@ different attributes that can be defined.
 === "Class Definition"
 
     ```python
-    class PerturbationTestingScope(ModelContractConfig):
+    class PerturbationTestingConfig(ModelContractConfig):
         behavioral_testing: Optional[BehavioralTestingOptions] = Field(
             BehavioralTestingOptions(), env="BEHAVIORAL_TESTING"
         )

--- a/tests/test_modules/test_caching.py
+++ b/tests/test_modules/test_caching.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import h5py
 import pytest
 
-from azimuth.config import PerturbationTestingScope
+from azimuth.config import PerturbationTestingConfig
 from azimuth.modules.base_classes import (
     AggregationModule,
     FilterableModule,
@@ -141,7 +141,7 @@ def test_wrong_aggregation_module(simple_text_config):
         )
 
 
-class MyPerturbationModule(Module[PerturbationTestingScope]):
+class MyPerturbationModule(Module[PerturbationTestingConfig]):
     def compute_on_dataset_split(self):
         return [{"potato": i} for i in self.get_indices()]
 


### PR DESCRIPTION
## Description:

Rename `PerturbationTestingScope` to `PerturbationTestingConfig` so it is uniform with the other `Config` classes.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
