### PR TITLE
Remove warnings from GitHub actions

### DIFF
--- a/.github/workflows/docker_cd.yml
+++ b/.github/workflows/docker_cd.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docs_cd.yml
+++ b/.github/workflows/docs_cd.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x

--- a/.github/workflows/webapp_ci.yml
+++ b/.github/workflows/webapp_ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=path::$(yarn cache dir)"
+        run: echo "path=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Resolve #

## Description:
We have a few warnings in our GitHub actions. We cannot remove them all because they are part of the actions that we use, but I removed the ones in our scripts. 
From https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [ ] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [ ] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [ ] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [ ] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
