### PR TITLE
Save config in cache when starting the app and when modifying config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Released changes are shown in the
 ### Added
 - Persistent id.
 - New fields in config page.
+- The initial config file and all subsequent changes are saved in the caching folder.
 
 ### Changed
 

--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -103,7 +103,7 @@ def start_app(config_path, debug=False) -> FastAPI:
 
     local_cluster = default_cluster(large=azimuth_config.large_dask_cluster)
 
-    run_start_up_tasks(azimuth_config, local_cluster)
+    run_startup_tasks(azimuth_config, local_cluster)
     assert_not_none(_task_manager).client.run(set_logger_config, level)
 
     app = create_app()
@@ -284,7 +284,7 @@ def run_validation(
     task_manager.restart()
 
 
-def run_start_up_tasks(azimuth_config: AzimuthConfig, cluster: SpecCluster):
+def run_startup_tasks(azimuth_config: AzimuthConfig, cluster: SpecCluster):
     """Initialize managers, run validation and startup tasks.
 
     Args:

--- a/azimuth/routers/v1/admin.py
+++ b/azimuth/routers/v1/admin.py
@@ -13,9 +13,11 @@ from azimuth.app import (
     get_task_manager,
     initialize_managers,
     require_editable_config,
+    run_start_up_tasks,
 )
 from azimuth.config import AzimuthConfig, AzimuthValidationError
 from azimuth.task_manager import TaskManager
+from azimuth.utils.project import update_new_config
 
 log = structlog.get_logger(__name__)
 router = APIRouter()
@@ -50,8 +52,8 @@ def update_config(
     change_set: Dict = Body(...),
 ) -> AzimuthConfig:
     try:
-        new_config = config.copy(update=change_set, deep=True)
-        initialize_managers(new_config, task_manager.cluster)
+        new_config = update_new_config(old_config=config, change_set=change_set)
+        run_start_up_tasks(new_config, task_manager.cluster)
     except Exception as e:
         log.error("Rollback config update due to error", exc_info=e)
         new_config = config

--- a/azimuth/routers/v1/admin.py
+++ b/azimuth/routers/v1/admin.py
@@ -13,11 +13,11 @@ from azimuth.app import (
     get_task_manager,
     initialize_managers,
     require_editable_config,
-    run_start_up_tasks,
+    run_startup_tasks,
 )
 from azimuth.config import AzimuthConfig, AzimuthValidationError
 from azimuth.task_manager import TaskManager
-from azimuth.utils.project import update_new_config
+from azimuth.utils.project import update_config
 
 log = structlog.get_logger(__name__)
 router = APIRouter()
@@ -41,19 +41,19 @@ def get_config_def(
 @router.patch(
     "/config",
     summary="Update config",
-    description="Update the config using a changeset.",
+    description="Update the config.",
     tags=TAGS,
     response_model=AzimuthConfig,
     dependencies=[Depends(require_editable_config)],
 )
-def update_config(
+def patch_config(
     task_manager: TaskManager = Depends(get_task_manager),
     config: AzimuthConfig = Depends(get_config),
-    change_set: Dict = Body(...),
+    partial_config: Dict = Body(...),
 ) -> AzimuthConfig:
     try:
-        new_config = update_new_config(old_config=config, change_set=change_set)
-        run_start_up_tasks(new_config, task_manager.cluster)
+        new_config = update_config(old_config=config, partial_config=partial_config)
+        run_startup_tasks(new_config, task_manager.cluster)
     except Exception as e:
         log.error("Rollback config update due to error", exc_info=e)
         new_config = config

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -54,8 +54,8 @@ def load_dataset_from_config(azimuth_config: AzimuthConfig) -> DatasetDict:
 
 
 def save_config(azimuth_config: AzimuthConfig):
-    """Append config to configs.jsonl to retrieve past configs."""
-    with jsonlines.open(f"{azimuth_config.artifact_path}/configs.jsonl", mode="a") as f:
+    """Append config to config_history.jsonl to retrieve past configs."""
+    with jsonlines.open(f"{azimuth_config.artifact_path}/config_history.jsonl", mode="a") as f:
         f.write(azimuth_config.dict())
 
 

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -3,6 +3,7 @@
 # in the root directory of this source tree.
 from typing import Dict, Optional
 
+import jsonlines
 import structlog
 from datasets import DatasetDict
 
@@ -50,6 +51,18 @@ def load_dataset_from_config(azimuth_config: AzimuthConfig) -> DatasetDict:
             f"Found {tuple(dataset_in_config.keys())}."
         )
     return dataset_train_eval
+
+
+def save_config(azimuth_config: AzimuthConfig):
+    """Append config to configs.jsonl to retrieve past configs."""
+    with jsonlines.open(f"{azimuth_config.get_artifact_path()}/configs.jsonl", mode="a") as f:
+        f.write(azimuth_config.dict())
+
+
+def update_new_config(old_config: AzimuthConfig, change_set: Dict) -> AzimuthConfig:
+    new_config = old_config.copy(update=change_set, deep=True)
+    save_config(new_config)
+    return new_config
 
 
 def load_dataset_split_managers_from_config(

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -59,8 +59,8 @@ def save_config(azimuth_config: AzimuthConfig):
         f.write(azimuth_config.dict())
 
 
-def update_new_config(old_config: AzimuthConfig, change_set: Dict) -> AzimuthConfig:
-    new_config = old_config.copy(update=change_set, deep=True)
+def update_config(old_config: AzimuthConfig, partial_config: Dict) -> AzimuthConfig:
+    new_config = old_config.copy(update=partial_config, deep=True)
     save_config(new_config)
     return new_config
 

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -55,7 +55,7 @@ def load_dataset_from_config(azimuth_config: AzimuthConfig) -> DatasetDict:
 
 def save_config(azimuth_config: AzimuthConfig):
     """Append config to configs.jsonl to retrieve past configs."""
-    with jsonlines.open(f"{azimuth_config.get_artifact_path()}/configs.jsonl", mode="a") as f:
+    with jsonlines.open(f"{azimuth_config.artifact_path}/configs.jsonl", mode="a") as f:
         f.write(azimuth_config.dict())
 
 

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -60,9 +60,7 @@ def save_config(azimuth_config: AzimuthConfig):
 
 
 def update_config(old_config: AzimuthConfig, partial_config: Dict) -> AzimuthConfig:
-    new_config = old_config.copy(update=partial_config, deep=True)
-    save_config(new_config)
-    return new_config
+    return old_config.copy(update=partial_config, deep=True)
 
 
 def load_dataset_split_managers_from_config(

--- a/makefiles/Makefile.local
+++ b/makefiles/Makefile.local
@@ -56,5 +56,5 @@ launch.local:
 clean:
 	mkdir -p ./cache
 	rm -rf ./cache/$(TARGET)*
-	rm -rf /tmp/azimuth_test_cache || true
+	rm -rf /tmp/azimuth_test_cache
 	find ./azimuth_shr -name 'cache' -exec rm -rf {} +

--- a/makefiles/Makefile.test
+++ b/makefiles/Makefile.test
@@ -29,6 +29,7 @@ mypy:
 
 
 unit-test:
+	rm -rf /tmp/azimuth_test_cache
 	poetry run pytest tests --durations 5 --cov azimuth --cov-config=tests/.coveragerc
 
 test-doc:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1105,6 +1105,17 @@ python-versions = "*"
 dev = ["hypothesis"]
 
 [[package]]
+name = "jsonlines"
+version = "3.1.0"
+description = "Library with helpers for the jsonlines file format"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+
+[[package]]
 name = "jsonschema"
 version = "4.4.0"
 description = "An implementation of JSON Schema validation for Python"
@@ -3415,7 +3426,7 @@ gpu = ["onnxruntime-gpu"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "52defc5f6dd215b9b97ea90d0abb3c275a358731d1cb7101bc6eb46446d0393b"
+content-hash = "3755c7e69ea5efb88b1fbb05ff7febd155f53aa197f9e078228e8cfc35af9901"
 
 [metadata.files]
 absl-py = [
@@ -4137,6 +4148,10 @@ joblib = [
 json5 = [
     {file = "json5-0.9.6-py2.py3-none-any.whl", hash = "sha256:823e510eb355949bed817e1f3e2d682455dc6af9daf6066d5698d6a2ca4481c2"},
     {file = "json5-0.9.6.tar.gz", hash = "sha256:9175ad1bc248e22bb8d95a8e8d765958bf0008fef2fe8abab5bc04e0f1ac8302"},
+]
+jsonlines = [
+    {file = "jsonlines-3.1.0-py3-none-any.whl", hash = "sha256:632f5e38f93dfcb1ac8c4e09780b92af3a55f38f26e7c47ae85109d420b6ad39"},
+    {file = "jsonlines-3.1.0.tar.gz", hash = "sha256:2579cb488d96f815b0eb81629e3e6b0332da0962a18fa3532958f7ba14a5c37f"},
 ]
 jsonschema = [
     {file = "jsonschema-4.4.0-py3-none-any.whl", hash = "sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ structlog = "21.1"  # locked because 21.2 generates an error.
 tqdm = "4.63.0"
 plotly = "^5.3.1"
 retrying = "^1.3.3"
+jsonlines = "^3.1.0"
 
 # FastAPI requirements
 fastapi = "0.65.3"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,7 +145,7 @@ def test_update_config(tiny_text_config, monkeypatch, dask_client):
     assert not new_config.similarity
     save_config(new_config)
 
-    with jsonlines.open(f"{new_config.artifact_path}/configs.jsonl", "r") as reader:
+    with jsonlines.open(f"{new_config.artifact_path}/config_history.jsonl", "r") as reader:
         all_configs = list(reader)
     assert len(all_configs) == 1
     assert all_configs[0] == new_config
@@ -156,7 +156,7 @@ def test_update_config(tiny_text_config, monkeypatch, dask_client):
     assert new_config.dataset_warnings.min_num_per_class == 40
     save_config(new_config)
 
-    with jsonlines.open(f"{new_config.artifact_path}/configs.jsonl", "r") as reader:
+    with jsonlines.open(f"{new_config.artifact_path}/config_history.jsonl", "r") as reader:
         all_configs = list(reader)
 
     assert len(all_configs) == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,20 +146,18 @@ def test_update_config(tiny_text_config, monkeypatch, dask_client):
     save_config(new_config)
 
     with jsonlines.open(f"{new_config.artifact_path}/configs.jsonl", "r") as reader:
-        all_configs = [config for config in reader]
+        all_configs = list(reader)
     assert len(all_configs) == 1
-    loaded_config = all_configs[0]
-    assert loaded_config == new_config
+    assert all_configs[0] == new_config
 
     # Changing config for a second time
-    partial_config_2 = {"dataset_warnings": {"min_num_per_class": 40}}
-    new_config_2 = update_config(new_config, partial_config_2)
-    assert new_config_2.dataset_warnings.min_num_per_class == 40
-    save_config(new_config_2)
+    partial_config = {"dataset_warnings": {"min_num_per_class": 40}}
+    new_config = update_config(new_config, partial_config)
+    assert new_config.dataset_warnings.min_num_per_class == 40
+    save_config(new_config)
 
-    with jsonlines.open(f"{new_config_2.artifact_path}/configs.jsonl", "r") as reader:
-        all_configs_2 = [config for config in reader]
+    with jsonlines.open(f"{new_config.artifact_path}/configs.jsonl", "r") as reader:
+        all_configs = list(reader)
 
-    assert len(all_configs_2) == 2
-    loaded_config_2 = all_configs_2[-1]
-    assert loaded_config_2 == new_config_2
+    assert len(all_configs) == 2
+    assert all_configs[-1] == new_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,7 +146,7 @@ def test_update_config(tiny_text_config):
 
     assert not new_config.similarity
 
-    with open(f"{new_config.get_artifact_path()}/configs.jsonl", "r") as f:
+    with open(f"{new_config.artifact_path}/configs.jsonl", "r") as f:
         loaded_config = json.load(f)
     assert loaded_config == new_config
 
@@ -155,7 +155,7 @@ def test_update_config(tiny_text_config):
 
     assert new_config_2.dataset_warnings.min_num_per_class == 40
 
-    with jsonlines.open(f"{new_config_2.get_artifact_path()}/configs.jsonl", "r") as reader:
+    with jsonlines.open(f"{new_config_2.artifact_path}/configs.jsonl", "r") as reader:
         all_configs = [config for config in reader]
 
     assert len(all_configs) == 2

--- a/tests/test_routers/admin/test_admin.py
+++ b/tests/test_routers/admin/test_admin.py
@@ -112,7 +112,7 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
     initial_config = client.get("/admin/config").json()
     initial_contract = initial_config["model_contract"]
     initial_pipelines = initial_config["pipelines"]
-    jsonl_file_path = f"{initial_config['artifact_path']}/configs.jsonl"
+    jsonl_file_path = f"{initial_config['artifact_path']}/config_history.jsonl"
 
     res = client.patch(
         "/admin/config",

--- a/tests/test_routers/admin/test_admin.py
+++ b/tests/test_routers/admin/test_admin.py
@@ -120,7 +120,7 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
     )
     assert res.json()["model_contract"] == "file_based_text_classification"
     with jsonlines.open(jsonl_file_path, "r") as reader:
-        loaded_configs = [config for config in reader]
+        loaded_configs = list(reader)
     assert len(loaded_configs) == 2, "Config have been modified once."
     assert loaded_configs[-1]["model_contract"] == "file_based_text_classification"
     assert not loaded_configs[-1]["pipelines"]
@@ -128,7 +128,7 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
     res = client.patch("/admin/config", json={"model_contract": "potato"})
     assert res.status_code == 400
     with jsonlines.open(jsonl_file_path, "r") as reader:
-        loaded_configs = [config for config in reader]
+        loaded_configs = list(reader)
     assert len(loaded_configs) == 2, "The invalid config should not be saved."
     assert loaded_configs[-1]["model_contract"] == "file_based_text_classification"
 

--- a/tests/test_routers/admin/test_admin.py
+++ b/tests/test_routers/admin/test_admin.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from jsonlines import jsonlines
 from starlette.testclient import TestClient
 
 
@@ -111,14 +112,25 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
     initial_config = client.get("/admin/config").json()
     initial_contract = initial_config["model_contract"]
     initial_pipelines = initial_config["pipelines"]
+    jsonl_file_path = f"{initial_config['artifact_path']}/configs.jsonl"
+
     res = client.patch(
         "/admin/config",
         json={"model_contract": "file_based_text_classification", "pipelines": None},
     )
     assert res.json()["model_contract"] == "file_based_text_classification"
+    with jsonlines.open(jsonl_file_path, "r") as reader:
+        loaded_configs = [config for config in reader]
+    assert len(loaded_configs) == 2, "Config have been modified once."
+    assert loaded_configs[-1]["model_contract"] == "file_based_text_classification"
+    assert not loaded_configs[-1]["pipelines"]
 
     res = client.patch("/admin/config", json={"model_contract": "potato"})
     assert res.status_code == 400
+    with jsonlines.open(jsonl_file_path, "r") as reader:
+        loaded_configs = [config for config in reader]
+    assert len(loaded_configs) == 2, "The invalid config should not be saved."
+    assert loaded_configs[-1]["model_contract"] == "file_based_text_classification"
 
     # Revert config change
     _ = client.patch(

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 from datasets import Dataset, DatasetDict
 
-from azimuth.app import get_ready_flag, run_start_up_tasks
+from azimuth.app import get_ready_flag, run_startup_tasks
 from azimuth.config import CustomObject
 from azimuth.modules.model_contracts import HFTextClassificationModule
 from azimuth.startup import on_end, startup_tasks
@@ -107,7 +107,7 @@ def test_initialize_backbone(tiny_text_config, dask_client):
     event = get_ready_flag()
     assert event is None
     assert get_startup_tasks() is None
-    run_start_up_tasks(tiny_text_config, cluster=dask_client.cluster)
+    run_startup_tasks(tiny_text_config, cluster=dask_client.cluster)
     assert get_task_manager().cluster is dask_client.cluster
     assert get_config() is tiny_text_config
     assert get_dataset_split_manager(DatasetSplitName.train).config is tiny_text_config

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 from datasets import Dataset, DatasetDict
 
-from azimuth.app import get_ready_flag, initialize_managers
+from azimuth.app import get_ready_flag, run_start_up_tasks
 from azimuth.config import CustomObject
 from azimuth.modules.model_contracts import HFTextClassificationModule
 from azimuth.startup import on_end, startup_tasks
@@ -107,7 +107,7 @@ def test_initialize_backbone(tiny_text_config, dask_client):
     event = get_ready_flag()
     assert event is None
     assert get_startup_tasks() is None
-    initialize_managers(tiny_text_config, cluster=dask_client.cluster)
+    run_start_up_tasks(tiny_text_config, cluster=dask_client.cluster)
     assert get_task_manager().cluster is dask_client.cluster
     assert get_config() is tiny_text_config
     assert get_dataset_split_manager(DatasetSplitName.train).config is tiny_text_config

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -23,8 +23,8 @@ export interface paths {
   "/admin/config": {
     /** Get the current configuration */
     get: operations["get_config_def_admin_config_get"];
-    /** Update the config using a changeset. */
-    patch: operations["update_config_admin_config_patch"];
+    /** Update the config. */
+    patch: operations["patch_config_admin_config_patch"];
   };
   "/dataset_splits/{dataset_split_name}/class_overlap/plot": {
     /** Get a plot of class overlap using Spectral clustering and Monte-Carlo sampling (currently set to all samples). */
@@ -962,8 +962,8 @@ export interface operations {
       };
     };
   };
-  /** Update the config using a changeset. */
-  update_config_admin_config_patch: {
+  /** Update the config. */
+  patch_config_admin_config_patch: {
     responses: {
       /** Successful Response */
       200: {


### PR DESCRIPTION
Resolve #345 

## Description:
- I took the opportunity to do some refactoring so we can skip the validation tasks and start-up tasks in some cases. For now, this is only useful in the `update_config` route, in the `except`  condition. 
- This refactoring triggered some new `mypy` warnings that I have fixed.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
