### PR TITLE
Add ability to specify F-E and B-E ports

### DIFF
--- a/makefiles/Makefile.local
+++ b/makefiles/Makefile.local
@@ -1,6 +1,7 @@
 
 config_folder = "local_configs"
 pwd := $(shell pwd)
+export PORT := 8091
 
 define UPDATE_CONFIG_PYSCRIPT
 from collections.abc import Sequence
@@ -50,7 +51,7 @@ local_configs:
 
 .PHONY: launch.local
 launch.local:
-	poetry run python runner.py ${CFG_PATH}
+	poetry run python runner.py ${CFG_PATH} --port ${PORT}
 
 .PHONY: clean
 clean:

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -26,7 +26,7 @@
     "react-toastify": "^7.0.4"
   },
   "scripts": {
-    "start": "PORT=3005 react-app-rewired start",
+    "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test --coverage",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Resolve # NA

Make it easier to simultaneously run multiple instances of Azimuth locally by passing port numbers in back-end and front-end commands.

## Description:

Launch back-end with:
```
make CFG=<path_to_config> PORT=<backend_port_number> launch.local
```
(where PORT is optional)

Launch front-end with:
```
REACT_APP_BACKEND_PORT=<backend_port_number> PORT=<frontend_port_number> yarn start 
```
(where both PORT variables are optional, and `backend_port_number` should match the one for the back-end 🙃)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [ ] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [ ] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
