### PR TITLE
Make overlap threshold input more user friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Released changes are shown in the
 
 ### Changed
 - The default port for the front end will now be 3000, the React default, instead of 3005.
+- Improved class overlap threshold number picker.
+  - Control input value with a `string` instead of with a `number` so for example when hitting backspace after `0.01`, you get `0.0` instead of `0` (as maybe you wanted to type `2` and get `0.02`).
+  - Debounce number picker to reduce calls to back end.
 
 ### Deprecated/Breaking Changes
 

--- a/webapp/src/components/Controls/FilterTextField.tsx
+++ b/webapp/src/components/Controls/FilterTextField.tsx
@@ -1,7 +1,6 @@
 import { Clear, Search } from "@mui/icons-material";
 import {
   Box,
-  debounce,
   IconButton,
   Input,
   InputAdornment,

--- a/webapp/src/components/Controls/FilterTextField.tsx
+++ b/webapp/src/components/Controls/FilterTextField.tsx
@@ -26,18 +26,16 @@ const FilterTextField: React.FC<Props> = ({
 
   React.useEffect(() => setLiveValue(filterValue), [filterValue]);
 
-  const setFilterValueDebounced = useDebounced(setFilterValue);
+  const commitFilterValue = useDebounced(setFilterValue);
 
   const handleChange = (value: string | undefined) => {
     setLiveValue(value);
-    setFilterValueDebounced(value);
+    commitFilterValue.debounce(value);
   };
 
   const handleClear = () => {
     setLiveValue(undefined);
-    // Clear filter value with no delay.
-    setFilterValue(undefined);
-    setFilterValueDebounced.clear();
+    commitFilterValue.now(undefined);
   };
 
   return (

--- a/webapp/src/components/Controls/FilterTextField.tsx
+++ b/webapp/src/components/Controls/FilterTextField.tsx
@@ -7,6 +7,7 @@ import {
   InputAdornment,
   Typography,
 } from "@mui/material";
+import useDebounced from "hooks/useDebounced";
 import React from "react";
 
 type Props = {
@@ -26,19 +27,9 @@ const FilterTextField: React.FC<Props> = ({
 
   React.useEffect(() => setLiveValue(filterValue), [filterValue]);
 
-  const setFilterValueDebounced = React.useMemo(
-    () => debounce(setFilterValue, 500),
-    [setFilterValue]
-  );
+  const setFilterValueDebounced = useDebounced(setFilterValue);
 
-  // Cancel debounced execution when the component unmounts,
-  // for example when navigating to Dashboard while continuously typing.
-  React.useEffect(
-    () => setFilterValueDebounced.clear,
-    [setFilterValueDebounced]
-  );
-
-  const handleChange = (value?: string) => {
+  const handleChange = (value: string | undefined) => {
     setLiveValue(value);
     setFilterValueDebounced(value);
   };

--- a/webapp/src/components/Metrics/Metric.tsx
+++ b/webapp/src/components/Metrics/Metric.tsx
@@ -38,10 +38,11 @@ const Metric: React.FC<Props> = ({
 }) => {
   const classes = useStyles();
 
-  const tooltip = description
-    .trim()
-    .split("\n")
-    .map((paragraph) => <Typography variant="inherit">{paragraph}</Typography>);
+  const tooltip = (
+    <Typography variant="inherit" whiteSpace="pre-wrap">
+      {description.trim()}
+    </Typography>
+  );
 
   return (
     <Box display="flex" justifyContent="flex-end">

--- a/webapp/src/components/PlotWrapper.tsx
+++ b/webapp/src/components/PlotWrapper.tsx
@@ -1,11 +1,11 @@
 import { Warning } from "@mui/icons-material";
 import { Box, MenuItem, Select } from "@mui/material";
 import _ from "lodash";
-import React, { useEffect, useRef, useState } from "react";
+import React, { memo, useEffect, useRef, useState } from "react";
 import Plot, { PlotParams } from "react-plotly.js";
 import { DatasetWarning } from "types/api";
 
-export const ResponsivePlotWrapper: React.FC<PlotParams> = (props) => {
+export const ResponsivePlotWrapper: React.FC<PlotParams> = memo((props) => {
   const ref = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
@@ -32,29 +32,31 @@ export const ResponsivePlotWrapper: React.FC<PlotParams> = (props) => {
       <PlotWrapper {...props} layout={{ ...props.layout, width }} />
     </Box>
   );
-};
+});
 
-export const PlotWrapper: React.FC<PlotParams> = (props) => {
+export const PlotWrapper: React.FC<PlotParams> = memo((props) => {
   // Because of the plotly library mutating the passed props, we have to clone the props here
   // because on rerendered they would not match the object plotly is now using
   // https://github.com/plotly/react-plotly.js/issues/43
   const clone = _.cloneDeep(props);
 
   return <Plot {...clone} config={{ displayModeBar: false }} />;
-};
+});
 
 type Props = {
   component?: typeof PlotWrapper | typeof ResponsivePlotWrapper;
   warning: DatasetWarning;
 };
 
-export const WarningPlot: React.FC<Props> = ({
-  component: Component = PlotWrapper,
-  warning: {
-    plots: { overall, perClass },
-    comparisons,
-  },
-}) => {
+export const WarningPlot: React.FC<Props> = memo((props) => {
+  const {
+    component: Component = PlotWrapper,
+    warning: {
+      plots: { overall, perClass },
+      comparisons,
+    },
+  } = props;
+
   const [view, setView] = React.useState("");
 
   return (
@@ -84,4 +86,4 @@ export const WarningPlot: React.FC<Props> = ({
       )}
     </Box>
   );
-};
+});

--- a/webapp/src/hooks/useDebounced.ts
+++ b/webapp/src/hooks/useDebounced.ts
@@ -1,0 +1,15 @@
+import { debounce } from "@mui/material";
+import React from "react";
+
+export default function useDebounced<T extends (...args: any[]) => any>(
+  func: T,
+  ms: number = 500
+) {
+  const setQueryDebounced = React.useMemo(() => debounce(func, ms), [func, ms]);
+
+  // Cancel debounced execution when the component unmounts,
+  // for example when navigating to another page while continuously typing.
+  React.useEffect(() => setQueryDebounced.clear, [setQueryDebounced]);
+
+  return setQueryDebounced;
+}

--- a/webapp/src/hooks/useDebounced.ts
+++ b/webapp/src/hooks/useDebounced.ts
@@ -5,11 +5,16 @@ export default function useDebounced<T extends (...args: any[]) => any>(
   func: T,
   ms: number = 500
 ) {
-  const setQueryDebounced = React.useMemo(() => debounce(func, ms), [func, ms]);
+  const debouncedFunc = React.useMemo(() => debounce(func, ms), [func, ms]);
 
   // Cancel debounced execution when the component unmounts,
   // for example when navigating to another page while continuously typing.
-  React.useEffect(() => setQueryDebounced.clear, [setQueryDebounced]);
+  React.useEffect(() => debouncedFunc.clear, [debouncedFunc]);
 
-  return setQueryDebounced;
+  const now = ((...args) => {
+    debouncedFunc.clear();
+    return func(...args);
+  }) as T;
+
+  return { debounce: debouncedFunc, now };
 }

--- a/webapp/src/pages/ClassAnalysis.tsx
+++ b/webapp/src/pages/ClassAnalysis.tsx
@@ -62,7 +62,9 @@ const ClassOverlap = () => {
     [history, jobId, pipeline, classOverlap]
   );
 
-  const setQueryDebounced = useDebounced(setQuery);
+  const commitOverlapThreshold = useDebounced(
+    (overlapThreshold: number | undefined) => setQuery({ overlapThreshold })
+  );
 
   const checkValid = data?.plot.data[0].node.x.length > 0;
 
@@ -202,8 +204,7 @@ const ClassOverlap = () => {
                   }}
                   onChangeCommitted={(_, value) => {
                     if (value !== classOverlap?.overlapThreshold) {
-                      setQuery({ overlapThreshold: value as number });
-                      setQueryDebounced.clear();
+                      commitOverlapThreshold.now(value as number);
                     }
                   }}
                 />
@@ -214,7 +215,7 @@ const ClassOverlap = () => {
                   inputProps={OVERLAP_THRESHOLD_INPUT_PROPS}
                   onChange={({ target: { value } }) => {
                     setOverlapThreshold(value);
-                    setQueryDebounced({ overlapThreshold: Number(value) });
+                    commitOverlapThreshold.debounce(Number(value));
                   }}
                 />
                 <Tooltip title="Reset threshold" arrow>
@@ -225,8 +226,7 @@ const ClassOverlap = () => {
                       disabled={classOverlap.overlapThreshold === undefined}
                       onClick={() => {
                         setOverlapThreshold(undefined);
-                        setQuery({ overlapThreshold: undefined });
-                        setQueryDebounced.clear();
+                        commitOverlapThreshold.now(undefined);
                       }}
                     >
                       <RestartAltIcon fontSize="large" />

--- a/webapp/src/pages/ClassAnalysis.tsx
+++ b/webapp/src/pages/ClassAnalysis.tsx
@@ -41,8 +41,12 @@ const ClassOverlap = () => {
     ...classOverlap,
   });
 
+  // Control overlap threshold with a `string` (and not with a `number`) so for
+  // example when hitting backspace after `0.01`, you get `0.0` (and not `0`).
   const [overlapThreshold, setOverlapThreshold] = React.useState(
-    classOverlap.overlapThreshold
+    classOverlap.overlapThreshold === undefined
+      ? undefined
+      : String(classOverlap.overlapThreshold)
   );
 
   const setQuery = (newClassOverlap: QueryClassOverlapState) =>
@@ -182,10 +186,12 @@ const ClassOverlap = () => {
                     "& .MuiSlider-track": { border: "none" }, // compensate bug with track="inverted"
                   }}
                   {...OVERLAP_THRESHOLD_INPUT_PROPS}
-                  value={overlapThreshold ?? data.defaultOverlapThreshold}
+                  value={Number(
+                    overlapThreshold ?? data.defaultOverlapThreshold
+                  )}
                   onChange={(_, value) => {
-                    if (value !== overlapThreshold) {
-                      setOverlapThreshold(value as number);
+                    if (value !== Number(overlapThreshold)) {
+                      setOverlapThreshold(String(value));
                     }
                   }}
                   onChangeCommitted={(_, value) => {

--- a/webapp/src/pages/ClassAnalysis.tsx
+++ b/webapp/src/pages/ClassAnalysis.tsx
@@ -1,7 +1,6 @@
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import {
   Box,
-  debounce,
   FormControlLabel,
   FormGroup,
   IconButton,

--- a/webapp/src/pages/ClassAnalysis.tsx
+++ b/webapp/src/pages/ClassAnalysis.tsx
@@ -45,11 +45,6 @@ const ClassOverlap = () => {
     classOverlap.overlapThreshold
   );
 
-  React.useEffect(
-    () => setOverlapThreshold(classOverlap.overlapThreshold),
-    [classOverlap.overlapThreshold]
-  );
-
   const setQuery = (newClassOverlap: QueryClassOverlapState) =>
     history.push(
       `/${jobId}/class_analysis${constructSearchString({
@@ -204,8 +199,9 @@ const ClassOverlap = () => {
                   type="number"
                   value={overlapThreshold ?? data.defaultOverlapThreshold}
                   inputProps={OVERLAP_THRESHOLD_INPUT_PROPS}
-                  onChange={(event) => {
-                    setQuery({ overlapThreshold: Number(event.target.value) });
+                  onChange={({ target: { value } }) => {
+                    setOverlapThreshold(value);
+                    setQuery({ overlapThreshold: Number(value) });
                   }}
                 />
                 <Tooltip title="Reset threshold" arrow>
@@ -215,6 +211,7 @@ const ClassOverlap = () => {
                       color="secondary"
                       disabled={classOverlap.overlapThreshold === undefined}
                       onClick={() => {
+                        setOverlapThreshold(undefined);
                         setQuery({ overlapThreshold: undefined });
                       }}
                     >


### PR DESCRIPTION
Resolve #294

## Description:

* [Always call `setOverlapThreshold()` directly](https://github.com/ServiceNow/azimuth/pull/307/commits/aa751f9ec6983dba8b8ccb9315ba8c16fdc17d0a) instead of waiting for `setQuery()` to take effect.
  - This does not affect the current behavior, but it will make the following steps easier, requiring less code duplication. I committed this change independently not to pollute the other commits.
* [Control overlap threshold with a `string` instead of with a `number`](https://github.com/ServiceNow/azimuth/pull/307/commits/7e8bf71ca2df262c2b6f79fba7b69fd2fe790d8f) so for example when hitting backspace after `0.01`, you get `0.0` instead of `0` (as maybe you wanted to type `2` and get `0.02`).
* [Debounce number picker](https://github.com/ServiceNow/azimuth/pull/307/commits/e3ef5b8679e0030e5c1b65bd2b180dd86aea7be9) to reduce calls to DB.
  - As long as you type (or hit the arrows) with less than 500 ms between your strokes, you won't trigger an API call. If 500 ms pass without you typing, we consider you are done typing and we call the API.
  - I refactored the debouncing logic into its own reusable hook and reused it in `FilterTextField`.
* [Fix missing `key`](https://github.com/ServiceNow/azimuth/pull/307/commits/b73e47daf773bf7a446802b6921d4573564e57c3) 
  - Instead of adding the `key`, I realized I could avoid the `.split("\n").map()` altogether and preserve the `\n`s with the help of `whiteSpace="pre-wrap"`.
* [Memoize plotly wrappers](https://github.com/ServiceNow/azimuth/pull/307/commits/4a5dc0104cb82dbbadf326375e52221a37351b04) to avoid unnecessary re-renders
  - The plot used to flash white when typing in the threshold input, for example, to go from `0.0` to `0.00`.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
