### PR TITLE
Generate frontend types without the back end running

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,8 +35,15 @@ repos:
       - id: prettier
         name: prettier
         language: system
-        entry: bash -c 'cd webapp && poetry run yarn prettier --write .'
+        entry: bash -c 'cd webapp && yarn prettier --write .'
         files: webapp
+  - repo: local
+    hooks:
+      - id: frontend types
+        name: Regenerate frontend types
+        language: system
+        entry: bash -c 'cd webapp && yarn types'
+        files: azimuth
   - repo: local
     hooks:
       - id: flake8

--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -139,6 +139,11 @@ def create_app_with(config_path, debug=False, profile=False) -> FastAPI:
 
 
 def define_app() -> FastAPI:
+    """Defines the FastAPI.
+
+    Returns:
+        FastAPI.
+    """
     app = FastAPI(
         title="Azimuth API",
         description="Azimuth API",

--- a/azimuth/app_loader.py
+++ b/azimuth/app_loader.py
@@ -2,6 +2,8 @@
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
 
-from azimuth.app import create_app
+from azimuth.app import start_app
+from azimuth.config import parse_args
 
-app = create_app()
+args = parse_args()
+app = start_app(config_path=args.config_path, debug=args.debug)

--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -24,7 +24,6 @@ def parse_args():
     parser.add_argument("config_path", default="/config/config.json")
     parser.add_argument("--port", default=8091, help="Port to serve the API.")
     parser.add_argument("--debug", action="store_true")
-    parser.add_argument("--profile", action="store_true")
     return parser.parse_args()
 
 

--- a/openapi.py
+++ b/openapi.py
@@ -1,0 +1,19 @@
+import json
+import sys
+
+from fastapi.openapi.utils import get_openapi
+
+from azimuth.app import define_app
+
+if __name__ == "__main__":
+    app = define_app()
+    openapi = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+        tags=app.openapi_tags,
+        servers=app.servers,
+    )
+    json.dump(openapi, sys.stdout)

--- a/openapi.py
+++ b/openapi.py
@@ -3,10 +3,10 @@ import sys
 
 from fastapi.openapi.utils import get_openapi
 
-from azimuth.app import define_app
+from azimuth.app import create_app
 
 if __name__ == "__main__":
-    app = define_app()
+    app = create_app()
     openapi = get_openapi(
         title=app.title,
         version=app.version,

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -8,7 +8,6 @@ import inspect
 import os
 import re
 from itertools import compress
-from pprint import pprint
 
 from pydantic.main import BaseModel
 
@@ -231,11 +230,8 @@ def test_doc():
     for module in modules:
         mod = importlib.import_module(module)
         handle_module(mod, exceptions, history)
-    if exceptions:
-        # Summary
-        exceptions = set([v[0] for v in exceptions])
-        pprint(exceptions, width=100)
-        raise ValueError(f"{len(exceptions)} documentation errors")
+    exceptions = set(v[0] for v in exceptions)
+    assert not exceptions
 
 
 if __name__ == "__main__":

--- a/tests/test_routers/conftest.py
+++ b/tests/test_routers/conftest.py
@@ -24,7 +24,7 @@ def mock_ready_flag_false():
 
 def create_test_app(config) -> FastAPI:
     json.dump(config.dict(by_alias=True), open("/tmp/config.json", "w"))
-    return me_app.create_app_with("/tmp/config.json", debug=False, profile=False)
+    return me_app.start_app("/tmp/config.json", debug=False, profile=False)
 
 
 FAST_TEST_CFG = {

--- a/tests/test_routers/conftest.py
+++ b/tests/test_routers/conftest.py
@@ -24,7 +24,7 @@ def mock_ready_flag_false():
 
 def create_test_app(config) -> FastAPI:
     json.dump(config.dict(by_alias=True), open("/tmp/config.json", "w"))
-    return me_app.start_app("/tmp/config.json", debug=False, profile=False)
+    return me_app.start_app("/tmp/config.json", debug=False)
 
 
 FAST_TEST_CFG = {

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -30,7 +30,7 @@ def test_startup_task(tiny_text_config, tiny_text_task_manager):
     assert all("train" in k or "eval" in k for k in mods.keys())
     assert all(
         on_end in [cbk.fn for cbk in mod._callbacks] for mod in mods.values()
-    ), "Some modules dont have callbacks!"
+    ), "Some modules don't have callbacks!"
 
 
 def test_startup_task_fast(tiny_text_config, tiny_text_task_manager):
@@ -76,7 +76,7 @@ def test_startup_task_no_train(tiny_text_config_no_train, tiny_text_task_manager
     assert all("train" not in k or "eval" in k for k in mods.keys())
     assert all(
         on_end in [cbk.fn for cbk in mod._callbacks] for mod in mods.values()
-    ), "Some modules dont have callbacks!"
+    ), "Some modules don't have callbacks!"
 
 
 @pytest.mark.parametrize("iterations", [20, 1])

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,7 +31,7 @@
     "test": "react-app-rewired test --coverage",
     "eject": "react-scripts eject",
     "fix": "make npm.audit.fix",
-    "types": "rm -f src/types/generated/generatedTypes.ts && openapi-typescript http://localhost:8091/openapi.json --output src/types/generated/generatedTypes.ts"
+    "types": "rm -f src/types/generated/generatedTypes.ts && poetry run python ../openapi.py > openapi.json && openapi-typescript openapi.json --output src/types/generated/generatedTypes.ts && rm -f openapi.json"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Description:

Generate frontend types without the back end running.
- Removes the need for running the back end.
- Enables generation in `pre-commit`.
- Enables to check generation in CI/CD (not covered in the PR, see issue #238).

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **FRONTEND TYPES.** Regenerate the front-ent types if you played with types and routes.
  Run `cd webapp && yarn types` while the back-end is running.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
