### PR TITLE
Read model from cache if offline

### DIFF
--- a/azimuth/modules/dataset_analysis/similarity_analysis.py
+++ b/azimuth/modules/dataset_analysis/similarity_analysis.py
@@ -2,6 +2,7 @@
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
 import itertools
+import os
 from collections import defaultdict
 from os.path import join as pjoin
 from typing import Dict, List, Optional, Tuple
@@ -40,7 +41,13 @@ class FAISSModule(IndexableModule[SimilarityConfig]):
     def get_model(self):
         if self.encoder is None:
             with FileLock(pjoin(self.cache_dir, "st.lock")):
-                self.encoder = SentenceTransformer(self.config.similarity.faiss_encoder)
+                model = self.config.similarity.faiss_encoder
+                if os.environ.get("TRANSFORMERS_OFFLINE"):
+                    model = os.path.join(
+                        os.environ.get("SENTENCE_TRANSFORMERS_HOME"),
+                        f"sentence-transformers_{model}",
+                    )
+                self.encoder = SentenceTransformer(model)
         return self.encoder
 
     def compute_on_dataset_split(self) -> List[FAISSResponse]:  # type: ignore


### PR DESCRIPTION
## Description:

Loading the sentence transformer currently fails without Internet access. Here is a simple workaround that uses sentence-transformers' own environment variables. I don't understand why it doesn't already work like that, so I opened a ticket on their end: https://github.com/UKPLab/sentence-transformers/issues/1725.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
