### PR TITLE
Fix bug with empty HF filtering

### DIFF
--- a/azimuth/utils/dataset_operations.py
+++ b/azimuth/utils/dataset_operations.py
@@ -50,12 +50,20 @@ def filter_dataset_split(
                 <= x[confidence_column][0]
                 <= filters.confidence_max
             )
-    if len(filters.label) > 0 and config.columns.label in dataset_split.column_names:
+    if (
+        len(filters.label) > 0
+        and config.columns.label in dataset_split.column_names
+        and dataset_split.num_rows != 0
+    ):
         dataset_split = dataset_split.filter(lambda x: x[config.columns.label] in filters.label)
-    if filters.utterance is not None and config.columns.text_input in dataset_split.column_names:
+    if (
+        filters.utterance is not None
+        and config.columns.text_input in dataset_split.column_names
+        and dataset_split.num_rows != 0
+    ):
         by = filters.utterance.lower()
         dataset_split = dataset_split.filter(lambda x: by in x[config.columns.text_input].lower())
-    if len(filters.prediction) > 0:
+    if len(filters.prediction) > 0 and dataset_split.num_rows != 0:
         prediction_column = (
             DatasetColumn.model_predictions
             if without_postprocessing
@@ -70,7 +78,7 @@ def filter_dataset_split(
                 dataset_split = dataset_split.filter(
                     lambda x: x[DatasetColumn.postprocessed_prediction] in filters.prediction
                 )
-    if len(filters.data_action) > 0:
+    if len(filters.data_action) > 0 and dataset_split.num_rows != 0:
         # We do OR for data_action tags.
         dataset_split = dataset_split.filter(
             lambda x: any(
@@ -78,7 +86,7 @@ def filter_dataset_split(
                 for v in filters.data_action
             )
         )
-    if len(filters.outcome) > 0:
+    if len(filters.outcome) > 0 and dataset_split.num_rows != 0:
         outcome_column = (
             DatasetColumn.model_outcome
             if without_postprocessing
@@ -91,8 +99,10 @@ def filter_dataset_split(
         # For each smart tag family, we do OR, but AND between families
         # If NO_SMART_TAGS, it is none of them.
         family = cast(SmartTagFamily, key)
-        if len(tags_in_family) > 0 and all(
-            tag in dataset_split.column_names for tag in SMART_TAGS_FAMILY_MAPPING[family]
+        if (
+            len(tags_in_family) > 0
+            and all(tag in dataset_split.column_names for tag in SMART_TAGS_FAMILY_MAPPING[family])
+            and dataset_split.num_rows != 0
         ):
             dataset_split = dataset_split.filter(
                 lambda x: any(

--- a/tests/test_routers/test_model_performance/test_outcome_count.py
+++ b/tests/test_routers/test_model_performance/test_outcome_count.py
@@ -24,3 +24,14 @@ def test_get_outcome_count_per_filter(app: FastAPI) -> None:
     data = resp.json()
     metrics = data.pop("countPerFilter")
     assert "label" in metrics and len(metrics["label"]) == 3
+
+
+def test_empty_search_with_filters(app: FastAPI):
+    client = TestClient(app)
+    resp = client.get("/dataset_splits/eval/outcome_count?utterance=rrgeth").json()
+    assert len(resp["utterances"]) == 0
+
+    resp = client.get(
+        "/dataset_splits/eval/outcome_count?utterance=rrgeth&data_action=relabel"
+    ).json()
+    assert len(resp["utterances"]) == 0

--- a/tests/test_routers/test_model_performance/test_outcome_count.py
+++ b/tests/test_routers/test_model_performance/test_outcome_count.py
@@ -35,7 +35,7 @@ def test_outcome_count_empty_filters(app: FastAPI):
     data = resp.json()
     assert data["utteranceCount"] == 0
 
-# This used to fail when we were filtering on an empty dataset
+    # This used to fail when we were filtering on an empty dataset
     resp = client.get(
         "/dataset_splits/eval/outcome_count/per_filter"
         "?pipeline_index=0&utterance=yukongold&data_action=relabel"

--- a/tests/test_routers/test_model_performance/test_outcome_count.py
+++ b/tests/test_routers/test_model_performance/test_outcome_count.py
@@ -29,15 +29,16 @@ def test_get_outcome_count_per_filter(app: FastAPI) -> None:
 def test_outcome_count_empty_filters(app: FastAPI):
     client = TestClient(app)
     resp = client.get(
-        "/dataset_splits/eval/outcome_count/per_filter?pipeline_index=0&utterance=rrgeth"
+        "/dataset_splits/eval/outcome_count/per_filter?pipeline_index=0&utterance=yukongold"
     )
     assert resp.status_code == HTTP_200_OK, resp.text
     data = resp.json()
     assert data["utteranceCount"] == 0
 
+# This used to fail when we were filtering on an empty dataset
     resp = client.get(
         "/dataset_splits/eval/outcome_count/per_filter"
-        "?pipeline_index=0&utterance=rrgeth&data_action=relabel"
+        "?pipeline_index=0&utterance=yukongold&data_action=relabel"
     )
     assert resp.status_code == HTTP_200_OK, resp.text
     data = resp.json()

--- a/tests/test_routers/test_model_performance/test_outcome_count.py
+++ b/tests/test_routers/test_model_performance/test_outcome_count.py
@@ -26,12 +26,19 @@ def test_get_outcome_count_per_filter(app: FastAPI) -> None:
     assert "label" in metrics and len(metrics["label"]) == 3
 
 
-def test_empty_search_with_filters(app: FastAPI):
+def test_outcome_count_empty_filters(app: FastAPI):
     client = TestClient(app)
-    resp = client.get("/dataset_splits/eval/outcome_count?utterance=rrgeth").json()
-    assert len(resp["utterances"]) == 0
+    resp = client.get(
+        "/dataset_splits/eval/outcome_count/per_filter?pipeline_index=0&utterance=rrgeth"
+    )
+    assert resp.status_code == HTTP_200_OK, resp.text
+    data = resp.json()
+    assert data["utteranceCount"] == 0
 
     resp = client.get(
-        "/dataset_splits/eval/outcome_count?utterance=rrgeth&data_action=relabel"
-    ).json()
-    assert len(resp["utterances"]) == 0
+        "/dataset_splits/eval/outcome_count/per_filter"
+        "?pipeline_index=0&utterance=rrgeth&data_action=relabel"
+    )
+    assert resp.status_code == HTTP_200_OK, resp.text
+    data = resp.json()
+    assert data["utteranceCount"] == 0

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -80,7 +80,9 @@ def test_get_utterances_empty_filters(app: FastAPI):
     assert len(resp["utterances"]) == 0
 
     # This used to fail when we were filtering on an empty dataset
-    resp = client.get("/dataset_splits/eval/utterances?utterance=yukongold&data_action=relabel").json()
+    resp = client.get(
+        "/dataset_splits/eval/utterances?utterance=yukongold&data_action=relabel"
+    ).json()
     assert len(resp["utterances"]) == 0
 
 

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -74,6 +74,15 @@ def test_get_utterances(app: FastAPI, monkeypatch):
     assert len(first_utterance["modelSaliency"]) == 2
 
 
+def test_empty_search_with_filters(app: FastAPI):
+    client = TestClient(app)
+    resp = client.get("/dataset_splits/eval/utterances?utterance=rrgeth").json()
+    assert len(resp["utterances"]) == 0
+
+    resp = client.get("/dataset_splits/eval/utterances?utterance=rrgeth&data_action=relabel").json()
+    assert len(resp["utterances"]) == 0
+
+
 def test_get_utterances_no_pipeline(app: FastAPI, monkeypatch):
     import azimuth.routers.v1.utterances as utt_module
 

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -74,7 +74,7 @@ def test_get_utterances(app: FastAPI, monkeypatch):
     assert len(first_utterance["modelSaliency"]) == 2
 
 
-def test_empty_search_with_filters(app: FastAPI):
+def test_get_utterances_empty_filters(app: FastAPI):
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances?utterance=rrgeth").json()
     assert len(resp["utterances"]) == 0

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -79,7 +79,7 @@ def test_get_utterances_empty_filters(app: FastAPI):
     resp = client.get("/dataset_splits/eval/utterances?utterance=yukongold").json()
     assert len(resp["utterances"]) == 0
 
-# This used to fail when we were filtering on an empty dataset
+    # This used to fail when we were filtering on an empty dataset
     resp = client.get("/dataset_splits/eval/utterances?utterance=yukongold&data_action=relabel").json()
     assert len(resp["utterances"]) == 0
 

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -76,10 +76,11 @@ def test_get_utterances(app: FastAPI, monkeypatch):
 
 def test_get_utterances_empty_filters(app: FastAPI):
     client = TestClient(app)
-    resp = client.get("/dataset_splits/eval/utterances?utterance=rrgeth").json()
+    resp = client.get("/dataset_splits/eval/utterances?utterance=yukongold").json()
     assert len(resp["utterances"]) == 0
 
-    resp = client.get("/dataset_splits/eval/utterances?utterance=rrgeth&data_action=relabel").json()
+# This used to fail when we were filtering on an empty dataset
+    resp = client.get("/dataset_splits/eval/utterances?utterance=yukongold&data_action=relabel").json()
     assert len(resp["utterances"]) == 0
 
 


### PR DESCRIPTION
Resolve #264 

## Description:
- Added 2 new tests which used to fail
- Added check that the dataset is not empty at each filtering `if`. This fixes the issue and also makes the function more efficient. 
- I submitted an issue on HF so they can fix the issue: https://github.com/huggingface/datasets/issues/5085

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
