### PR TITLE
Exclude fields from cache

### DIFF
--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, BaseSettings, Extra, Field, root_validator, vali
 
 from azimuth.types import AliasModel, DatasetColumn, SupportedModelContract
 from azimuth.utils.conversion import md5_hash
-from azimuth.utils.exclude_fields_with_extra import exclude_fields_with_extra
+from azimuth.utils.exclude_fields_from_cache import exclude_fields_from_cache
 
 log = structlog.get_logger(__file__)
 T = TypeVar("T", bound="ProjectConfig")
@@ -256,7 +256,7 @@ class ProjectConfig(BaseSettings):
         return md5_hash(
             self.dict(
                 include=ProjectConfig.__fields__.keys(),
-                exclude=exclude_fields_with_extra(self, "exclude_from_cache"),
+                exclude=exclude_fields_from_cache(self),
                 by_alias=True,
             )
         )

--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -128,7 +128,7 @@ class ThresholdConfig(BaseSettings, CustomObject):
 
 
 class PipelineDefinition(BaseSettings):
-    name: str
+    name: str = Field(exclude_from_cache=True)
     model: CustomObject
     postprocessors: Optional[
         List[Union[TemperatureScaling, ThresholdConfig, CustomObject]]
@@ -233,7 +233,7 @@ class ColumnConfiguration(BaseModel):
 
 class ProjectConfig(BaseSettings):
     # Name of the current project.
-    name: str = Field("New project", env="NAME")
+    name: str = Field("New project", env="NAME", exclude_from_cache=True)
     # Dataset object definition.
     dataset: CustomObject
     # Which model_contract the application is using.
@@ -261,15 +261,15 @@ class CommonFieldsConfig(ProjectConfig, extra=Extra.ignore):
     # Where to store artifacts. (HDF5 files,  HF datasets, Dask config)
     artifact_path: str = "/cache"
     # Batch size to use during inference.
-    batch_size: int = 32
+    batch_size: int = Field(32, exclude_from_cache=True)
     # Will use CUDA and will need GPUs if set to True.
     # If "auto" we check if CUDA is available.
-    use_cuda: Union[Literal["auto"], bool] = "auto"
+    use_cuda: Union[Literal["auto"], bool] = Field("auto", exclude_from_cache=True)
     # Memory of the dask cluster. Regular is 6GB, Large is 12GB.
     # For bigger models, large might be needed.
-    large_dask_cluster: bool = False
+    large_dask_cluster: bool = Field(False, exclude_from_cache=True)
     # Disable configuration changes
-    read_only_config: bool = Field(False, env="READ_ONLY_CONFIG")
+    read_only_config: bool = Field(False, env="READ_ONLY_CONFIG", exclude_from_cache=True)
 
     def get_artifact_path(self) -> str:
         """Generate a path for caching.

--- a/azimuth/modules/base_classes/module.py
+++ b/azimuth/modules/base_classes/module.py
@@ -45,9 +45,11 @@ class Module(DaskModule[ConfigScope]):
         super().__init__(dataset_split_name, config)
 
     def _get_name(self) -> str:
-        options_to_consider = self.mod_options.dict()
-        # Indices are excluded, since the cache for all indices should be in the same folder.
-        options_to_consider = self.mod_options.dict(exclude={"indices"})
+        # indices are excluded, since the cache for all indices should be in the same file.
+        # model_contract_method_name are excluded too because it's already in the task_name.
+        options_to_consider = self.mod_options.dict(
+            exclude={"indices", "model_contract_method_name"}, include=self.allowed_mod_options
+        )
         attributes_to_consider = self.config.dict(
             include={
                 k: ...

--- a/azimuth/modules/base_classes/module.py
+++ b/azimuth/modules/base_classes/module.py
@@ -7,16 +7,12 @@ import numpy as np
 from datasets import Dataset
 from tqdm import tqdm
 
-from azimuth.config import (
-    AzimuthConfig,
-    CommonFieldsConfig,
-    ModelContractConfig,
-    PipelineDefinition,
-)
+from azimuth.config import AzimuthConfig, ModelContractConfig, PipelineDefinition
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
 from azimuth.modules.base_classes import ArtifactManager, ConfigScope, DaskModule
 from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, ModuleResponse
 from azimuth.utils.conversion import md5_hash
+from azimuth.utils.exclude_fields_with_extra import exclude_fields_with_extra
 from azimuth.utils.validation import assert_not_none
 
 
@@ -51,12 +47,7 @@ class Module(DaskModule[ConfigScope]):
             exclude={"indices", "model_contract_method_name"}, include=self.allowed_mod_options
         )
         attributes_to_consider = self.config.dict(
-            include={
-                k: ...
-                for k in set(AzimuthConfig.__fields__.keys()).difference(
-                    CommonFieldsConfig.__fields__.keys()
-                )
-            }
+            exclude=exclude_fields_with_extra(AzimuthConfig.__fields__, "exclude_from_cache"),
         )
 
         return (

--- a/azimuth/modules/base_classes/module.py
+++ b/azimuth/modules/base_classes/module.py
@@ -12,7 +12,7 @@ from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKe
 from azimuth.modules.base_classes import ArtifactManager, ConfigScope, DaskModule
 from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, ModuleResponse
 from azimuth.utils.conversion import md5_hash
-from azimuth.utils.exclude_fields_with_extra import exclude_fields_with_extra
+from azimuth.utils.exclude_fields_from_cache import exclude_fields_from_cache
 from azimuth.utils.validation import assert_not_none
 
 
@@ -47,7 +47,7 @@ class Module(DaskModule[ConfigScope]):
             exclude={"indices", "model_contract_method_name"}, include=self.allowed_mod_options
         )
         attributes_to_consider = self.config.dict(
-            exclude=exclude_fields_with_extra(self.config, "exclude_from_cache"),
+            exclude=exclude_fields_from_cache(self.config),
         )
 
         return (

--- a/azimuth/modules/base_classes/module.py
+++ b/azimuth/modules/base_classes/module.py
@@ -7,7 +7,7 @@ import numpy as np
 from datasets import Dataset
 from tqdm import tqdm
 
-from azimuth.config import AzimuthConfig, ModelContractConfig, PipelineDefinition
+from azimuth.config import ModelContractConfig, PipelineDefinition
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
 from azimuth.modules.base_classes import ArtifactManager, ConfigScope, DaskModule
 from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, ModuleResponse
@@ -47,7 +47,7 @@ class Module(DaskModule[ConfigScope]):
             exclude={"indices", "model_contract_method_name"}, include=self.allowed_mod_options
         )
         attributes_to_consider = self.config.dict(
-            exclude=exclude_fields_with_extra(AzimuthConfig.__fields__, "exclude_from_cache"),
+            exclude=exclude_fields_with_extra(self.config, "exclude_from_cache"),
         )
 
         return (

--- a/azimuth/utils/dataset_operations.py
+++ b/azimuth/utils/dataset_operations.py
@@ -161,7 +161,7 @@ def get_confidences_from_ds(ds: Dataset, without_postprocessing: bool = False) -
 def get_outcomes_from_ds(ds: Dataset, without_postprocessing: bool = False) -> List[OutcomeName]:
     """Get outcomes, with or without postprocessing.
 
-        Args:
+    Args:
         ds: Dataset Split for which to get outcomes.
         without_postprocessing: Determine which column to use.
 

--- a/azimuth/utils/exclude_fields_with_extra.py
+++ b/azimuth/utils/exclude_fields_with_extra.py
@@ -5,12 +5,25 @@ from pydantic.fields import SHAPE_SINGLETON, ModelField
 
 
 def exclude_fields_with_extra(fields: Dict[str, ModelField], extra: str):
+    """Exclude pydantic fields with given extra keyword argument.
+
+    Args:
+        fields: Usually pydantic.BaseModel.__field__.
+        extra: The extra keyword argument to look for in each field.
+
+    Returns: The format expected by pydantic.BaseModel.dict(exclude=...), json() and _iter()
+
+    """
     exclude = dict()
     for key, field in fields.items():
         if field.field_info.extra.get(extra):
             exclude[key] = ...  # TODO update pydantic to >=1.9 and change `...` to `True`
-        elif issubclass(field.type_, BaseModel):
-            sub = exclude_fields_with_extra(field.type_.__fields__, extra)
-            if sub:
-                exclude[key] = sub if field.shape == SHAPE_SINGLETON else {"__all__": sub}
+        else:
+            try:
+                if issubclass(field.type_, BaseModel):
+                    sub = exclude_fields_with_extra(field.type_.__fields__, extra)
+                    if sub:
+                        exclude[key] = sub if field.shape == SHAPE_SINGLETON else {"__all__": sub}
+            except TypeError:
+                pass
     return exclude

--- a/azimuth/utils/exclude_fields_with_extra.py
+++ b/azimuth/utils/exclude_fields_with_extra.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+from pydantic import BaseModel
+from pydantic.fields import SHAPE_SINGLETON, ModelField
+
+
+def exclude_fields_with_extra(fields: Dict[str, ModelField], extra: str):
+    exclude = dict()
+    for key, field in fields.items():
+        if field.field_info.extra.get(extra):
+            exclude[key] = ...  # TODO update pydantic to >=1.9 and change `...` to `True`
+        elif issubclass(field.type_, BaseModel):
+            sub = exclude_fields_with_extra(field.type_.__fields__, extra)
+            if sub:
+                exclude[key] = sub if field.shape == SHAPE_SINGLETON else {"__all__": sub}
+    return exclude

--- a/azimuth/utils/exclude_fields_with_extra.py
+++ b/azimuth/utils/exclude_fields_with_extra.py
@@ -1,29 +1,40 @@
-from typing import Dict
+# Copyright ServiceNow, Inc. 2021 – 2022
+# This source code is licensed under the Apache 2.0 license found in the LICENSE file
+# in the root directory of this source tree.
+
+from typing import Collection, Dict, Mapping, TypeVar
 
 from pydantic import BaseModel
-from pydantic.fields import SHAPE_SINGLETON, ModelField
+
+Model = TypeVar("Model", bound=BaseModel)
 
 
-def exclude_fields_with_extra(fields: Dict[str, ModelField], extra: str):
+def exclude_fields_with_extra(model: Model, extra: str):
     """Exclude pydantic fields with given extra keyword argument.
 
     Args:
-        fields: Usually pydantic.BaseModel.__field__.
+        model: Model, inheriting from pydantic.BaseModel.
         extra: The extra keyword argument to look for in each field.
 
     Returns: The format expected by pydantic.BaseModel.dict(exclude=...), json() and _iter()
-
     """
     exclude = dict()
-    for key, field in fields.items():
+    for key, field in model.__fields__.items():
         if field.field_info.extra.get(extra):
             exclude[key] = ...  # TODO update pydantic to >=1.9 and change `...` to `True`
         else:
-            try:
-                if issubclass(field.type_, BaseModel):
-                    sub = exclude_fields_with_extra(field.type_.__fields__, extra)
-                    if sub:
-                        exclude[key] = sub if field.shape == SHAPE_SINGLETON else {"__all__": sub}
-            except TypeError:
-                pass
+            val = getattr(model, key)
+            if isinstance(val, BaseModel):
+                set_if(exclude, key, exclude_fields_with_extra(val, extra))
+            elif isinstance(val, Collection):
+                sub: Dict = dict()
+                for sub_key, sub_val in val.items() if isinstance(val, Mapping) else enumerate(val):
+                    if isinstance(sub_val, BaseModel):
+                        set_if(sub, sub_key, exclude_fields_with_extra(sub_val, extra))
+                set_if(exclude, key, sub)
     return exclude
+
+
+def set_if(d: Dict, key, val):
+    if val:
+        d[key] = val

--- a/tests/test_utils/test_exclude_from_cache.py
+++ b/tests/test_utils/test_exclude_from_cache.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Union
 
 from pydantic import BaseModel, Field
 
-from azimuth.utils.exclude_fields_with_extra import exclude_fields_with_extra
+from azimuth.utils.exclude_fields_from_cache import exclude_fields_from_cache
 
 
 class Sub(BaseModel):
@@ -40,7 +40,7 @@ def test_exclude_from_cache():
             "c": 11,
         },
     )
-    exclude = exclude_fields_with_extra(model, "exclude_from_cache")
+    exclude = exclude_fields_from_cache(model)
     assert exclude == {
         "excluded_sub_with_excluded_field": ...,
         "sub_with_excluded_field": {"excluded_field": ...},

--- a/tests/test_utils/test_exclude_from_cache.py
+++ b/tests/test_utils/test_exclude_from_cache.py
@@ -1,4 +1,8 @@
-from typing import List
+# Copyright ServiceNow, Inc. 2021 – 2022
+# This source code is licensed under the Apache 2.0 license found in the LICENSE file
+# in the root directory of this source tree.
+
+from typing import Dict, List, Union
 
 from pydantic import BaseModel, Field
 
@@ -19,6 +23,8 @@ class Model(BaseModel):
     excluded_sub_with_excluded_field: SubWithExcludedField = Field(..., exclude_from_cache=True)
     sub_with_excluded_field: SubWithExcludedField
     list_of_sub_with_excluded_field: List[SubWithExcludedField]
+    list_of_union: List[Union[SubWithExcludedField, Sub, int]]
+    dict_of_union: Dict[str, Union[SubWithExcludedField, Sub, int]]
 
 
 def test_exclude_from_cache():
@@ -27,15 +33,25 @@ def test_exclude_from_cache():
         excluded_sub_with_excluded_field=SubWithExcludedField(excluded_field=1, field=7),
         sub_with_excluded_field=SubWithExcludedField(excluded_field=2, field=8),
         list_of_sub_with_excluded_field=[SubWithExcludedField(excluded_field=3, field=5)],
+        list_of_union=[SubWithExcludedField(excluded_field=4, field=6), Sub(field=10), 11],
+        dict_of_union={
+            "a": SubWithExcludedField(excluded_field=4, field=6),
+            "b": Sub(field=10),
+            "c": 11,
+        },
     )
-    exclude = exclude_fields_with_extra(model.__fields__, "exclude_from_cache")
+    exclude = exclude_fields_with_extra(model, "exclude_from_cache")
     assert exclude == {
         "excluded_sub_with_excluded_field": ...,
         "sub_with_excluded_field": {"excluded_field": ...},
-        "list_of_sub_with_excluded_field": {"__all__": {"excluded_field": ...}},
+        "list_of_sub_with_excluded_field": {0: {"excluded_field": ...}},
+        "list_of_union": {0: {"excluded_field": ...}},
+        "dict_of_union": {"a": {"excluded_field": ...}},
     }
     assert model.dict(exclude=exclude) == {
         "sub": {"field": 9},
         "sub_with_excluded_field": {"field": 8},
         "list_of_sub_with_excluded_field": [{"field": 5}],
+        "list_of_union": [{"field": 6}, {"field": 10}, 11],
+        "dict_of_union": {"a": {"field": 6}, "b": {"field": 10}, "c": 11},
     }

--- a/tests/test_utils/test_exclude_from_cache.py
+++ b/tests/test_utils/test_exclude_from_cache.py
@@ -1,0 +1,41 @@
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from azimuth.utils.exclude_fields_with_extra import exclude_fields_with_extra
+
+
+class Sub(BaseModel):
+    field: int
+
+
+class SubWithExcludedField(BaseModel):
+    excluded_field: int = Field(..., exclude_from_cache=True)
+    field: int
+
+
+class Model(BaseModel):
+    sub: Sub
+    excluded_sub_with_excluded_field: SubWithExcludedField = Field(..., exclude_from_cache=True)
+    sub_with_excluded_field: SubWithExcludedField
+    list_of_sub_with_excluded_field: List[SubWithExcludedField]
+
+
+def test_exclude_from_cache():
+    model = Model(
+        sub=Sub(field=9),
+        excluded_sub_with_excluded_field=SubWithExcludedField(excluded_field=1, field=7),
+        sub_with_excluded_field=SubWithExcludedField(excluded_field=2, field=8),
+        list_of_sub_with_excluded_field=[SubWithExcludedField(excluded_field=3, field=5)],
+    )
+    exclude = exclude_fields_with_extra(model.__fields__, "exclude_from_cache")
+    assert exclude == {
+        "excluded_sub_with_excluded_field": ...,
+        "sub_with_excluded_field": {"excluded_field": ...},
+        "list_of_sub_with_excluded_field": {"__all__": {"excluded_field": ...}},
+    }
+    assert model.dict(exclude=exclude) == {
+        "sub": {"field": 9},
+        "sub_with_excluded_field": {"field": 8},
+        "list_of_sub_with_excluded_field": [{"field": 5}],
+    }

--- a/tests/test_utils/test_exclude_from_cache.py
+++ b/tests/test_utils/test_exclude_from_cache.py
@@ -23,6 +23,7 @@ class Model(BaseModel):
     excluded_sub_with_excluded_field: SubWithExcludedField = Field(..., exclude_from_cache=True)
     sub_with_excluded_field: SubWithExcludedField
     list_of_sub_with_excluded_field: List[SubWithExcludedField]
+    list_of_any: List
     list_of_union: List[Union[SubWithExcludedField, Sub, int]]
     dict_of_union: Dict[str, Union[SubWithExcludedField, Sub, int]]
 
@@ -33,6 +34,7 @@ def test_exclude_from_cache():
         excluded_sub_with_excluded_field=SubWithExcludedField(excluded_field=1, field=7),
         sub_with_excluded_field=SubWithExcludedField(excluded_field=2, field=8),
         list_of_sub_with_excluded_field=[SubWithExcludedField(excluded_field=3, field=5)],
+        list_of_any=[SubWithExcludedField(excluded_field=4, field=6), Sub(field=10), 11, "hi!"],
         list_of_union=[SubWithExcludedField(excluded_field=4, field=6), Sub(field=10), 11],
         dict_of_union={
             "a": SubWithExcludedField(excluded_field=4, field=6),
@@ -45,6 +47,7 @@ def test_exclude_from_cache():
         "excluded_sub_with_excluded_field": ...,
         "sub_with_excluded_field": {"excluded_field": ...},
         "list_of_sub_with_excluded_field": {0: {"excluded_field": ...}},
+        "list_of_any": {0: {"excluded_field": ...}},
         "list_of_union": {0: {"excluded_field": ...}},
         "dict_of_union": {"a": {"excluded_field": ...}},
     }
@@ -52,6 +55,7 @@ def test_exclude_from_cache():
         "sub": {"field": 9},
         "sub_with_excluded_field": {"field": 8},
         "list_of_sub_with_excluded_field": [{"field": 5}],
+        "list_of_any": [{"field": 6}, {"field": 10}, 11, "hi!"],
         "list_of_union": [{"field": 6}, {"field": 10}, 11],
         "dict_of_union": {"a": {"field": 6}, "b": {"field": 10}, "c": 11},
     }

--- a/tests/test_utils/test_exclude_from_cache.py
+++ b/tests/test_utils/test_exclude_from_cache.py
@@ -2,7 +2,7 @@
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
 
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 from pydantic import BaseModel, Field
 
@@ -23,7 +23,8 @@ class Model(BaseModel):
     excluded_sub_with_excluded_field: SubWithExcludedField = Field(..., exclude_from_cache=True)
     sub_with_excluded_field: SubWithExcludedField
     list_of_sub_with_excluded_field: List[SubWithExcludedField]
-    list_of_any: List
+    any: Any
+    list_of_any: List[Any]
     list_of_union: List[Union[SubWithExcludedField, Sub, int]]
     dict_of_union: Dict[str, Union[SubWithExcludedField, Sub, int]]
 
@@ -34,6 +35,7 @@ def test_exclude_from_cache():
         excluded_sub_with_excluded_field=SubWithExcludedField(excluded_field=1, field=7),
         sub_with_excluded_field=SubWithExcludedField(excluded_field=2, field=8),
         list_of_sub_with_excluded_field=[SubWithExcludedField(excluded_field=3, field=5)],
+        any=SubWithExcludedField(excluded_field=-1, field=-2),
         list_of_any=[SubWithExcludedField(excluded_field=4, field=6), Sub(field=10), 11, "hi!"],
         list_of_union=[SubWithExcludedField(excluded_field=4, field=6), Sub(field=10), 11],
         dict_of_union={
@@ -47,6 +49,7 @@ def test_exclude_from_cache():
         "excluded_sub_with_excluded_field": ...,
         "sub_with_excluded_field": {"excluded_field": ...},
         "list_of_sub_with_excluded_field": {0: {"excluded_field": ...}},
+        "any": {"excluded_field": ...},
         "list_of_any": {0: {"excluded_field": ...}},
         "list_of_union": {0: {"excluded_field": ...}},
         "dict_of_union": {"a": {"excluded_field": ...}},
@@ -55,6 +58,7 @@ def test_exclude_from_cache():
         "sub": {"field": 9},
         "sub_with_excluded_field": {"field": 8},
         "list_of_sub_with_excluded_field": [{"field": 5}],
+        "any": {"field": -2},
         "list_of_any": [{"field": 6}, {"field": 10}, 11, "hi!"],
         "list_of_union": [{"field": 6}, {"field": 10}, 11],
         "dict_of_union": {"a": {"field": 6}, "b": {"field": 10}, "c": 11},


### PR DESCRIPTION
Resolve #348

## Description:

Exclude desired fields from cache hash by setting an extra parameter `exclude_from_cache=True`. This allows for more granular control over which config fields (when they are edited) will trigger some modules to recompute. For example, we don't need to recompute the predictions if a pipeline's name changes, so we add `exclude_from_cache=True` to the `name` field.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
