### PR TITLE
Ignore `language` environment variable

### DIFF
--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -338,7 +338,7 @@ class ModelContractConfig(CommonFieldsConfig):
 class LanguageConfig(CommonFieldsConfig):
     # Language config sets multiple config values; see `config_defaults_per_language` for details
     # Language should only determine other config values and not be referenced in modules.
-    language: SupportedLanguage = SupportedLanguage.en
+    language: SupportedLanguage = Field(SupportedLanguage.en, env=[])
 
 
 class PerturbationTestingConfig(ModelContractConfig):

--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -338,6 +338,7 @@ class ModelContractConfig(CommonFieldsConfig):
 class LanguageConfig(CommonFieldsConfig):
     # Language config sets multiple config values; see `config_defaults_per_language` for details
     # Language should only determine other config values and not be referenced in modules.
+    # The default `language` environment variable was conflicting on certain machines.
     language: SupportedLanguage = Field(SupportedLanguage.en, env=[])
 
 

--- a/docs/docs/getting-started/changelog.md
+++ b/docs/docs/getting-started/changelog.md
@@ -1,5 +1,10 @@
 # Releases
 
+## [2.5.1] - 2022-12-05
+
+### Fixed
+- Ignore `language` environment variable as we have seen conflicts with it on certain machines.
+
 ## [2.5.0] - 2022-12-05
 
 ### Added


### PR DESCRIPTION
## Description:

Ignore `language` environment variable as we have seen conflicts with it on certain machines.

That might be temporary, as we will consider a more general prefix-based solution to avoid all conflicts with any non-azimuth variable names.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
