### PR TITLE
Fix sort by confidence or prediction without postprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,6 @@ Released changes are shown in the
 ### Fixed
 - Showing long utterances fully on hover in similar and perturbed utterances tables.
 - Webapp crash when no pipeline.
+- Sort confidence or prediction without postprocessing.
 
 ### Security

--- a/azimuth/routers/v1/utterances.py
+++ b/azimuth/routers/v1/utterances.py
@@ -140,9 +140,9 @@ def get_utterances(
             )
         ds = ds.filter(lambda i: i in indices, input_columns=DatasetColumn.row_idx)
 
-    # We create _top_conf because we can't sort on a column made of lists.
-    # Starts with underscore to emphasize that
-    # this should not be used elsewhere and it is not saved.
+    # We create _top_conf and _top_prediction because we can't sort on columns made of lists.
+    # They start with an underscore to emphasize that they are not saved and that therefore they
+    # should not be used anywhere else.
     if sort_by == UtterancesSortableColumn.confidence and pipeline_index is not None:
         sort_by_column = "_top_conf"
         column = (

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -52,6 +52,38 @@ def test_get_utterances_sort_confidence(app: FastAPI):
         [u["modelPrediction"]["postprocessedConfidences"][0] for u in resp["utterances"]]
     )
 
+    resp = client.get(
+        "/dataset_splits/eval/utterances?pipeline_index=0&sort=confidence"
+        "&without_postprocessing=true"
+    ).json()
+    assert len(resp["utterances"]) == 42
+    assert resp["utteranceCount"] == 42
+    assert is_sorted([u["modelPrediction"]["modelConfidences"][0] for u in resp["utterances"]])
+
+
+def test_get_utterances_sort_prediction(app: FastAPI):
+    client = TestClient(app)
+    resp = client.get("/dataset_splits/eval/utterances?pipeline_index=0&sort=prediction").json()
+    assert len(resp["utterances"]) == 42
+    assert resp["utteranceCount"] == 42
+    assert is_sorted([u["modelPrediction"]["postprocessedPrediction"] for u in resp["utterances"]])
+
+    resp = client.get(
+        "/dataset_splits/eval/utterances?pipeline_index=0&sort=prediction"
+        "&without_postprocessing=true"
+    ).json()
+    assert len(resp["utterances"]) == 42
+    assert resp["utteranceCount"] == 42
+    assert is_sorted([u["modelPrediction"]["modelPredictions"][0] for u in resp["utterances"]])
+
+
+def test_get_utterances_sort_descending(app: FastAPI):
+    client = TestClient(app)
+    resp = client.get("/dataset_splits/eval/utterances?pipeline_index=0&descending=true").json()
+    assert len(resp["utterances"]) == 42
+    assert resp["utteranceCount"] == 42
+    assert is_sorted([u["index"] for u in resp["utterances"]], descending=True)
+
 
 def test_get_utterances_sort_unavailable_column(app: FastAPI):
     client = TestClient(app)

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -30,17 +30,16 @@ def test_get_similar(app: FastAPI) -> None:
     assert len(resp) == 2
 
 
+def is_sorted(numbers: List[float], descending=False):
+    return all(a >= b if descending else a <= b for a, b in zip(numbers[:-1], numbers[1:]))
+
+
 def test_get_utterances(app: FastAPI):
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances").json()
     assert len(resp["utterances"]) == 42
     assert resp["utteranceCount"] == 42
-    indices = [u["index"] for u in resp["utterances"]]
-    assert all(a <= b for a, b in zip(indices[:-1], indices[1:])), indices
-
-
-def is_sorted(numbers: List[float], descending=False):
-    return all(a >= b if descending else a <= b for a, b in zip(numbers[:-1], numbers[1:]))
+    assert is_sorted([u["index"] for u in resp["utterances"]])
 
 
 def test_get_utterances_sort_confidence(app: FastAPI):

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -6,6 +6,8 @@ from typing import List
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
+UTTERANCE_COUNT = 42
+
 
 def test_get_similar(app: FastAPI) -> None:
     client = TestClient(app)
@@ -37,16 +39,16 @@ def is_sorted(numbers: List[float], descending=False):
 def test_get_utterances(app: FastAPI):
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances").json()
-    assert len(resp["utterances"]) == 42
-    assert resp["utteranceCount"] == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
     assert is_sorted([u["index"] for u in resp["utterances"]])
 
 
 def test_get_utterances_sort_confidence(app: FastAPI):
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances?pipeline_index=0&sort=confidence").json()
-    assert len(resp["utterances"]) == 42
-    assert resp["utteranceCount"] == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
     assert is_sorted(
         [u["modelPrediction"]["postprocessedConfidences"][0] for u in resp["utterances"]]
     )
@@ -55,32 +57,32 @@ def test_get_utterances_sort_confidence(app: FastAPI):
         "/dataset_splits/eval/utterances?pipeline_index=0&sort=confidence"
         "&without_postprocessing=true"
     ).json()
-    assert len(resp["utterances"]) == 42
-    assert resp["utteranceCount"] == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
     assert is_sorted([u["modelPrediction"]["modelConfidences"][0] for u in resp["utterances"]])
 
 
 def test_get_utterances_sort_prediction(app: FastAPI):
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances?pipeline_index=0&sort=prediction").json()
-    assert len(resp["utterances"]) == 42
-    assert resp["utteranceCount"] == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
     assert is_sorted([u["modelPrediction"]["postprocessedPrediction"] for u in resp["utterances"]])
 
     resp = client.get(
         "/dataset_splits/eval/utterances?pipeline_index=0&sort=prediction"
         "&without_postprocessing=true"
     ).json()
-    assert len(resp["utterances"]) == 42
-    assert resp["utteranceCount"] == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
     assert is_sorted([u["modelPrediction"]["modelPredictions"][0] for u in resp["utterances"]])
 
 
 def test_get_utterances_sort_descending(app: FastAPI):
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances?pipeline_index=0&descending=true").json()
-    assert len(resp["utterances"]) == 42
-    assert resp["utteranceCount"] == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
     assert is_sorted([u["index"] for u in resp["utterances"]], descending=True)
 
 
@@ -88,8 +90,8 @@ def test_get_utterances_sort_unavailable_column(app: FastAPI):
     client = TestClient(app)
     # The `sort=confidence` is ignored because no pipeline is specified
     resp = client.get("/dataset_splits/eval/utterances?sort=confidence").json()
-    assert len(resp["utterances"]) == 42
-    assert resp["utteranceCount"] == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
     assert is_sorted([u["index"] for u in resp["utterances"]])
 
 
@@ -97,12 +99,12 @@ def test_get_utterances_pagination(app: FastAPI):
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances?limit=10&offset=10").json()
     assert len(resp["utterances"]) == 10
-    assert resp["utteranceCount"] == 42
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
     assert resp["utterances"][0]["index"] == 10
 
     resp = client.get("/dataset_splits/eval/utterances?limit=10&offset=100").json()
     assert len(resp["utterances"]) == 0
-    assert resp["utteranceCount"] == 42
+    assert resp["utteranceCount"] == UTTERANCE_COUNT
 
     resp = client.get("/dataset_splits/eval/utterances?limit=3")
     assert resp.status_code == 400
@@ -117,7 +119,7 @@ def test_get_utterances_saliency(app: FastAPI, monkeypatch):
     monkeypatch.setattr(utt_module, "saliency_available", lambda x: True)
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances?pipeline_index=0").json()
-    assert len(resp["utterances"]) == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
 
     first_utterance = resp["utterances"][0]
     assert len(first_utterance["modelPrediction"]["modelPredictions"]) == 2
@@ -142,7 +144,7 @@ def test_get_utterances_no_pipeline(app: FastAPI, monkeypatch):
     monkeypatch.setattr(utt_module, "saliency_available", lambda x: True)
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances").json()
-    assert len(resp["utterances"]) == 42
+    assert len(resp["utterances"]) == UTTERANCE_COUNT
     assert all(
         item["modelPrediction"] is None and item["modelSaliency"] is None
         for item in resp["utterances"]

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -1,6 +1,7 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
+from typing import List
 
 from fastapi import FastAPI
 from starlette.testclient import TestClient
@@ -29,22 +30,40 @@ def test_get_similar(app: FastAPI) -> None:
     assert len(resp) == 2
 
 
-def test_utterances(app: FastAPI):
+def test_get_utterances(app: FastAPI):
     client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances").json()
     assert len(resp["utterances"]) == 42
     assert resp["utteranceCount"] == 42
-    first_idx = resp["utterances"][0]["index"]
+    indices = [u["index"] for u in resp["utterances"]]
+    assert all(a <= b for a, b in zip(indices[:-1], indices[1:])), indices
 
+
+def is_sorted(numbers: List[float], descending=False):
+    return all(a >= b if descending else a <= b for a, b in zip(numbers[:-1], numbers[1:]))
+
+
+def test_get_utterances_sort_confidence(app: FastAPI):
+    client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances?pipeline_index=0&sort=confidence").json()
-    first_idx_sorted = resp["utterances"][0]["index"]
-    assert first_idx_sorted != first_idx
+    assert len(resp["utterances"]) == 42
+    assert resp["utteranceCount"] == 42
+    assert is_sorted(
+        [u["modelPrediction"]["postprocessedConfidences"][0] for u in resp["utterances"]]
+    )
 
+
+def test_get_utterances_sort_unavailable_column(app: FastAPI):
+    client = TestClient(app)
     # The `sort=confidence` is ignored because no pipeline is specified
     resp = client.get("/dataset_splits/eval/utterances?sort=confidence").json()
-    first_idx_ignored = resp["utterances"][0]["index"]
-    assert first_idx_ignored == first_idx
+    assert len(resp["utterances"]) == 42
+    assert resp["utteranceCount"] == 42
+    assert is_sorted([u["index"] for u in resp["utterances"]])
 
+
+def test_get_utterances_pagination(app: FastAPI):
+    client = TestClient(app)
     resp = client.get("/dataset_splits/eval/utterances?limit=10&offset=10").json()
     assert len(resp["utterances"]) == 10
     assert resp["utteranceCount"] == 42
@@ -61,7 +80,7 @@ def test_utterances(app: FastAPI):
     assert resp.status_code == 400
 
 
-def test_get_utterances(app: FastAPI, monkeypatch):
+def test_get_utterances_saliency(app: FastAPI, monkeypatch):
     import azimuth.routers.v1.utterances as utt_module
 
     monkeypatch.setattr(utt_module, "saliency_available", lambda x: True)


### PR DESCRIPTION
Resolve #319

## Description:

* [Clean up test utterances](https://github.com/ServiceNow/azimuth/pull/327/commits/4dc55d3ab1cc69e2210ee005697f92361267bf94) 
  - Split into unit tests
  - Assert that responses are sorted
* [Test sort without postprocessing](https://github.com/ServiceNow/azimuth/pull/327/commits/644d7540e79614f16ac8a752d45af52370c6c52c) (initially fails)
* [Fix sort without postprocessing](https://github.com/ServiceNow/azimuth/pull/327/commits/54f44aacaa8e1a778ef12221dba8d675a38323ae) (gets the tests to pass)
  - Fix sort by confidence or prediction without postprocessing, while also simplifying the mapping from `UtterancesSortableColumn` to the actual dataset column, since it's no longer 1:1 (it now depends on `without_postprocessing`).
* [Polish comment](https://github.com/ServiceNow/azimuth/pull/327/commits/ed8bfc2f9fd9d4644dcc55eb1ab333d58688dbb3)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
