### PR TITLE
Nandhini/performance analysis table additional change

### DIFF
--- a/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
@@ -191,6 +191,14 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
     selectedMetricPerFilterOption,
   ]);
 
+  const fieldWithTooltip = (tooltip: string, label: string) => (
+    <Tooltip title={tooltip}>
+      <Typography variant="caption" fontSize={14}>
+        {label}
+      </Typography>
+    </Tooltip>
+  );
+
   const columns = React.useMemo((): Column<Row>[] => {
     const metricsEntries = Object.entries(metricInfo ?? {});
 
@@ -350,14 +358,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
           ...pipelines.map<Column<Row>>((pipeline) => ({
             ...METRIC_COLUMN,
             field: `${pipeline}${metricName}`,
-            ...groupHeader(
-              pipeline,
-              <Tooltip title={description}>
-                <Typography variant="caption" fontSize={14}>
-                  {metricName}
-                </Typography>
-              </Tooltip>
-            ),
+            ...groupHeader(pipeline, fieldWithTooltip(description, metricName)),
             valueGetter: ({ row: { [pipeline]: metrics } }) =>
               metrics ? metrics.customMetrics[metricName] ?? NaN : undefined,
             renderCell: ({ value }: GridCellParams<number | undefined>) =>
@@ -393,14 +394,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
       ...pipelines.map<Column<Row>>((pipeline) => ({
         ...METRIC_COLUMN,
         field: `${pipeline}ECE`,
-        ...groupHeader(
-          pipeline,
-          <Tooltip title={ECE_TOOLTIP}>
-            <Typography variant="caption" fontSize={14}>
-              ECE
-            </Typography>
-          </Tooltip>
-        ),
+        ...groupHeader(pipeline, fieldWithTooltip(ECE_TOOLTIP, "ECE")),
         valueGetter: ({ row }) => row[pipeline]?.ece,
         renderCell: ({ value }: GridCellParams<number | undefined>) =>
           value !== undefined && (
@@ -437,8 +431,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
   ]);
 
   React.useEffect(() => {
-    config &&
-      config.pipelines &&
+    config?.pipelines &&
       config.pipelines.length > 1 &&
       config.pipelines.map(
         (_, index) =>

--- a/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
@@ -111,9 +111,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
 
   const { data: config } = getConfigEndpoint.useQuery({ jobId });
 
-  const [comparedPipeline, setComparedPipeline] = React.useState<
-    number | undefined
-  >(
+  const [comparedPipeline, setComparedPipeline] = React.useState(
     config?.pipelines && config.pipelines.length > 1
       ? (pipeline.pipelineIndex + 1) % config.pipelines.length
       : undefined
@@ -195,9 +193,9 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
     selectedMetricPerFilterOption,
   ]);
 
-  const reactNodeWithTooltip = (tooltip: string, nodeText: string) => (
+  const typographyWithTooltip = (tooltip: string, typography: string) => (
     <Tooltip title={tooltip}>
-      <Typography variant="inherit">{nodeText}</Typography>
+      <Typography variant="inherit">{typography}</Typography>
     </Tooltip>
   );
 
@@ -362,7 +360,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
             field: `${pipeline}${metricName}`,
             ...groupHeader(
               pipeline,
-              reactNodeWithTooltip(description, metricName)
+              typographyWithTooltip(description, metricName)
             ),
             valueGetter: ({ row: { [pipeline]: metrics } }) =>
               metrics ? metrics.customMetrics[metricName] ?? NaN : undefined,
@@ -399,7 +397,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
       ...pipelines.map<Column<Row>>((pipeline) => ({
         ...METRIC_COLUMN,
         field: `${pipeline}ECE`,
-        ...groupHeader(pipeline, reactNodeWithTooltip(ECE_TOOLTIP, "ECE")),
+        ...groupHeader(pipeline, typographyWithTooltip(ECE_TOOLTIP, "ECE")),
         valueGetter: ({ row }) => row[pipeline]?.ece,
         renderCell: ({ value }: GridCellParams<number | undefined>) =>
           value !== undefined && (

--- a/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
@@ -437,6 +437,13 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
   ]);
 
   React.useEffect(() => {
+    config &&
+      config.pipelines &&
+      config.pipelines.length > 1 &&
+      config.pipelines.map(
+        (_, index) =>
+          index !== pipeline.pipelineIndex && setComparedPipeline(index)
+      );
     if (comparedPipeline === pipeline.pipelineIndex) {
       setComparedPipeline(undefined);
     }
@@ -554,7 +561,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
             onChange={setSelectedDatasetSplit}
           />
         </Box>
-        {config && (
+        {config?.pipelines && config.pipelines?.length > 1 && (
           <Box display="flex" flexDirection="row" alignItems="center">
             <FormControlLabel
               label={`Compare Baseline (${

--- a/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
@@ -5,6 +5,7 @@ import {
   MenuItem,
   Paper,
   Select,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import {
@@ -147,7 +148,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
 
   // Track table sort model to keep 'overall' at top.
   const [sortModel, setSortModel] = React.useState<GridSortModel>([
-    { field: "utteranceCount", sort: "desc" },
+    { field: "basePipelineUtteranceCount", sort: "desc" },
   ]);
   // We must redefine columns when selectedMetricPerFilterOption changes.
   // The Table then loses any uncontrolled (internal) states. So, we must
@@ -253,6 +254,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
                         display="flex"
                         alignItems="center"
                         justifyContent="center"
+                        zIndex="tooltip"
                         gap={1}
                       >
                         {longHeader}
@@ -348,8 +350,14 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
           ...pipelines.map<Column<Row>>((pipeline) => ({
             ...METRIC_COLUMN,
             field: `${pipeline}${metricName}`,
-            description,
-            ...groupHeader(pipeline, metricName),
+            ...groupHeader(
+              pipeline,
+              <Tooltip title={description}>
+                <Typography variant="caption" fontSize={14}>
+                  {metricName}
+                </Typography>
+              </Tooltip>
+            ),
             valueGetter: ({ row: { [pipeline]: metrics } }) =>
               metrics ? metrics.customMetrics[metricName] ?? NaN : undefined,
             renderCell: ({ value }: GridCellParams<number | undefined>) =>
@@ -385,8 +393,14 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
       ...pipelines.map<Column<Row>>((pipeline) => ({
         ...METRIC_COLUMN,
         field: `${pipeline}ECE`,
-        ...groupHeader(pipeline, "ECE"),
-        description: ECE_TOOLTIP,
+        ...groupHeader(
+          pipeline,
+          <Tooltip title={ECE_TOOLTIP}>
+            <Typography variant="caption" fontSize={14}>
+              ECE
+            </Typography>
+          </Tooltip>
+        ),
         valueGetter: ({ row }) => row[pipeline]?.ece,
         renderCell: ({ value }: GridCellParams<number | undefined>) =>
           value !== undefined && (

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -103,10 +103,9 @@ const Dashboard = () => {
           title="Pipeline Metrics by Data Subpopulation"
           to={`/${jobId}/pipeline_metrics${searchString}`}
           linkButtonText={
-            (config?.pipelines &&
-              config?.pipelines?.length > 1 &&
-              "Compare pipelines") ||
-            undefined
+            config?.pipelines && config.pipelines.length > 1
+              ? "Compare pipelines"
+              : undefined
           }
           description={performanceAnalysisDescription}
         >

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -13,7 +13,7 @@ import ThresholdPlot from "components/ThresholdPlot";
 import useQueryState from "hooks/useQueryState";
 import React from "react";
 import { Link, useParams } from "react-router-dom";
-import { getDatasetInfoEndpoint } from "services/api";
+import { getConfigEndpoint, getDatasetInfoEndpoint } from "services/api";
 import { isPipelineSelected } from "utils/helpers";
 import { classAnalysisDescription } from "./ClassAnalysis";
 import { performanceAnalysisDescription } from "./PerformanceAnalysis";
@@ -26,6 +26,8 @@ const DEFAULT_PREVIEW_CONTENT_HEIGHT = 502;
 const Dashboard = () => {
   const { jobId } = useParams<{ jobId: string }>();
   const { pipeline, searchString } = useQueryState();
+
+  const { data: config } = getConfigEndpoint.useQuery({ jobId });
 
   const {
     data: datasetInfo,
@@ -100,7 +102,12 @@ const Dashboard = () => {
         <PreviewCard
           title="Pipeline Metrics by Data Subpopulation"
           to={`/${jobId}/pipeline_metrics${searchString}`}
-          linkButtonText="Compare pipelines"
+          linkButtonText={
+            (config?.pipelines &&
+              config?.pipelines?.length > 1 &&
+              "Compare pipelines") ||
+            undefined
+          }
           description={performanceAnalysisDescription}
         >
           <PerformanceAnalysis


### PR DESCRIPTION
Resolve #

## Description:
1. Added "desc" icon to Utterance Count to enable desc by default.

2. Added the tooltip for custom metric columns and ECE.

3. When there is only one pipeline configured...

The "Compare Pipelines" button on the dashboard is instead called "View details" and is still linking to the standalone page.
The "Compare Baseline with" select menu is hidden.

The "Compare Baseline with" select menu has a default value of the first available pipeline.
## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
