### PR TITLE
Fix config scopes

### DIFF
--- a/azimuth/modules/README.md
+++ b/azimuth/modules/README.md
@@ -98,9 +98,8 @@ Because the user can make changes to the dataset, we needed to add a Mixin that 
 - Expirable Mixin
     - This module needs to be recomputed every time the user makes a change to the dataset. This
       usually happens because of the use of data action tags in the filter in module options, which
-      can lead to a different set of data points once the user starts to annotate.
-    - Since it is a Mixin, it is added as a second inheritance to Modules that need it. You will
-      need to set up the `self._time` value in the constructor of your Module.
+      can lead to a different set of data points once the user starts to annotate. This also happens when thresholds are edited in the config, which recompute some smart tags.
+    - Since it is a Mixin, it is added as a second inheritance to Modules that need it.
 
 ## ConfigScope
 

--- a/azimuth/modules/base_classes/aggregation_module.py
+++ b/azimuth/modules/base_classes/aggregation_module.py
@@ -1,14 +1,13 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
-import time
 from abc import ABC
-from typing import List, Optional
+from typing import List
 
 from datasets import Dataset
 
 from azimuth.modules.base_classes import ConfigScope, ExpirableMixin, Module
-from azimuth.types import DatasetSplitName, ModuleOptions, ModuleResponse
+from azimuth.types import DatasetSplitName, ModuleResponse
 from azimuth.utils.dataset_operations import filter_dataset_split
 
 
@@ -34,15 +33,6 @@ class FilterableModule(AggregationModule[ConfigScope], ExpirableMixin, ABC):
     """Filterable Module are affected by filters in mod options."""
 
     allowed_mod_options = {"filters", "pipeline_index", "without_postprocessing"}
-
-    def __init__(
-        self,
-        dataset_split_name: DatasetSplitName,
-        config: ConfigScope,
-        mod_options: Optional[ModuleOptions] = None,
-    ):
-        super().__init__(dataset_split_name, config, mod_options=mod_options)
-        self._time = time.time()
 
     def get_dataset_split(self, name: DatasetSplitName = None) -> Dataset:
         """Get the specified dataset_split, filtered according to mod_options.

--- a/azimuth/modules/base_classes/dask_module.py
+++ b/azimuth/modules/base_classes/dask_module.py
@@ -63,6 +63,7 @@ class DaskModule(HDF5CacheMixin, Generic[ConfigScope]):
         self._cache_lock = pjoin(self.cache_dir, f"{self.name}.h5.lock")
         self._cache_effective_arguments = pjoin(self.cache_dir, f"{self.name}.json")
         self._status = "not_started"
+        self._time = time.time()  # Only used for expirable modules
 
     @property
     def name(self):

--- a/azimuth/modules/model_performance/metrics.py
+++ b/azimuth/modules/model_performance/metrics.py
@@ -12,7 +12,7 @@ from datasets import Dataset, Metric
 from sklearn.exceptions import UndefinedMetricWarning
 from tqdm import tqdm
 
-from azimuth.config import AzimuthConfig, ModelContractConfig
+from azimuth.config import AzimuthConfig, MetricConfig
 from azimuth.modules.base_classes import AggregationModule, FilterableModule
 from azimuth.modules.model_performance.confidence_binning import (
     ConfidenceHistogramModule,
@@ -61,7 +61,7 @@ def first_value(di: Optional[Dict]) -> Optional[float]:
     return next(iter(di.values()), None)
 
 
-class MetricsModule(FilterableModule[ModelContractConfig]):
+class MetricsModule(FilterableModule[MetricConfig]):
     """Computes different metrics on each dataset split."""
 
     def compute_metrics(self, ds: Dataset) -> List[MetricsModuleResponse]:

--- a/azimuth/modules/model_performance/outcome_count.py
+++ b/azimuth/modules/model_performance/outcome_count.py
@@ -8,7 +8,7 @@ import numpy as np
 from datasets import Dataset
 from tqdm import tqdm
 
-from azimuth.config import AzimuthConfig, ModelContractConfig
+from azimuth.config import ModelContractConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.base_classes import AggregationModule, FilterableModule
 from azimuth.modules.model_performance.outcomes import OutcomesModule
@@ -35,7 +35,7 @@ from azimuth.utils.project import postprocessing_editable
 from azimuth.utils.validation import assert_is_list
 
 
-class OutcomeCountPerFilterModule(FilterableModule[AzimuthConfig]):
+class OutcomeCountPerFilterModule(FilterableModule[ModelContractConfig]):
     """Computes the outcome count for each filter."""
 
     def get_outcome_count_per_class(

--- a/azimuth/routers/v1/utterances.py
+++ b/azimuth/routers/v1/utterances.py
@@ -246,7 +246,6 @@ def get_utterances(
             model_prediction=model_prediction,
             model_saliency=model_saliency,
             # Smart tags families
-            # type: ignore[call-arg]  # TODO Remove once we update pydantic and mypy
             **{
                 family.value: [t for t in tags_in_family if tag[t]]
                 if family in available_families

--- a/azimuth/types/model_performance.py
+++ b/azimuth/types/model_performance.py
@@ -67,6 +67,13 @@ class ValuePerPipelineFilter(ValuePerPipelineSmartTag[T], GenericModel, Generic[
     outcome: List[T] = Field(..., title="Outcome")
 
 
+class ValuePerClassFilter(
+    ValuePerPipelineSmartTag[T], ValuePerDatasetSmartTag[T], GenericModel, Generic[T]
+):
+    label: List[T] = Field(..., title="Label")
+    prediction: List[T] = Field(..., title="Prediction")
+
+
 class UtteranceCountPerFilter(ValuePerDatasetFilter[UtteranceCountPerFilterValue]):
     pass
 
@@ -96,9 +103,7 @@ class MetricsPerFilterValue(MetricsResponseCommonFields, UtteranceCountPerFilter
     pass
 
 
-class MetricsPerFilter(
-    ValuePerDatasetFilter[MetricsPerFilterValue], ValuePerPipelineFilter[MetricsPerFilterValue]
-):
+class MetricsPerFilter(ValuePerClassFilter[MetricsPerFilterValue]):
     pass
 
 

--- a/azimuth/types/model_performance.py
+++ b/azimuth/types/model_performance.py
@@ -67,13 +67,6 @@ class ValuePerPipelineFilter(ValuePerPipelineSmartTag[T], GenericModel, Generic[
     outcome: List[T] = Field(..., title="Outcome")
 
 
-class ValuePerClassFilter(
-    ValuePerPipelineSmartTag[T], ValuePerDatasetSmartTag[T], GenericModel, Generic[T]
-):
-    label: List[T] = Field(..., title="Label")
-    prediction: List[T] = Field(..., title="Prediction")
-
-
 class UtteranceCountPerFilter(ValuePerDatasetFilter[UtteranceCountPerFilterValue]):
     pass
 
@@ -103,8 +96,12 @@ class MetricsPerFilterValue(MetricsResponseCommonFields, UtteranceCountPerFilter
     pass
 
 
-class MetricsPerFilter(ValuePerClassFilter[MetricsPerFilterValue]):
-    pass
+class MetricsPerFilter(
+    ValuePerDatasetSmartTag[MetricsPerFilterValue],
+    ValuePerPipelineSmartTag[MetricsPerFilterValue],
+):
+    label: List[MetricsPerFilterValue] = Field(..., title="Label")
+    prediction: List[MetricsPerFilterValue] = Field(..., title="Prediction")
 
 
 class MetricsPerFilterModuleResponse(ModuleResponse):

--- a/azimuth/types/model_performance.py
+++ b/azimuth/types/model_performance.py
@@ -36,10 +36,10 @@ class UtteranceCountPerFilterValue(AliasModel):
 
 if typing.TYPE_CHECKING:
 
-    class ValuePerDatasetSmartTag(AliasModel, Generic[T]):
+    class ValuePerDatasetSmartTag(GenericModel, Generic[T]):
         pass
 
-    class ValuePerPipelineSmartTag(AliasModel, Generic[T]):
+    class ValuePerPipelineSmartTag(GenericModel, Generic[T]):
         pass
 
 else:

--- a/tests/test_modules/test_model_performance/test_metrics.py
+++ b/tests/test_modules/test_model_performance/test_metrics.py
@@ -21,12 +21,7 @@ from azimuth.modules.model_performance.outcomes import OutcomesModule
 from azimuth.plots.ece import make_ece_figure
 from azimuth.types import DatasetFilters, DatasetSplitName, ModuleOptions
 from azimuth.types.outcomes import OutcomeName, OutcomeResponse
-from azimuth.types.tag import (
-    ALL_DATA_ACTION_FILTERS,
-    SMART_TAGS_FAMILY_MAPPING,
-    DataAction,
-    SmartTag,
-)
+from azimuth.types.tag import SMART_TAGS_FAMILY_MAPPING, DataAction, SmartTag
 from tests.utils import save_outcomes, save_predictions
 
 
@@ -301,14 +296,6 @@ def test_metrics_per_filter(tiny_text_config, apply_mocked_startup_task):
         smart_tag_metrics = getattr(result.metrics_per_filter, family.value)
         assert sum([mf_v.utterance_count for mf_v in smart_tag_metrics]) == ds_len
         assert len(smart_tag_metrics) == len(smart_tags) + 1
-
-    data_action_metrics = result.metrics_per_filter.data_action
-    assert sum([mf_v.utterance_count for mf_v in data_action_metrics]) == ds_len
-    assert len(data_action_metrics) == len(ALL_DATA_ACTION_FILTERS)
-
-    outcome_metrics = result.metrics_per_filter.outcome
-    assert sum([mf_v.utterance_count for mf_v in outcome_metrics]) == ds_len
-    assert len(outcome_metrics) == 4
 
 
 _CITATION = """\

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -137,8 +137,8 @@ export interface components {
       pipelines?: components["schemas"]["PipelineDefinition"][];
       uncertainty?: components["schemas"]["UncertaintyOptions"];
       saliency_layer?: string;
-      metrics?: { [key: string]: components["schemas"]["MetricDefinition"] };
       behavioral_testing?: components["schemas"]["BehavioralTestingOptions"];
+      metrics?: { [key: string]: components["schemas"]["MetricDefinition"] };
     };
     BehavioralTestingOptions: {
       neutral_token?: components["schemas"]["NeutralTokenOptions"];

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -378,13 +378,13 @@ export interface components {
      * that all fields are represented correctly.
      */
     MetricsPerFilter: {
-      extremeLength: components["schemas"]["MetricsPerFilterValue"][];
-      partialSyntax: components["schemas"]["MetricsPerFilterValue"][];
-      dissimilar: components["schemas"]["MetricsPerFilterValue"][];
       almostCorrect: components["schemas"]["MetricsPerFilterValue"][];
       behavioralTesting: components["schemas"]["MetricsPerFilterValue"][];
       pipelineComparison: components["schemas"]["MetricsPerFilterValue"][];
       uncertain: components["schemas"]["MetricsPerFilterValue"][];
+      extremeLength: components["schemas"]["MetricsPerFilterValue"][];
+      partialSyntax: components["schemas"]["MetricsPerFilterValue"][];
+      dissimilar: components["schemas"]["MetricsPerFilterValue"][];
       label: components["schemas"]["MetricsPerFilterValue"][];
       prediction: components["schemas"]["MetricsPerFilterValue"][];
     };

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -378,17 +378,15 @@ export interface components {
      * that all fields are represented correctly.
      */
     MetricsPerFilter: {
+      extremeLength: components["schemas"]["MetricsPerFilterValue"][];
+      partialSyntax: components["schemas"]["MetricsPerFilterValue"][];
+      dissimilar: components["schemas"]["MetricsPerFilterValue"][];
       almostCorrect: components["schemas"]["MetricsPerFilterValue"][];
       behavioralTesting: components["schemas"]["MetricsPerFilterValue"][];
       pipelineComparison: components["schemas"]["MetricsPerFilterValue"][];
       uncertain: components["schemas"]["MetricsPerFilterValue"][];
-      prediction: components["schemas"]["MetricsPerFilterValue"][];
-      outcome: components["schemas"]["MetricsPerFilterValue"][];
-      extremeLength: components["schemas"]["MetricsPerFilterValue"][];
-      partialSyntax: components["schemas"]["MetricsPerFilterValue"][];
-      dissimilar: components["schemas"]["MetricsPerFilterValue"][];
       label: components["schemas"]["MetricsPerFilterValue"][];
-      dataAction: components["schemas"]["MetricsPerFilterValue"][];
+      prediction: components["schemas"]["MetricsPerFilterValue"][];
     };
     /**
      * This model should be used as the base for any model that defines aliases to ensure


### PR DESCRIPTION
## Description:
- I fixed a few issues with config scopes and expirable modules. Modules don't need `AzimuthConfig` as a scope if they are affected by smart tags, as long as they are `ExpirableModule`s. Since `FilterableModule`s are already `ExpirableModule`s, they were all ok except `MetricsbyFilter`. 
- I also separated the `metrics` from the `ModelContractConfig`, to avoid recomputing all predictions if we only change the metrics. 

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
