### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ def simple_text_config_multi_pipeline(simple_text_config):
 @pytest.fixture
 def tiny_text_config(simple_text_config) -> AzimuthConfig:
     tiny_text_config = simple_text_config.copy(deep=True)
-    tiny_text_config.dataset.kwargs["max_dataset_len"] = 2
+    tiny_text_config.dataset.kwargs["max_dataset_len"] = 4
     return tiny_text_config
 
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -14,6 +14,7 @@ from azimuth.types import (
     SupportedMethod,
     SupportedModule,
 )
+from tests.utils import generate_mocked_dm
 
 
 def test_get_all_task(tiny_text_task_manager):
@@ -85,7 +86,9 @@ def test_clearing_cache(tiny_text_config):
     assert not any([m and d for m, d in cached.values()])
 
 
-def test_expired_task(tiny_text_task_manager):
+def test_expired_task(tiny_text_task_manager, tiny_text_config):
+    # Generating fake dm so modules don't fail because of missing columns.
+    generate_mocked_dm(tiny_text_config)
     current_update = time.time()
     pipeline_index_option = ModuleOptions(pipeline_index=0)
     _, pred_task = tiny_text_task_manager.get_task(
@@ -120,7 +123,7 @@ def test_expired_task(tiny_text_task_manager):
     )
     assert pred_task.done() and confusion_matrix_task.done()
 
-    # If we update the dataset_split, bin task will be recomputed
+    # If we update the dataset_split, confusion matrix task will be recomputed
     current_update = time.time()
     _, pred_task = tiny_text_task_manager.get_task(
         SupportedMethod.Predictions,


### PR DESCRIPTION
Resolve #

## Description:
Often in the CI, some tests would fail. 
- Expirable module test: One hypothesis is that because the modules in the test would fail, maybe it would fail too fast and put the confusion matrix to `done()` too quickly.
- Precision being equals to 0 before and after postprocessing: I increased slightly the size of the dataset so it's less likely to happen.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
