### PR TITLE
Fix generated types for `CustomObject`s

### DIFF
--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -77,8 +77,8 @@ class AzimuthValidationError(Exception):
 # Mypy does not like a variable named kwargs.
 class CustomObject(BaseModel):  # type: ignore
     class_name: str = Field(..., title="Class name to load.")
-    args: List[Union["CustomObject", Any]] = []
-    kwargs: Dict[str, Union["CustomObject", Any]] = {}
+    args: List[Any] = []
+    kwargs: Dict[str, Any] = {}
     remote: Optional[str] = Field(
         None,
         description="Relative path to class. `class_name` needs to be accessible from this path.",

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -212,12 +212,8 @@ export interface components {
     };
     CustomObject: {
       class_name: string;
-      args?: (Partial<components["schemas"]["CustomObject"]> &
-        Partial<{ [key: string]: any }>)[];
-      kwargs?: {
-        [key: string]: Partial<components["schemas"]["CustomObject"]> &
-          Partial<{ [key: string]: any }>;
-      };
+      args?: { [key: string]: any }[];
+      kwargs?: { [key: string]: any };
       /** Relative path to class. `class_name` needs to be accessible from this path. */
       remote?: string;
     };
@@ -343,12 +339,8 @@ export interface components {
     };
     MetricDefinition: {
       class_name: string;
-      args?: (Partial<components["schemas"]["CustomObject"]> &
-        Partial<{ [key: string]: any }>)[];
-      kwargs?: {
-        [key: string]: Partial<components["schemas"]["CustomObject"]> &
-          Partial<{ [key: string]: any }>;
-      };
+      args?: { [key: string]: any }[];
+      kwargs?: { [key: string]: any };
       /** Relative path to class. `class_name` needs to be accessible from this path. */
       remote?: string;
       /** Keyword arguments supplied to `compute`. */
@@ -714,12 +706,8 @@ export interface components {
      */
     TemperatureScaling: {
       class_name?: "azimuth.utils.ml.postprocessing.TemperatureScaling";
-      args?: (Partial<components["schemas"]["CustomObject"]> &
-        Partial<{ [key: string]: any }>)[];
-      kwargs?: {
-        [key: string]: Partial<components["schemas"]["CustomObject"]> &
-          Partial<{ [key: string]: any }>;
-      };
+      args?: { [key: string]: any }[];
+      kwargs?: { [key: string]: any };
       /** Relative path to class. `class_name` needs to be accessible from this path. */
       remote?: string;
       temperature?: number;
@@ -732,12 +720,8 @@ export interface components {
      */
     ThresholdConfig: {
       class_name?: "azimuth.utils.ml.postprocessing.Thresholding";
-      args?: (Partial<components["schemas"]["CustomObject"]> &
-        Partial<{ [key: string]: any }>)[];
-      kwargs?: {
-        [key: string]: Partial<components["schemas"]["CustomObject"]> &
-          Partial<{ [key: string]: any }>;
-      };
+      args?: { [key: string]: any }[];
+      kwargs?: { [key: string]: any };
       /** Relative path to class. `class_name` needs to be accessible from this path. */
       remote?: string;
       threshold?: number;


### PR DESCRIPTION
## Description:

Fix generated types for `CustomObject`s, as the `Union` doesn't seem to work properly.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
