### PR TITLE
Pr/ggm/improve metrics per filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cache
 *.swp
 !poetry.lock
 !yarn.lock
+tests/logs.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/azimuth/modules/base_classes/aggregation_module.py
+++ b/azimuth/modules/base_classes/aggregation_module.py
@@ -3,14 +3,13 @@
 # in the root directory of this source tree.
 import time
 from abc import ABC
-from typing import List, Optional, cast
+from typing import List, Optional
 
 from datasets import Dataset
 
 from azimuth.modules.base_classes import ConfigScope, ExpirableMixin, Module
-from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, ModuleResponse
-from azimuth.types.outcomes import OutcomeName
-from azimuth.utils.filtering import filter_dataset_split
+from azimuth.types import DatasetSplitName, ModuleOptions, ModuleResponse
+from azimuth.utils.dataset_operations import filter_dataset_split
 
 
 class AggregationModule(Module[ConfigScope], ABC):
@@ -62,42 +61,3 @@ class FilterableModule(AggregationModule[ConfigScope], ExpirableMixin, ABC):
             config=self.config,
             without_postprocessing=self.mod_options.without_postprocessing,
         )
-
-    def _get_predictions_from_ds(self) -> List[int]:
-        """Get predicted classes according to the module options (with or without postprocessing).
-
-        Returns: List of Predictions
-        """
-        ds = self.get_dataset_split()
-        if self.mod_options.without_postprocessing:
-            return cast(List[int], [preds[0] for preds in ds[DatasetColumn.model_predictions]])
-        else:
-            return cast(List[int], ds[DatasetColumn.postprocessed_prediction])
-
-    def _get_confidences_from_ds(self) -> List[List[float]]:
-        """Get confidences according to the module options (with or without postprocessing).
-
-        Notes: Confidences are sorted according to their values (not the class id).
-
-        Returns: List of Confidences
-        """
-        ds = self.get_dataset_split()
-        confidences = (
-            ds[DatasetColumn.model_confidences]
-            if self.mod_options.without_postprocessing
-            else ds[DatasetColumn.postprocessed_confidences]
-        )
-        return cast(List[List[float]], confidences)
-
-    def _get_outcomes_from_ds(self) -> List[OutcomeName]:
-        """Get outcomes according to the module options (with or without postprocessing).
-
-        Returns: List of Outcomes
-        """
-        ds = self.get_dataset_split()
-        outcomes = (
-            ds[DatasetColumn.model_outcome]
-            if self.mod_options.without_postprocessing
-            else ds[DatasetColumn.postprocessed_outcome]
-        )
-        return cast(List[OutcomeName], outcomes)

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -41,11 +41,15 @@ class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
     def get_bins(
         cls, ds: Dataset, without_postprocessing: bool = False
     ) -> List[ConfidenceBinDetails]:
-        """Compute the bins on the dataset split.
+        """Compute the bins on the specified dataset split.
+
+        Note: This lives outside of `compute_on_dataset_split()` so that it can be called without
+        going through calling the module and filtering the dataset.
 
         Args:
             ds: Dataset Split on which to compute bins
-            without_postprocessing: Whether to use outcomes and confidences without pipeline postprocessing
+            without_postprocessing: Whether to use outcomes and confidences without pipeline
+                postprocessing
 
         Returns:
             List of the confidence bins with their confidence and the outcome count.

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -16,6 +16,10 @@ from azimuth.types.model_performance import (
     ConfidenceHistogramResponse,
 )
 from azimuth.types.outcomes import ALL_OUTCOMES, OutcomeName
+from azimuth.utils.dataset_operations import (
+    get_confidences_from_ds,
+    get_outcomes_from_ds,
+)
 from azimuth.utils.validation import assert_not_none
 
 CONFIDENCE_BINS_COUNT = 20
@@ -24,23 +28,34 @@ CONFIDENCE_BINS_COUNT = 20
 class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
     """Return a confidence histogram of the predictions."""
 
-    def get_outcome_mask(self, outcome: OutcomeName) -> List[bool]:
-        return [utterance_outcome == outcome for utterance_outcome in self._get_outcomes_from_ds()]
+    @staticmethod
+    def get_outcome_mask(
+        ds, outcome: OutcomeName, without_postprocessing: bool = False
+    ) -> List[bool]:
+        return [
+            utterance_outcome == outcome
+            for utterance_outcome in get_outcomes_from_ds(ds, without_postprocessing)
+        ]
 
-    def compute_on_dataset_split(self) -> List[ConfidenceHistogramResponse]:  # type: ignore
-        """Compute the confidence histogram with CONFIDENCE_BINS_COUNT bins on the dataset split.
+    @classmethod
+    def get_bins(
+        cls, ds: Dataset, without_postprocessing: bool = False
+    ) -> List[ConfidenceBinDetails]:
+        """Compute the bins on the dataset split.
+
+        Args:
+            ds: Dataset Split to compute bins
+            without_postprocessing: Determine which outcomes and confidences to use.
 
         Returns:
             List of the confidence bins with their confidence and the outcome count.
-
         """
-        bins = np.linspace(0, 1, CONFIDENCE_BINS_COUNT + 1)
 
-        ds: Dataset = assert_not_none(self.get_dataset_split())
+        bins = np.linspace(0, 1, CONFIDENCE_BINS_COUNT + 1)
 
         if len(ds) > 0:
             # Get the bin index for each prediction.
-            confidences = np.max(self._get_confidences_from_ds(), axis=1)
+            confidences = np.max(get_confidences_from_ds(ds, without_postprocessing), axis=1)
             bin_indices = np.floor(confidences * CONFIDENCE_BINS_COUNT)
 
             # Create the records. We drop the last bin as it's the maximum.
@@ -50,7 +65,7 @@ class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
                 outcome_count = defaultdict(int)
                 for outcome in ALL_OUTCOMES:
                     outcome_count[outcome] = np.logical_and(
-                        bin_mask, self.get_outcome_mask(outcome)
+                        bin_mask, cls.get_outcome_mask(ds, outcome, without_postprocessing)
                     ).sum()
                 mean_conf = (
                     0 if bin_mask.sum() == 0 else np.nan_to_num(confidences[bin_mask].mean())
@@ -75,7 +90,23 @@ class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
                 for bin_index, bin_min_value in enumerate(bins[:-1])
             ]
 
-        return [ConfidenceHistogramResponse(bins=result, confidence_threshold=self.get_threshold())]
+        return result
+
+    def compute_on_dataset_split(self) -> List[ConfidenceHistogramResponse]:  # type: ignore
+        """Compute the confidence histogram with CONFIDENCE_BINS_COUNT bins on the dataset split.
+
+        Returns:
+            Confidence bins and threshold.
+
+        """
+        ds: Dataset = assert_not_none(self.get_dataset_split())
+
+        return [
+            ConfidenceHistogramResponse(
+                bins=self.get_bins(ds, self.mod_options.without_postprocessing),
+                confidence_threshold=self.get_threshold(),
+            )
+        ]
 
 
 class ConfidenceBinIndexModule(DatasetResultModule[ModelContractConfig]):

--- a/azimuth/modules/model_performance/confusion_matrix.py
+++ b/azimuth/modules/model_performance/confusion_matrix.py
@@ -13,6 +13,7 @@ from sklearn.metrics import confusion_matrix
 from azimuth.config import ModelContractConfig
 from azimuth.modules.base_classes import FilterableModule
 from azimuth.types.model_performance import ConfusionMatrixResponse
+from azimuth.utils.dataset_operations import get_predictions_from_ds
 from azimuth.utils.validation import assert_not_none
 
 MIN_CONFUSION_CUTHILL_MCKEE = 0.1
@@ -35,7 +36,7 @@ class ConfusionMatrixModule(FilterableModule[ModelContractConfig]):
         """
         ds: Dataset = assert_not_none(self.get_dataset_split())
         predictions, labels = (
-            self._get_predictions_from_ds(),
+            get_predictions_from_ds(ds, self.mod_options.without_postprocessing),
             ds[self.config.columns.label],
         )
         ds_mng = self.get_dataset_split_manager()

--- a/azimuth/modules/model_performance/metrics.py
+++ b/azimuth/modules/model_performance/metrics.py
@@ -65,7 +65,10 @@ class MetricsModule(FilterableModule[ModelContractConfig]):
     """Computes different metrics on each dataset split."""
 
     def compute_metrics(self, ds: Dataset) -> List[MetricsModuleResponse]:
-        """Compute all metrics on a given dataset split.
+        """Compute all metrics on the specified dataset split.
+
+        Note: This lives outside of `compute_on_dataset_split()` so that it can be called without
+        going through calling the module and filtering the dataset.
 
         Args:
             ds: Dataset Split for which to compute metrics.
@@ -130,6 +133,7 @@ class MetricsModule(FilterableModule[ModelContractConfig]):
             ]
 
     def compute_on_dataset_split(self) -> List[MetricsModuleResponse]:  # type: ignore
+        """Computes different metrics according to the specified module options."""
         ds: Dataset = assert_not_none(self.get_dataset_split())
         return self.compute_metrics(ds)
 
@@ -191,11 +195,11 @@ class MetricsPerFilterModule(AggregationModule[AzimuthConfig]):
         ds = self.get_dataset_split()
         accumulator = []
         for filter_value, filters in filters_dict.items():
-            ds_filter = filter_dataset_split(ds, filters, config=self.config)
+            ds_filtered = filter_dataset_split(ds, filters, config=self.config)
             metric = MetricsModule(
                 dataset_split_name=self.dataset_split_name,
                 config=self.config,
-            ).compute_metrics(ds_filter)[0]
+            ).compute_metrics(ds_filtered)[0]
             accumulator.append(MetricsPerFilterValue(**metric.dict(), filter_value=filter_value))
         return accumulator
 

--- a/azimuth/modules/word_analysis/top_words.py
+++ b/azimuth/modules/word_analysis/top_words.py
@@ -18,6 +18,7 @@ from azimuth.types.word_analysis import (
     TopWordsResponse,
     TopWordsResult,
 )
+from azimuth.utils.dataset_operations import get_predictions_from_ds
 from azimuth.utils.ml.third_parties.stop_words import STOP_WORDS
 from azimuth.utils.project import saliency_available
 
@@ -89,9 +90,9 @@ class TopWordsModule(FilterableModule[ModelContractConfig]):
             else TopWordsImportanceCriteria.frequent
         )
 
-        dataset_split = self.get_dataset_split()
+        ds = self.get_dataset_split()
 
-        if len(dataset_split) == 0:
+        if len(ds) == 0:
             return [
                 TopWordsResponse(
                     all=[],
@@ -109,9 +110,9 @@ class TopWordsModule(FilterableModule[ModelContractConfig]):
         important_words_errors = []
 
         tokenizer = self.artifact_manager.get_tokenizer()
-        is_error = np.array(self._get_predictions_from_ds()) != np.array(
-            dataset_split[self.config.columns.label]
-        )
+        is_error = np.array(
+            get_predictions_from_ds(ds, self.mod_options.without_postprocessing)
+        ) != np.array(ds[self.config.columns.label])
 
         for idx, record in enumerate(words_saliencies):
             # Put everything to lower case and remove cls/sep tokens.

--- a/azimuth/routers/v1/model_performance/utterance_count.py
+++ b/azimuth/routers/v1/model_performance/utterance_count.py
@@ -22,7 +22,7 @@ from azimuth.types.tag import (
     SmartTagFamily,
 )
 from azimuth.utils.conversion import merge_counters
-from azimuth.utils.filtering import filter_dataset_split
+from azimuth.utils.dataset_operations import filter_dataset_split
 from azimuth.utils.ml.model_performance import sorted_by_utterance_count_with_last
 from azimuth.utils.routers import build_named_dataset_filters
 

--- a/azimuth/routers/v1/utterances.py
+++ b/azimuth/routers/v1/utterances.py
@@ -47,7 +47,7 @@ from azimuth.types.utterance import (
     ModelSaliency,
     Utterance,
 )
-from azimuth.utils.filtering import filter_dataset_split
+from azimuth.utils.dataset_operations import filter_dataset_split
 from azimuth.utils.project import (
     perturbation_testing_available,
     postprocessing_known,

--- a/azimuth/utils/dataset_operations.py
+++ b/azimuth/utils/dataset_operations.py
@@ -1,12 +1,13 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
-from typing import Union, cast
+from typing import List, Union, cast
 
 from datasets import Dataset
 
 from azimuth.config import ProjectConfig
 from azimuth.types import DatasetColumn, DatasetFilters, NamedDatasetFilters
+from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import (
     ALL_DATA_ACTIONS,
     SMART_TAGS_FAMILY_MAPPING,
@@ -105,3 +106,54 @@ def filter_dataset_split(
             )
 
     return dataset_split
+
+
+def get_predictions_from_ds(ds: Dataset, without_postprocessing: bool = False) -> List[int]:
+    """Get predicted classes, with or without postprocessing.
+
+    Args:
+        ds: Dataset Split for which to get predictions.
+        without_postprocessing: Determine which column to use.
+
+    Returns: List of Predictions
+    """
+    if without_postprocessing:
+        return cast(List[int], [preds[0] for preds in ds[DatasetColumn.model_predictions]])
+    else:
+        return cast(List[int], ds[DatasetColumn.postprocessed_prediction])
+
+
+def get_confidences_from_ds(ds: Dataset, without_postprocessing: bool = False) -> List[List[float]]:
+    """Get confidences, with or without postprocessing.
+
+    Notes: Confidences are sorted according to their values (not the class id).
+
+    Args:
+        ds: Dataset Split for which to get confidences.
+        without_postprocessing: Determine which column to use.
+
+    Returns: List of Confidences
+    """
+    confidences = (
+        ds[DatasetColumn.model_confidences]
+        if without_postprocessing
+        else ds[DatasetColumn.postprocessed_confidences]
+    )
+    return cast(List[List[float]], confidences)
+
+
+def get_outcomes_from_ds(ds: Dataset, without_postprocessing: bool = False) -> List[OutcomeName]:
+    """Get outcomes, with or without postprocessing.
+
+        Args:
+        ds: Dataset Split for which to get outcomes.
+        without_postprocessing: Determine which column to use.
+
+    Returns: List of Outcomes
+    """
+    outcomes = (
+        ds[DatasetColumn.model_outcome]
+        if without_postprocessing
+        else ds[DatasetColumn.postprocessed_outcome]
+    )
+    return cast(List[OutcomeName], outcomes)

--- a/makefiles/Makefile.docs
+++ b/makefiles/Makefile.docs
@@ -1,16 +1,13 @@
 # Minimal makefile for documentation
 
-REGISTRY = servicenowdocker
-IMAGE = azimuth_docs
-
 .PHONY: build_docs
 build_docs:
-	docker build -t $(REGISTRY)/$(IMAGE) -f docs/Dockerfile.docs .
+	docker build -t $(REGISTRY)/$(IMAGE)_docs -f docs/Dockerfile.docs .
 
 .PHONY: push_docs
 push_docs:
-	docker push $(REGISTRY)/$(IMAGE)
+	docker push $(REGISTRY)/$(IMAGE)_docs
 
 .PHONY: serve_docs
 serve_docs:
-	docker run -p 8080:8080 --rm -it $(REGISTRY)/$(IMAGE)
+	docker run -p 8080:8080 --rm -it $(REGISTRY)/$(IMAGE)_docs

--- a/poetry.lock
+++ b/poetry.lock
@@ -2071,6 +2071,17 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "pyinstrument"
+version = "4.3.0"
+description = "Call stack profiler for Python. Shows you why your code is slow!"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+jupyter = ["ipython"]
+
+[[package]]
 name = "pymdown-extensions"
 version = "9.3"
 description = "Extension pack for Python Markdown."
@@ -3276,7 +3287,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "21d9953c400000ae0a11d7812cddd26b629d1d65ad1df88612efbf4ca1600e3d"
+content-hash = "25053e8404dc1e79d9aa0317238d8f63d64a1596625c83cffe6b762743f65766"
 
 [metadata.files]
 absl-py = [
@@ -4972,6 +4983,58 @@ pyflakes = [
 pygments = [
     {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
+]
+pyinstrument = [
+    {file = "pyinstrument-4.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a641c1c37dd9259162b76c28b2a846f66d5b2c91825c8eaf536329c127855e01"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4ce24e16d3c4aae641186bd9c2540526642e6b6f181fb41f0fc6ecbe488cb3fb"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0b795db84fa066ff3502695cfe9a15dbda62c2e2ad66c27b6e12c7f96a2ca07"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:425bd0a3d5536d080b3f4b6f31707c9402a736209c9cc2decd930583ef858112"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6672bd073ecfd1304b4908742f447fd005acacd29746d7d31c1413bee9ac453d"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a4d327f47b1a31b306fb4fe6432af1d886c835cdbd980c7c4555beb092685804"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:27a5cbd7dcf0b768f1a8faf82787e9fa358f278f810218633be7e0be1fa4b565"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b7ee1f54109a2da76170cedfcae32c2281179108c02d227250f3b00298b90625"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-win32.whl", hash = "sha256:251b394c03e9de88707e5deffbb62a5792374396db18608e595b6de85ab2345a"},
+    {file = "pyinstrument-4.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:1e33e506a671561c72074324eba62babca7392ab3ed244cec683687eb6984f41"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1a7da205c581a195ffb5c9d7fac2342e31fc47ae993eaa6161973ad87090c077"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a2a3e3e4db917a55b06b520fba940df073ed0b06d1e6ae002a6bf2962d400b1c"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:11450181910c2c7aba2a2cf3f54168a7adc02357e0e75f1d22393294a54b69db"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ff8c38829e2fe0dba8cc02ec58927d8d2cffffb73ae27ab229bf0b687e59785"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9968ad846a359458ba8c04085180962c871d851c3a05647f152ff1c86029d54c"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e785fe9f35a5e782e692bb1eb9fe2a9a94f06f1b9e090402ebd9028ce2effce6"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c943f0a5eefeffe19a31c955b01e96d814b423bcdb739717a30c9de0e469793e"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9925dffaeb7cfc44c164169327c81c854f09478852be289d75790b2df35f02e0"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-win32.whl", hash = "sha256:17ef8c945725c36de6d6c04039ac6d2178985579b1aa1b185d7bda5dc3c36897"},
+    {file = "pyinstrument-4.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:5e5664ad63bae9db89775933d7c4fbfc42c7820506ba86501688a4aade8dda9f"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3ebd661641237c2e7861e288bd2a144934bef06b10adfc9851ffd00d2e75af0e"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5d6967294b91eefdd94035c35981bbffbaa41c96155c3ed3b23788f878f5106"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8fea9898d52d16774b36c62ef100fef1c56da25bcf913e156a2d5c7bc1330cd9"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:372548770c558cd25b8174a06bbac01963dd9cb2479233ae590be61ab40ce0ad"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6ca5d57298307bc81713161b2603a8805bdea1eda93489698d2179a754476e8f"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:0816507fc3284e93b258d8f773e56aea420834d1415f986a3e5482441f78d274"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a0330a6245f997277f93a1d189a16928408794a097d1266bb55128d9964f9071"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-win32.whl", hash = "sha256:829676c816b2fc7475082ab495938ac64ba9e99a311246b5f197528f009657b9"},
+    {file = "pyinstrument-4.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b923df701afd8f42cd8227c654c0c90bd69e5180207c4ea0368930d96e633ed9"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5e5e7fa5ba84cbef2ae1eed17fa3c242988e09922ba5a28fd3edb0e2c6493b61"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:37b3661ae8113286d244595e467088b312285f43b035c07d5328767508b168e2"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378f126edb1c225016cb15eb775d0b9b330c549f62595c30b7298aaa0ee884c4"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb2aa31a68b695623860379ee6aa3242a803fe4bf81304faa70c238101a2b2ad"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:997485418224a34af66f27b1bab364b846321632e0dad8e7b6ed434903bb4b0d"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:eb4db9e18e2e190e4e8833014e28bfaa847c27758d9a355255c92d481845aaaa"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:960c80e48137194f8758519bc5a8296a599994cc32303b765474a6015da6982d"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:12b553cf578fe1c6805529bf25c5e9c72877cb46de6c773c2d4f38626c956f9d"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-win32.whl", hash = "sha256:19ec8ffc2f8fe7466e97dc6e8aac6acc19fa51337432f317685a585694525927"},
+    {file = "pyinstrument-4.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:4db0f0c2ce4616e7312c8eaa869ad377e98ab43f997c2e3fdf15d9ace1aba660"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7d6a06ab1f66d5e4d69804a8efa37e527648c5af9cdaea6a8eff8d6c8514788f"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:128d470628bc3aca03aeb9f3baa63f245f5f53a8fb1f43c6b1e004486c5ceeca"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5d2f0de75234a2dbf46ddad9aa02787f3d0cee24bc62095d113660490c9a0da"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d8e739d8261c478936d39c4f15317ddc10516e03484a5ddd77787486dc4c102e"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cba3ab3da1756820d4fa6ff68b3b0e9728560a6e12b2fc709a9b0b0963648d"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8bb06a4650c7b84c91f227b67f898a5a514eae02df3ce0727e119e87863d9731"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f900c409f8eb5b4446dd6daecfd4f544a0e1ffcc727515e0085028dea9c64f0c"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3a3c3e6161795277544a30b3c298afda2eb58f13be288fcde1f933e6ba603583"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-win32.whl", hash = "sha256:12ca63435e71191c1a135ad28b0480ab0060268b3b16a6f20686919b492d83fd"},
+    {file = "pyinstrument-4.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:99c8dca1dddad2cebee0e96a7d285cad0f28341084c5616bde3fac87f0f38929"},
+    {file = "pyinstrument-4.3.0.tar.gz", hash = "sha256:575c5e2581839a21800194842291e1348edecc6f4c67f8efeef8356588ea4c25"},
 ]
 pymdown-extensions = [
     {file = "pymdown-extensions-9.3.tar.gz", hash = "sha256:a80553b243d3ed2d6c27723bcd64ca9887e560e6f4808baa96f36e93061eaf90"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ isort = "^5.9.3"
 types-simplejson = "^3.17.0"
 types-filelock = "^0.1.5"
 types-orjson = "^3.6.0"
+pyinstrument = "^4.3.0"
 
 # Documentation
 mkdocs = "^1.2.3"

--- a/tests/profiling_debugging.py
+++ b/tests/profiling_debugging.py
@@ -2,7 +2,9 @@
 This file help profiling Module. Change the constants and run the file.
 """
 import tempfile
+import threading
 
+import psutil
 from pyinstrument import Profiler
 from tqdm import tqdm
 
@@ -27,7 +29,13 @@ DEPS_MOD_OPTIONS = ModuleOptions(pipeline_index=0)
 MOD_OPTIONS = ModuleOptions(pipeline_index=0)
 
 
+def print_memory():
+    threading.Timer(2.0, print_memory).start()
+    print(f"Memory used: {psutil.virtual_memory().used / 1024 / 1024}")
+
+
 def main():
+    print_memory()
     config = AzimuthConfig.parse_file(CFG_FILE).copy(
         update={"artifact_path": str(tempfile.mkdtemp())}
     )

--- a/tests/profiling_debugging.py
+++ b/tests/profiling_debugging.py
@@ -3,6 +3,7 @@ This file help profiling Module. Change the constants and run the file.
 """
 import tempfile
 import threading
+import time
 
 import psutil
 from pyinstrument import Profiler
@@ -30,8 +31,12 @@ MOD_OPTIONS = ModuleOptions(pipeline_index=0)
 
 
 def print_memory():
-    threading.Timer(2.0, print_memory).start()
-    print(f"Memory used: {psutil.virtual_memory().used / 1024 / 1024}")
+    def fn():
+        while True:
+            print(f"Memory used: {psutil.virtual_memory().used / 1024 / 1024}")
+            time.sleep(2)
+
+    threading.Thread(target=fn).start()
 
 
 def main():

--- a/tests/profiling_debugging.py
+++ b/tests/profiling_debugging.py
@@ -43,9 +43,13 @@ def main():
     print("Starting profiler!")
     with Profiler() as p:
         mod = MODULE(dataset_split_name=DATASET_SPLIT, config=config, mod_options=MOD_OPTIONS)
-        mod.compute_on_dataset_split()
+        res = mod.compute_on_dataset_split()
 
-    p.print()
+    file_name = "logs.txt"
+    with open(file_name, "w") as f:
+        p.print(file=f)
+
+    print(res)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils/test_dataset_filtering.py
+++ b/tests/test_utils/test_dataset_filtering.py
@@ -15,7 +15,7 @@ from azimuth.types.tag import (
     SmartTag,
     SmartTagFamily,
 )
-from azimuth.utils.filtering import filter_dataset_split
+from azimuth.utils.dataset_operations import filter_dataset_split
 from tests.utils import generate_mocked_dm, get_table_key
 
 


### PR DESCRIPTION
Resolve #243 

## Description:
On clinc, it takes from 75 sec to 14 sec with the new method which reduces the amount of filtering.  The main changes are modifying metric and bin modules so their methods can directly receive the filtered dataset, instead of going through filters in module options.
[log_less_filtering.txt](https://github.com/ServiceNow/azimuth/files/9612833/log_less_filtering.txt)
[log.txt](https://github.com/ServiceNow/azimuth/files/9612834/log.txt)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
