### PR TITLE
Fix pipeline confusion in class overlap

### DIFF
--- a/azimuth/routers/v1/class_overlap.py
+++ b/azimuth/routers/v1/class_overlap.py
@@ -123,7 +123,9 @@ def get_class_analysis(
             SupportedModule.ConfusionMatrix,
             DatasetSplitName.eval,
             task_manager=task_manager,
-            mod_options=ModuleOptions(pipeline_index=pipeline_index, cf_normalized=False),
+            mod_options=ModuleOptions(
+                pipeline_index=pipeline_index, cf_normalized=False, cf_reorder_classes=False
+            ),
             last_update=dataset_split_managers[DatasetSplitName.eval].last_update,
         )[0]
         if pipeline_index is not None

--- a/azimuth/routers/v1/class_overlap.py
+++ b/azimuth/routers/v1/class_overlap.py
@@ -124,7 +124,7 @@ def get_class_analysis(
             DatasetSplitName.eval,
             task_manager=task_manager,
             mod_options=ModuleOptions(
-                pipeline_index=pipeline_index, cf_normalized=False, cf_reorder_classes=False
+                pipeline_index=pipeline_index, cf_normalize=False, cf_reorder_classes=False
             ),
             last_update=dataset_split_managers[DatasetSplitName.eval].last_update,
         )[0]

--- a/tests/test_routers/test_class_analysis.py
+++ b/tests/test_routers/test_class_analysis.py
@@ -25,32 +25,52 @@ def test_class_analysis_route(app: FastAPI) -> None:
     assert resp_no_pipeline.status_code == HTTP_200_OK, resp_no_pipeline.text
     data_no_pipeline = resp_no_pipeline.json()
 
+    assert data_no_pipeline == {
+        "classPairs": [
+            {
+                "sourceClass": "negative",
+                "targetClass": "positive",
+                "overlapScoreTrain": 0.22608695652173913,
+                "pipelineConfusionEval": None,
+                "utteranceCountSourceTrain": 23,
+                "utteranceCountSourceEval": 22,
+                "utteranceCountWithOverlapTrain": 16,
+            },
+            {
+                "sourceClass": "positive",
+                "targetClass": "negative",
+                "overlapScoreTrain": 0.4421052631578947,
+                "pipelineConfusionEval": None,
+                "utteranceCountSourceTrain": 19,
+                "utteranceCountSourceEval": 20,
+                "utteranceCountWithOverlapTrain": 16,
+            },
+        ]
+    }
+
     resp_pipeline_0 = client.get("/class_analysis?pipeline_index=0")
     assert resp_pipeline_0.status_code == HTTP_200_OK, resp_pipeline_0.text
     data_pipeline_0 = resp_pipeline_0.json()
 
-    assert set(data_no_pipeline["classPairs"][0].keys()) == {
-        "sourceClass",
-        "targetClass",
-        "overlapScoreTrain",
-        "pipelineConfusionEval",
-        "utteranceCountSourceTrain",
-        "utteranceCountSourceEval",
-        "utteranceCountWithOverlapTrain",
+    assert data_pipeline_0 == {
+        "classPairs": [
+            {
+                "sourceClass": "negative",
+                "targetClass": "positive",
+                "overlapScoreTrain": 0.22608695652173913,
+                "pipelineConfusionEval": 3,
+                "utteranceCountSourceTrain": 23,
+                "utteranceCountSourceEval": 22,
+                "utteranceCountWithOverlapTrain": 16,
+            },
+            {
+                "sourceClass": "positive",
+                "targetClass": "negative",
+                "overlapScoreTrain": 0.4421052631578947,
+                "pipelineConfusionEval": 1,
+                "utteranceCountSourceTrain": 19,
+                "utteranceCountSourceEval": 20,
+                "utteranceCountWithOverlapTrain": 16,
+            },
+        ]
     }
-    assert (
-        data_no_pipeline["classPairs"][0]["sourceClass"]
-        != data_pipeline_0["classPairs"][0]["targetClass"]
-    ), "Table should not contain rows where class A == class B."
-    assert isinstance(
-        data_no_pipeline["classPairs"][0]["overlapScoreTrain"], float
-    ), "Overlap score should exist as a float."
-    assert isinstance(
-        data_no_pipeline["classPairs"][0]["utteranceCountSourceTrain"], int
-    ), "Sample count should be an integer."
-    assert (
-        data_no_pipeline["classPairs"][0]["pipelineConfusionEval"] is None
-    ), "There should not be a confusion value when no pipeline is not supplied."
-    assert isinstance(
-        data_pipeline_0["classPairs"][0]["pipelineConfusionEval"], int
-    ), "Data should have confusion values when a pipeline is supplied."


### PR DESCRIPTION
Resolve #303 

## Description: 
- Pipeline confusion in class overlap wasn't working for 2 reasons: 
   - A change was done in the confusion matrix module where classes were now re-ordered by "cluster", by default. The class overlap route code counts on the confusion matrix being ordered by the dataset class order. However, it turns out that this bug was hidden by this second bug.
   - There was a typo in the module options sent to the confusion matrix. `cf_normalized=False` instead of `cf_normalize=False`. This resulted in the confusion matrix being normalized, and so all pipeline confusion scores were 0 or 100% (because the normalized confusion was converted to an `int`). 
  
I added a new issue in our repo so we can be more robust to that second bug: #305 

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
