### PR TITLE
Add new start-up tasks

### DIFF
--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -58,7 +58,6 @@ SIMILARITY_TASKS = [
     ),
 ]
 
-
 BMA_PREDICTION_TASKS = [
     Startup(
         "prediction_bma",

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -183,7 +183,11 @@ def make_startup_tasks(
     dms = {k: v for k, v in dataset_split_managers.items() if v is not None}
     tasks: Dict[DatasetSplitName, DaskModule] = {}
 
-    available_datasets_splits = list(set(dataset_split_names) & set(dms))
+    if DatasetSplitName.all not in dataset_split_names:
+        available_datasets_splits = list(set(dataset_split_names) & set(dms))
+    else:
+        available_datasets_splits = [DatasetSplitName.all]
+
     for dataset_split_name in available_datasets_splits:
         _, maybe_task = task_manager.get_task(
             task_name=supported_module,

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -54,7 +54,7 @@ SIMILARITY_TRAIN_TASKS = [
     Startup(
         "class_overlap",
         SupportedModule.ClassOverlap,
-        dependency_names=["prediction", "neighbors_tags"],
+        dependency_names=["neighbors_tags"],
         dataset_split_names=[DatasetSplitName.train],
     )
 ]

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -31,6 +31,7 @@ def test_startup_task(tiny_text_config, tiny_text_task_manager):
     assert all(
         on_end in [cbk.fn for cbk in mod._callbacks] for mod in mods.values()
     ), "Some modules don't have callbacks!"
+    assert len(mods) == 19
 
 
 def test_startup_task_fast(tiny_text_config, tiny_text_task_manager):

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -27,7 +27,7 @@ def test_startup_task(tiny_text_config, tiny_text_task_manager):
     # We lock the task manager
     assert tiny_text_task_manager.is_locked
     assert not one_mod.done()
-    assert all("train" in k or "eval" in k for k in mods.keys())
+    assert all("train" in k or "eval" in k or "all" in k for k in mods.keys())
     assert all(
         on_end in [cbk.fn for cbk in mod._callbacks] for mod in mods.values()
     ), "Some modules don't have callbacks!"


### PR DESCRIPTION
## Description:
On big datasets, the behavioral testing summary and class overlap modules would error out in the UI, while they were being computed. I added them both to the start-up, and that forced me to refactor so we could define what dataset splits to send to a particular start-up task.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
