### PR TITLE
Clean up the last `useTheme()`

### DIFF
--- a/webapp/src/components/TopWords/TopWords.tsx
+++ b/webapp/src/components/TopWords/TopWords.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, Typography, useTheme } from "@mui/material";
+import { Box, Link, Typography } from "@mui/material";
 import useResizeObserver from "hooks/useResizeObserver";
 import React from "react";
 import { Link as RouterLink } from "react-router-dom";
@@ -37,8 +37,6 @@ const TopWords: React.FC<Props> = ({
   wordCounts,
   palette = "success",
 }) => {
-  const theme = useTheme();
-
   // It is impossible to know how large the word cloud will end up being so we have to scale it down to fit the parent if it is too big
   const [contentRef, contentWidth, contentHeight] = useResizeObserver();
   const [wrapperRef, wrapperWidth, wrapperHeight] = useResizeObserver();
@@ -95,9 +93,7 @@ const TopWords: React.FC<Props> = ({
                 ...pipeline,
                 ...postprocessing,
               })}`}
-              // Despite color's type allowing for `(theme) => `,
-              // it results in an uncaught error that crashes the app.
-              color={theme.palette[palette].dark}
+              color={`${palette}.dark`}
               display="block"
               fontSize={`${Math.max(
                 maxFontSizeInEm * count * normalizingScaleFactor,


### PR DESCRIPTION
## Description:

Ridiculously tiny (but satisfying) PR to clean up the very last `useTheme()`.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
