### PR TITLE
Support training set only

### DIFF
--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -164,7 +164,7 @@ def create_app() -> FastAPI:
     api_router.include_router(admin_router, prefix="/admin")
     api_router.include_router(
         class_overlap_router,
-        prefix="/class_overlap",
+        prefix="/dataset_splits/{dataset_split_name}/class_overlap",
         dependencies=[Depends(require_application_ready)],
     )
     api_router.include_router(tags_router, prefix="/tags", dependencies=[])

--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -251,7 +251,8 @@ def initialize_managers(azimuth_config, cluster):
     # Validate that everything is in order **before** the startup tasks.
     if _dataset_split_managers.get(DatasetSplitName.train):
         run_validation(DatasetSplitName.train, _task_manager, azimuth_config)
-    run_validation(DatasetSplitName.eval, _task_manager, azimuth_config)
+    if _dataset_split_managers.get(DatasetSplitName.eval):
+        run_validation(DatasetSplitName.eval, _task_manager, azimuth_config)
 
     _startup_tasks = startup.startup_tasks(_dataset_split_managers, _task_manager)
     _ready_flag = Event()

--- a/azimuth/modules/dataset_analysis/similarity_analysis.py
+++ b/azimuth/modules/dataset_analysis/similarity_analysis.py
@@ -75,22 +75,13 @@ class NeighborsTaggingModule(DatasetResultModule[SimilarityConfig]):
     def compute_on_dataset_split(self) -> List[TaggingResponse]:  # type: ignore
         # Get the features from FAISS for all available splits to make sure they are all computed
         # and that we can compute neighbors for all splits.
-        eval_features = (
-            self._get_features_from_faiss(DatasetSplitName.eval)
-            if DatasetSplitName.eval in self.available_dataset_splits
-            else None
-        )
-        train_features = (
-            self._get_features_from_faiss(DatasetSplitName.train)
-            if DatasetSplitName.train in self.available_dataset_splits
-            else None
-        )
+        features_dict = {
+            split: self._get_features_from_faiss(split) for split in self.available_dataset_splits
+        }
 
         dm = self.get_dataset_split_manager()
         indices = self.get_indices()
-        features = assert_not_none(
-            eval_features if self.dataset_split_name == DatasetSplitName.eval else train_features
-        )
+        features = features_dict[self.dataset_split_name]
         neighbors = self.get_neighbors([features[i] for i in indices])
 
         similarity_config: SimilarityOptions = assert_not_none(self.config.similarity)

--- a/azimuth/modules/dataset_analysis/similarity_analysis.py
+++ b/azimuth/modules/dataset_analysis/similarity_analysis.py
@@ -73,7 +73,8 @@ class NeighborsTaggingModule(DatasetResultModule[SimilarityConfig]):
     """Compute neighbors for each utterance in a dataset split."""
 
     def compute_on_dataset_split(self) -> List[TaggingResponse]:  # type: ignore
-        # FAISS is computed for all available splits so neighbors can be computed for all splits.
+        # Get the features from FAISS for all available splits to make sure they are all computed
+        # and that we can compute neighbors for all splits.
         eval_features = (
             self._get_features_from_faiss(DatasetSplitName.eval)
             if DatasetSplitName.eval in self.available_dataset_splits

--- a/azimuth/routers/v1/app.py
+++ b/azimuth/routers/v1/app.py
@@ -93,7 +93,7 @@ def get_dataset_info(
 ):
     eval_dm = dataset_split_managers.get(DatasetSplitName.eval)
     training_dm = dataset_split_managers.get(DatasetSplitName.train)
-    dm = assert_not_none(eval_dm if eval_dm is not None else training_dm)
+    dm = assert_not_none(eval_dm or training_dm)
 
     model_contract = task_manager.config.model_contract
 

--- a/azimuth/routers/v1/app.py
+++ b/azimuth/routers/v1/app.py
@@ -38,6 +38,7 @@ from azimuth.utils.project import (
     similarity_available,
 )
 from azimuth.utils.routers import (
+    get_last_update,
     get_standard_task_result,
     require_application_ready,
     require_available_model,
@@ -169,9 +170,7 @@ def get_perturbation_testing_summary(
     eval_dm = dataset_split_managers.get(DatasetSplitName.eval)
     training_dm = dataset_split_managers.get(DatasetSplitName.train)
 
-    last_update_eval = eval_dm.last_update if eval_dm else 0
-    last_update_train = training_dm.last_update if training_dm else 0
-    last_update = max(last_update_eval, last_update_train)
+    last_update = get_last_update([training_dm, eval_dm])
 
     if perturbation_testing_available(config) and pipeline_index is not None:
         perturbation_testing_result: PerturbationTestingMergedResponse = get_standard_task_result(

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -43,9 +43,10 @@ def load_dataset_from_config(azimuth_config: AzimuthConfig) -> DatasetDict:
         dataset_train_eval[DatasetSplitName.eval] = dataset_in_config["validation"]
     elif "test" in dataset_in_config and len(dataset_in_config["test"]) > 0:
         dataset_train_eval[DatasetSplitName.eval] = dataset_in_config["test"]
-    else:
+
+    if not dataset_train_eval:
         raise ValueError(
-            "Unable to find a validation set or a test set. "
+            "Unable to find a dataset split named train, validation or test"
             f"Found {tuple(dataset_in_config.keys())}."
         )
     return dataset_train_eval

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -37,7 +37,7 @@ def load_dataset_from_config(azimuth_config: AzimuthConfig) -> DatasetDict:
         azimuth_config.dataset, azimuth_config=azimuth_config
     )
     dataset_train_eval: DatasetDict = DatasetDict()
-    if "train" in dataset_in_config:
+    if "train" in dataset_in_config and len(dataset_in_config["train"]) > 0:
         dataset_train_eval[DatasetSplitName.train] = dataset_in_config["train"]
     if "validation" in dataset_in_config and len(dataset_in_config["validation"]) > 0:
         dataset_train_eval[DatasetSplitName.eval] = dataset_in_config["validation"]

--- a/azimuth_shr/loading_resources.py
+++ b/azimuth_shr/loading_resources.py
@@ -60,10 +60,13 @@ def load_sst2_dataset() -> DatasetDict:
     )
 
 
-def load_CLINC150_data(full_path, python_loader, train=True) -> Dataset:
+def load_CLINC150_data(full_path, python_loader, train=True, eval=True) -> Dataset:
     """This dataset contains train, validation and test in one file."""
     log.debug("Loading dataset for CLINC150 intent classification")
     dst = load_dataset(python_loader, data_files={"full": full_path})
     if not train:
         dst.pop("train")
+    if not eval:
+        dst.pop("validation")
+        dst.pop("test")
     return dst

--- a/config/development/clinc_dummy/conf_no_eval.json
+++ b/config/development/clinc_dummy/conf_no_eval.json
@@ -1,0 +1,26 @@
+{
+  "name": "CLINC Dummy no eval",
+  "pipelines": [
+    {
+      "model": {
+        "class_name": "loading_resources.load_hf_text_classif_pipeline",
+        "remote": "/azimuth_shr",
+        "kwargs": {
+          "checkpoint_path": "/azimuth_shr/files/clinc-demo/CLINC150_trained_model"
+        }
+      }
+    }
+  ],
+  "dataset": {
+    "class_name": "loading_resources.load_CLINC150_data",
+    "remote": "/azimuth_shr",
+    "kwargs": {
+      "python_loader": "/azimuth_shr/data/CLINC150.py",
+      "full_path": "/azimuth_shr/files/clinc-demo/oos-eval/data/clinc_data_dummy.json",
+      "eval": false
+    }
+  },
+  "saliency_layer": "distilbert.embeddings.word_embeddings",
+  "model_contract": "hf_text_classification",
+  "rejection_class": "NO_INTENT"
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1712,7 +1712,7 @@ python-versions = ">=3.8"
 
 [[package]]
 name = "oauthlib"
-version = "3.2.0"
+version = "3.2.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 category = "main"
 optional = false
@@ -4703,8 +4703,8 @@ numpy = [
     {file = "numpy-1.22.4.zip", hash = "sha256:425b390e4619f58d8526b3dcf656dde069133ae5c240229821f01b5f44ea07af"},
 ]
 oauthlib = [
-    {file = "oauthlib-3.2.0-py3-none-any.whl", hash = "sha256:6db33440354787f9b7f3a6dbd4febf5d0f93758354060e802f6c06cb493022fe"},
-    {file = "oauthlib-3.2.0.tar.gz", hash = "sha256:23a8208d75b902797ea29fd31fa80a15ed9dc2c6c16fe73f5d346f83f6fa27a2"},
+    {file = "oauthlib-3.2.1-py3-none-any.whl", hash = "sha256:88e912ca1ad915e1dcc1c06fc9259d19de8deacd6fd17cc2df266decc2e49066"},
+    {file = "oauthlib-3.2.1.tar.gz", hash = "sha256:1565237372795bf6ee3e5aba5e2a85bd5a65d0e2aa5c628b9a97b7d7a0da3721"},
 ]
 onnx = [
     {file = "onnx-1.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bdbd2578424c70836f4d0f9dda16c21868ddb07cc8192f9e8a176908b43d694b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -2026,7 +2026,7 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "3.19.4"
+version = "3.19.5"
 description = "Protocol Buffers"
 category = "main"
 optional = false
@@ -4982,32 +4982,31 @@ prompt-toolkit = [
     {file = "prompt_toolkit-3.0.28.tar.gz", hash = "sha256:9f1cd16b1e86c2968f2519d7fb31dd9d669916f515612c269d14e9ed52b51650"},
 ]
 protobuf = [
-    {file = "protobuf-3.19.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f51d5a9f137f7a2cec2d326a74b6e3fc79d635d69ffe1b036d39fc7d75430d37"},
-    {file = "protobuf-3.19.4-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:09297b7972da685ce269ec52af761743714996b4381c085205914c41fcab59fb"},
-    {file = "protobuf-3.19.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072fbc78d705d3edc7ccac58a62c4c8e0cec856987da7df8aca86e647be4e35c"},
-    {file = "protobuf-3.19.4-cp310-cp310-win32.whl", hash = "sha256:7bb03bc2873a2842e5ebb4801f5c7ff1bfbdf426f85d0172f7644fcda0671ae0"},
-    {file = "protobuf-3.19.4-cp310-cp310-win_amd64.whl", hash = "sha256:f358aa33e03b7a84e0d91270a4d4d8f5df6921abe99a377828839e8ed0c04e07"},
-    {file = "protobuf-3.19.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1c91ef4110fdd2c590effb5dca8fdbdcb3bf563eece99287019c4204f53d81a4"},
-    {file = "protobuf-3.19.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c438268eebb8cf039552897d78f402d734a404f1360592fef55297285f7f953f"},
-    {file = "protobuf-3.19.4-cp36-cp36m-win32.whl", hash = "sha256:835a9c949dc193953c319603b2961c5c8f4327957fe23d914ca80d982665e8ee"},
-    {file = "protobuf-3.19.4-cp36-cp36m-win_amd64.whl", hash = "sha256:4276cdec4447bd5015453e41bdc0c0c1234eda08420b7c9a18b8d647add51e4b"},
-    {file = "protobuf-3.19.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6cbc312be5e71869d9d5ea25147cdf652a6781cf4d906497ca7690b7b9b5df13"},
-    {file = "protobuf-3.19.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:54a1473077f3b616779ce31f477351a45b4fef8c9fd7892d6d87e287a38df368"},
-    {file = "protobuf-3.19.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:435bb78b37fc386f9275a7035fe4fb1364484e38980d0dd91bc834a02c5ec909"},
-    {file = "protobuf-3.19.4-cp37-cp37m-win32.whl", hash = "sha256:16f519de1313f1b7139ad70772e7db515b1420d208cb16c6d7858ea989fc64a9"},
-    {file = "protobuf-3.19.4-cp37-cp37m-win_amd64.whl", hash = "sha256:cdc076c03381f5c1d9bb1abdcc5503d9ca8b53cf0a9d31a9f6754ec9e6c8af0f"},
-    {file = "protobuf-3.19.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:69da7d39e39942bd52848438462674c463e23963a1fdaa84d88df7fbd7e749b2"},
-    {file = "protobuf-3.19.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:48ed3877fa43e22bcacc852ca76d4775741f9709dd9575881a373bd3e85e54b2"},
-    {file = "protobuf-3.19.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd95d1dfb9c4f4563e6093a9aa19d9c186bf98fa54da5252531cc0d3a07977e7"},
-    {file = "protobuf-3.19.4-cp38-cp38-win32.whl", hash = "sha256:b38057450a0c566cbd04890a40edf916db890f2818e8682221611d78dc32ae26"},
-    {file = "protobuf-3.19.4-cp38-cp38-win_amd64.whl", hash = "sha256:7ca7da9c339ca8890d66958f5462beabd611eca6c958691a8fe6eccbd1eb0c6e"},
-    {file = "protobuf-3.19.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:36cecbabbda242915529b8ff364f2263cd4de7c46bbe361418b5ed859677ba58"},
-    {file = "protobuf-3.19.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c1068287025f8ea025103e37d62ffd63fec8e9e636246b89c341aeda8a67c934"},
-    {file = "protobuf-3.19.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96bd766831596d6014ca88d86dc8fe0fb2e428c0b02432fd9db3943202bf8c5e"},
-    {file = "protobuf-3.19.4-cp39-cp39-win32.whl", hash = "sha256:84123274d982b9e248a143dadd1b9815049f4477dc783bf84efe6250eb4b836a"},
-    {file = "protobuf-3.19.4-cp39-cp39-win_amd64.whl", hash = "sha256:3112b58aac3bac9c8be2b60a9daf6b558ca3f7681c130dcdd788ade7c9ffbdca"},
-    {file = "protobuf-3.19.4-py2.py3-none-any.whl", hash = "sha256:8961c3a78ebfcd000920c9060a262f082f29838682b1f7201889300c1fbe0616"},
-    {file = "protobuf-3.19.4.tar.gz", hash = "sha256:9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a"},
+    {file = "protobuf-3.19.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:f2b599a21c9a32e171ec29a2ac54e03297736c578698e11b099d031f79da114b"},
+    {file = "protobuf-3.19.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f976234e20ab2785f54224bcdafa027674e23663b132fa3ca0caa291a6cfbde7"},
+    {file = "protobuf-3.19.5-cp310-cp310-win32.whl", hash = "sha256:4ee2af7051d3b10c8a4fe6fd1a2c69f201fea36aeee7086cf202a692e1b99ee1"},
+    {file = "protobuf-3.19.5-cp310-cp310-win_amd64.whl", hash = "sha256:dca2284378a5f2a86ffed35c6ac147d14c48b525eefcd1083e5a9ce28dfa8657"},
+    {file = "protobuf-3.19.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c0f80876a8ff0ae7064084ed094eb86497bd5a3812e6fc96a05318b92301674e"},
+    {file = "protobuf-3.19.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c4160b601220627f7e91154e572baf5e161a9c3f445a8242d536ee3d0b7b17c"},
+    {file = "protobuf-3.19.5-cp36-cp36m-win32.whl", hash = "sha256:f2bde37667b18c2b5280df83bc799204394a5d2d774e4deaf9de0eb741df6833"},
+    {file = "protobuf-3.19.5-cp36-cp36m-win_amd64.whl", hash = "sha256:1867f93b06a183f87696871bb8d1e99ee71dbb69d468ce1f0cc8bf3d30f982f3"},
+    {file = "protobuf-3.19.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a89aa0c042e61e11ade320b802d6db4ee5391d8d973e46d3a48172c1597789f8"},
+    {file = "protobuf-3.19.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f9cebda093c2f6bfed88f1c17cdade09d4d96096421b344026feee236532d4de"},
+    {file = "protobuf-3.19.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67efb5d20618020aa9596e17bfc37ca068c28ec0c1507d9507f73c93d46c9855"},
+    {file = "protobuf-3.19.5-cp37-cp37m-win32.whl", hash = "sha256:950abd6c00e7b51f87ae8b18a0ce4d69fea217f62f171426e77de5061f6d9850"},
+    {file = "protobuf-3.19.5-cp37-cp37m-win_amd64.whl", hash = "sha256:d3973a2d58aefc7d1230725c2447ce7f86a71cbc094b86a77c6ee1505ac7cdb1"},
+    {file = "protobuf-3.19.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e1d74032f56ff25f417cfe84c8147047732e5059137ca42efad20cbbd25f5e0"},
+    {file = "protobuf-3.19.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d249519ba5ecf5dd6b18150c9b6bcde510b273714b696f3923ff8308fc11ae49"},
+    {file = "protobuf-3.19.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f957ef53e872d58a0afd3bf6d80d48535d28c99b40e75e6634cbc33ea42fd54"},
+    {file = "protobuf-3.19.5-cp38-cp38-win32.whl", hash = "sha256:5470f892961af464ae6eaf0f3099e2c1190ae8c7f36f174b89491281341f79ca"},
+    {file = "protobuf-3.19.5-cp38-cp38-win_amd64.whl", hash = "sha256:c44e3282cff74ad18c7e8a0375f407f69ee50c2116364b44492a196293e08b21"},
+    {file = "protobuf-3.19.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:66d14b5b90090353efe75c9fb1bf65ef7267383034688d255b500822e37d5c2f"},
+    {file = "protobuf-3.19.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f4f909f4dde413dec435a44b0894956d55bb928ded7d6e3c726556ca4c796e84"},
+    {file = "protobuf-3.19.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5266c36cc0af3bb3dbf44f199d225b33da66a9a5c3bdc2b14865ad10eddf0e37"},
+    {file = "protobuf-3.19.5-cp39-cp39-win32.whl", hash = "sha256:6a02172b9650f819d01fb8e224fc69b0706458fc1ab4f1c669281243c71c1a5e"},
+    {file = "protobuf-3.19.5-cp39-cp39-win_amd64.whl", hash = "sha256:696e6cfab94cc15a14946f2bf72719dced087d437adbd994fff34f38986628bc"},
+    {file = "protobuf-3.19.5-py2.py3-none-any.whl", hash = "sha256:9e42b1cf2ecd8a1bd161239e693f22035ba99905ae6d7efeac8a0546c7ec1a27"},
+    {file = "protobuf-3.19.5.tar.gz", hash = "sha256:e63b0b3c42e51c94add62b010366cd4979cb6d5f06158bcae8faac4c294f91e1"},
 ]
 psutil = [
     {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,13 @@ def tiny_text_config_no_train(tiny_text_config) -> AzimuthConfig:
     return tiny_text_config_no_train
 
 
+@pytest.fixture(params=["train", "eval"])
+def tiny_text_config_one_ds(tiny_text_config, request) -> AzimuthConfig:
+    tiny_text_config_one_ds = tiny_text_config.copy(deep=True)
+    tiny_text_config_one_ds.dataset.kwargs[request.param] = False
+    return tiny_text_config_one_ds
+
+
 @pytest.fixture
 def tiny_text_config_no_pipeline(tiny_text_config) -> AzimuthConfig:
     tiny_text_config_no_pipeline = tiny_text_config.copy(deep=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,13 +109,6 @@ def tiny_text_config(simple_text_config) -> AzimuthConfig:
     return tiny_text_config
 
 
-@pytest.fixture
-def tiny_text_config_no_train(tiny_text_config) -> AzimuthConfig:
-    tiny_text_config_no_train = tiny_text_config.copy(deep=True)
-    tiny_text_config_no_train.dataset.kwargs["train"] = False
-    return tiny_text_config_no_train
-
-
 @pytest.fixture(params=["train", "eval"])
 def tiny_text_config_one_ds(tiny_text_config, request) -> AzimuthConfig:
     tiny_text_config_one_ds = tiny_text_config.copy(deep=True)

--- a/tests/test_loading_resources.py
+++ b/tests/test_loading_resources.py
@@ -58,11 +58,15 @@ def load_hf_text_classif_pipeline(checkpoint_path: str, azimuth_config: AzimuthC
     )
 
 
-def load_sst2_dataset(train: bool = True, max_dataset_len: int = _MAX_DATASET_LEN) -> DatasetDict:
+def load_sst2_dataset(
+    train: bool = True, eval: bool = True, max_dataset_len: int = _MAX_DATASET_LEN
+) -> DatasetDict:
     datasets = load_dataset("glue", "sst2")
-    datasets["validation"] = datasets["validation"].rename_column("sentence", "utterance")
-    # Test has no label
-    ds = {"validation": datasets["validation"].select(np.arange(max_dataset_len))}
+    ds = {}
+    if eval:
+        # Test set has no label
+        datasets["validation"] = datasets["validation"].rename_column("sentence", "utterance")
+        ds.update({"validation": datasets["validation"].select(np.arange(max_dataset_len))})
     if train:
         datasets["train"] = datasets["train"].rename_column("sentence", "utterance")
         ds.update({"train": datasets["train"].select(np.arange(max_dataset_len))})

--- a/tests/test_loading_resources.py
+++ b/tests/test_loading_resources.py
@@ -66,10 +66,10 @@ def load_sst2_dataset(
     if eval:
         # Test set has no label
         datasets["validation"] = datasets["validation"].rename_column("sentence", "utterance")
-        ds.update({"validation": datasets["validation"].select(np.arange(max_dataset_len))})
+        ds["validation"] = datasets["validation"].select(np.arange(max_dataset_len))
     if train:
         datasets["train"] = datasets["train"].rename_column("sentence", "utterance")
-        ds.update({"train": datasets["train"].select(np.arange(max_dataset_len))})
+        ds["train"] = datasets["train"].select(np.arange(max_dataset_len))
     return DatasetDict(ds)
 
 

--- a/tests/test_modules/test_dataset_analysis/test_similarity_analysis.py
+++ b/tests/test_modules/test_dataset_analysis/test_similarity_analysis.py
@@ -10,7 +10,7 @@ from azimuth.dataset_split_manager import FEATURE_FAISS
 from azimuth.modules.dataset_analysis.similarity_analysis import NeighborsTaggingModule
 from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions
 from azimuth.types.tag import SmartTag
-from tests.utils import get_table_key
+from tests.utils import get_table_key, get_tiny_text_config_one_ds_name
 
 IDX = 3
 
@@ -71,18 +71,19 @@ def test_neighbors(simple_text_config, dask_client, monkeypatch):
     # Would currently fail on mod.save_result() because of indices (length) mismatch
 
 
-def test_neighbors_no_train(tiny_text_config_no_train, dask_client, monkeypatch):
+def test_neighbors_one_ds(tiny_text_config_one_ds, dask_client, monkeypatch):
     monkeypatch.setattr(faiss_mod, "SentenceTransformer", MockedTransformer)
     # Mock SentenceTransformer on all workers.
     dask_client.run(
         lambda: monkeypatch.setattr(faiss_mod, "SentenceTransformer", MockedTransformer)
     )
-    tiny_text_config_no_train.similarity.conflicting_neighbors_threshold = 0.1
+    tiny_text_config_one_ds.similarity.conflicting_neighbors_threshold = 0.1
 
-    mod = NeighborsTaggingModule(DatasetSplitName.eval, tiny_text_config_no_train)
+    ds_name, other_ds_name = get_tiny_text_config_one_ds_name(tiny_text_config_one_ds)
+    mod = NeighborsTaggingModule(ds_name, tiny_text_config_one_ds)
     res = mod.compute_on_dataset_split()
 
-    assert not any([r.tags["conflicting_neighbors_train"] for r in res])
-    assert not any([r.tags["no_close_train"] for r in res])
-    assert not any([r.adds["neighbors_train"] for r in res])
-    assert any([r.adds["neighbors_eval"] for r in res])
+    assert not any([r.tags[f"conflicting_neighbors_{other_ds_name}"] for r in res])
+    assert not any([r.tags[f"no_close_{other_ds_name}"] for r in res])
+    assert not any([r.adds[f"neighbors_{other_ds_name}"] for r in res])
+    assert any([r.adds[f"neighbors_{ds_name}"] for r in res])

--- a/tests/test_modules/test_perturbation_testing/test_perturbation_testing_summary.py
+++ b/tests/test_modules/test_perturbation_testing/test_perturbation_testing_summary.py
@@ -47,11 +47,11 @@ def test_perturbation_testing_summary_one_ds(tiny_text_config_one_ds):
         config=tiny_text_config_one_ds,
         mod_options=ModuleOptions(pipeline_index=0),
     )
-    res_dict = mod.compute_on_dataset_split()[0].no_alias_dict()
+    [res] = mod.compute_on_dataset_split()
     ds_name, other_ds_name = get_tiny_text_config_one_ds_name(tiny_text_config_one_ds)
     assert (
-        res_dict[f"{ds_name}_failure_rate"] >= 0.0
-        and res_dict[f"{other_ds_name}_failure_rate"] == 0.0
+        getattr(res, f"{ds_name}_failure_rate") >= 0.0
+        and getattr(res, f"{other_ds_name}_failure_rate") == 0.0
     )
 
     mod_sum = PerturbationTestingSummaryModule(
@@ -61,4 +61,4 @@ def test_perturbation_testing_summary_one_ds(tiny_text_config_one_ds):
     )
 
     res = mod_sum.compute_on_dataset_split()[0]
-    assert all(t.no_alias_dict()[f"{other_ds_name}_count"] == 0 for t in res.all_tests_summary)
+    assert all(getattr(t, f"{other_ds_name}_count") == 0 for t in res.all_tests_summary)

--- a/tests/test_modules/test_perturbation_testing/test_perturbation_testing_summary.py
+++ b/tests/test_modules/test_perturbation_testing/test_perturbation_testing_summary.py
@@ -1,12 +1,14 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
+
 from azimuth.modules.perturbation_testing import (
     PerturbationTestingMergedModule,
     PerturbationTestingModule,
     PerturbationTestingSummaryModule,
 )
 from azimuth.types import DatasetSplitName, ModuleOptions
+from tests.utils import get_tiny_text_config_one_ds_name
 
 
 def test_perturbation_testing_summary(tiny_text_config):
@@ -39,20 +41,24 @@ def test_perturbation_testing_summary(tiny_text_config):
             assert any(test.name in r.name for r in res)
 
 
-def test_without_train(tiny_text_config_no_train):
+def test_perturbation_testing_summary_one_ds(tiny_text_config_one_ds):
     mod = PerturbationTestingMergedModule(
         dataset_split_name=DatasetSplitName.all,
-        config=tiny_text_config_no_train,
+        config=tiny_text_config_one_ds,
         mod_options=ModuleOptions(pipeline_index=0),
     )
-    [res] = mod.compute_on_dataset_split()
-    assert res.eval_failure_rate >= 0.0 and res.train_failure_rate == 0.0
+    res_dict = mod.compute_on_dataset_split()[0].no_alias_dict()
+    ds_name, other_ds_name = get_tiny_text_config_one_ds_name(tiny_text_config_one_ds)
+    assert (
+        res_dict[f"{ds_name}_failure_rate"] >= 0.0
+        and res_dict[f"{other_ds_name}_failure_rate"] == 0.0
+    )
 
     mod_sum = PerturbationTestingSummaryModule(
         dataset_split_name=DatasetSplitName.all,
-        config=tiny_text_config_no_train,
+        config=tiny_text_config_one_ds,
         mod_options=ModuleOptions(pipeline_index=0),
     )
 
     res = mod_sum.compute_on_dataset_split()[0]
-    assert all(t.train_count == 0 for t in res.all_tests_summary)
+    assert all(t.no_alias_dict()[f"{other_ds_name}_count"] == 0 for t in res.all_tests_summary)

--- a/tests/test_routers/test_class_analysis.py
+++ b/tests/test_routers/test_class_analysis.py
@@ -10,7 +10,7 @@ from starlette.testclient import TestClient
 def test_class_overlap_plot_route(app: FastAPI) -> None:
     client = TestClient(app)
 
-    resp = client.get("/class_overlap/plot")
+    resp = client.get("dataset_splits/train/class_overlap/plot")
     assert resp.status_code == HTTP_200_OK, resp.text
     data = resp.json()
 
@@ -21,7 +21,7 @@ def test_class_overlap_plot_route(app: FastAPI) -> None:
 def test_class_overlap_route(app: FastAPI) -> None:
     client = TestClient(app)
 
-    resp_no_pipeline = client.get("/class_overlap")  # Dataset only, no pipeline
+    resp_no_pipeline = client.get("dataset_splits/train/class_overlap")  # No pipeline
     assert resp_no_pipeline.status_code == HTTP_200_OK, resp_no_pipeline.text
     data_no_pipeline = resp_no_pipeline.json()
 
@@ -48,7 +48,7 @@ def test_class_overlap_route(app: FastAPI) -> None:
         ]
     }
 
-    resp_pipeline_0 = client.get("/class_overlap?pipeline_index=0")
+    resp_pipeline_0 = client.get("dataset_splits/train/class_overlap?pipeline_index=0")
     assert resp_pipeline_0.status_code == HTTP_200_OK, resp_pipeline_0.text
     data_pipeline_0 = resp_pipeline_0.json()
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -17,7 +17,7 @@ from azimuth.types import (
     SupportedModule,
 )
 from azimuth.utils.project import load_dataset_split_managers_from_config
-from tests.utils import get_table_key
+from tests.utils import get_table_key, get_tiny_text_config_one_ds_name
 
 
 def test_startup_task(tiny_text_config, tiny_text_task_manager):
@@ -69,12 +69,13 @@ def test_on_end(tiny_text_config):
     task_manager.clear_worker_cache.assert_called_once()
 
 
-def test_startup_task_no_train(tiny_text_config_no_train, tiny_text_task_manager):
-    dms = load_dataset_split_managers_from_config(tiny_text_config_no_train)
+def test_startup_task_one_ds(tiny_text_config_one_ds, tiny_text_task_manager):
+    dms = load_dataset_split_managers_from_config(tiny_text_config_one_ds)
     assert DatasetSplitName.eval in dms and DatasetSplitName.train in dms
 
     mods = startup_tasks(dms, tiny_text_task_manager)
-    assert all("train" not in k or "eval" in k for k in mods.keys())
+    ds_name, other_ds_name = get_tiny_text_config_one_ds_name(tiny_text_config_one_ds)
+    assert all(other_ds_name not in k or ds_name in k for k in mods.keys())
     assert all(
         on_end in [cbk.fn for cbk in mod._callbacks] for mod in mods.values()
     ), "Some modules don't have callbacks!"

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -76,7 +76,7 @@ def test_startup_task_one_ds(tiny_text_config_one_ds, tiny_text_task_manager):
     mods = startup_tasks(dms, tiny_text_task_manager)
     ds_name, other_ds_name = get_tiny_text_config_one_ds_name(tiny_text_config_one_ds)
     assert all(
-        (DatasetSplitName.all or ds_name in k) and other_ds_name not in k for k in mods.keys()
+        (DatasetSplitName.all in k or ds_name in k) and other_ds_name not in k for k in mods.keys()
     )
     assert all(
         on_end in [cbk.fn for cbk in mod._callbacks] for mod in mods.values()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -75,7 +75,9 @@ def test_startup_task_one_ds(tiny_text_config_one_ds, tiny_text_task_manager):
 
     mods = startup_tasks(dms, tiny_text_task_manager)
     ds_name, other_ds_name = get_tiny_text_config_one_ds_name(tiny_text_config_one_ds)
-    assert all(other_ds_name not in k or ds_name in k for k in mods.keys())
+    assert all(
+        (DatasetSplitName.all or ds_name in k) and other_ds_name not in k for k in mods.keys()
+    )
     assert all(
         on_end in [cbk.fn for cbk in mod._callbacks] for mod in mods.values()
     ), "Some modules don't have callbacks!"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -193,3 +193,11 @@ def add_tags(dm):
     table_key = get_table_key(dm.config)
     add_all_tags_once(ALL_DATA_ACTIONS)
     add_all_tags_once(ALL_SMART_TAGS)
+
+
+def get_tiny_text_config_one_ds_name(config):
+    ds_name = DatasetSplitName.eval if "train" in config.dataset.kwargs else DatasetSplitName.train
+    other_ds_name = (
+        DatasetSplitName.train if ds_name == DatasetSplitName.eval else DatasetSplitName.eval
+    )
+    return ds_name, other_ds_name

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -89,12 +89,26 @@ export default class App extends React.Component<Props> {
                                 <Settings />
                               </BasicLayout>
                             </Route>
-                            <Route path="/:jobId/class_overlap" exact>
+                            <Route
+                              path="/:jobId/dataset_splits/:datasetSplitName/class_overlap"
+                              exact
+                            >
                               <BasicLayout maxWidth="md">
                                 <ClassOverlap />
                               </BasicLayout>
                             </Route>
-                            <Route path="/:jobId/smart_tags" exact>
+                            <Route
+                              path="/:jobId/dataset_splits/:datasetSplitName/pipeline_metrics"
+                              exact
+                            >
+                              <BasicLayout>
+                                <PerformanceAnalysis />
+                              </BasicLayout>
+                            </Route>
+                            <Route
+                              path="/:jobId/dataset_splits/:datasetSplitName/smart_tags"
+                              exact
+                            >
                               <BasicLayout>
                                 <SmartTags />
                               </BasicLayout>
@@ -135,11 +149,6 @@ export default class App extends React.Component<Props> {
                             >
                               <BasicLayout>
                                 <UtteranceDetail />
-                              </BasicLayout>
-                            </Route>
-                            <Route path="/:jobId/pipeline_metrics" exact>
-                              <BasicLayout>
-                                <PerformanceAnalysis />
                               </BasicLayout>
                             </Route>
                             <Route>

--- a/webapp/src/components/Analysis/PerturbationTestingPreview.tsx
+++ b/webapp/src/components/Analysis/PerturbationTestingPreview.tsx
@@ -22,8 +22,13 @@ const PerturbationTestingPreview: React.FC<{
   const { data, error, isError, isFetching } =
     getPerturbationTestingSummaryEndpoint.useQuery({ jobId, ...pipeline });
 
+  const defaultOption = DATASET_SPLIT_NAMES.findIndex(
+    (datasetSplitName) => availableDatasetSplits[datasetSplitName]
+  );
+
   return (
     <PreviewToggle
+      defaultOption={defaultOption}
       options={DATASET_SPLIT_NAMES.map((name, i) => ({
         button: (
           <PreviewToggleButton

--- a/webapp/src/components/Analysis/PreviewToggle.tsx
+++ b/webapp/src/components/Analysis/PreviewToggle.tsx
@@ -2,14 +2,15 @@ import { Box, ToggleButton, ToggleButtonGroup } from "@mui/material";
 import React from "react";
 
 type Props = {
+  defaultOption?: number;
   options: {
     button: React.ReactElement<typeof ToggleButton>;
     content: React.ReactNode;
   }[];
 };
 
-const PreviewToggle: React.FC<Props> = ({ options }) => {
-  const [option, setOption] = React.useState(0);
+const PreviewToggle: React.FC<Props> = ({ defaultOption = 0, options }) => {
+  const [option, setOption] = React.useState(defaultOption);
 
   const handleOptionChange = (newValue: number | null) => {
     if (newValue !== null) {

--- a/webapp/src/components/ClassOverlapTable.tsx
+++ b/webapp/src/components/ClassOverlapTable.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box } from "@mui/material";
-import { GridValueFormatterParams, GridCellParams } from "@mui/x-data-grid";
+import { GridCellParams, GridValueFormatterParams } from "@mui/x-data-grid";
 import { QueryPipelineState } from "types/models";
 import { getClassOverlapEndpoint } from "services/api";
 import { formatRatioAsPercentageString } from "utils/format";
@@ -9,7 +9,7 @@ import SeeMoreLess, {
   useMoreLess,
 } from "components/SeeMoreLess";
 import { Table } from "./Table";
-import { ClassOverlapTableClassPair } from "types/api";
+import { AvailableDatasetSplits, ClassOverlapTableClassPair } from "types/api";
 import { isPipelineSelected } from "utils/helpers";
 
 const ROW_HEIGHT = 35;
@@ -19,11 +19,16 @@ type Row = ClassOverlapTableClassPair & { id: number };
 type Props = {
   jobId: string;
   pipeline: QueryPipelineState;
+  availableDatasetSplits: AvailableDatasetSplits | undefined;
 };
 const twoDigitFormatter = ({ value }: GridValueFormatterParams) =>
   isNaN(value as number) ? "--" : (value as number).toFixed(2);
 
-const ClassOverlapTable: React.FC<Props> = ({ jobId, pipeline }) => {
+const ClassOverlapTable: React.FC<Props> = ({
+  jobId,
+  pipeline,
+  availableDatasetSplits,
+}) => {
   const { data, isFetching, error } = getClassOverlapEndpoint.useQuery({
     jobId,
     ...pipeline,
@@ -120,7 +125,9 @@ const ClassOverlapTable: React.FC<Props> = ({ jobId, pipeline }) => {
         },
       ]}
       columnVisibilityModel={
-        isPipelineSelected(pipeline) ? {} : { pipelineConfusionEval: false }
+        isPipelineSelected(pipeline) && availableDatasetSplits?.eval
+          ? {}
+          : { pipelineConfusionEval: false }
       }
       rows={rows}
       sortingOrder={["desc", "asc"]}

--- a/webapp/src/components/ClassOverlapTable.tsx
+++ b/webapp/src/components/ClassOverlapTable.tsx
@@ -19,7 +19,7 @@ type Row = ClassOverlapTableClassPair & { id: number };
 type Props = {
   jobId: string;
   pipeline: QueryPipelineState;
-  availableDatasetSplits: AvailableDatasetSplits | undefined;
+  availableDatasetSplits: AvailableDatasetSplits;
 };
 const twoDigitFormatter = ({ value }: GridValueFormatterParams) =>
   isNaN(value as number) ? "--" : (value as number).toFixed(2);
@@ -31,6 +31,7 @@ const ClassOverlapTable: React.FC<Props> = ({
 }) => {
   const { data, isFetching, error } = getClassOverlapEndpoint.useQuery({
     jobId,
+    datasetSplitName: "train",
     ...pipeline,
   });
 
@@ -125,7 +126,7 @@ const ClassOverlapTable: React.FC<Props> = ({
         },
       ]}
       columnVisibilityModel={
-        isPipelineSelected(pipeline) && availableDatasetSplits?.eval
+        isPipelineSelected(pipeline) && availableDatasetSplits.eval
           ? {}
           : { pipelineConfusionEval: false }
       }

--- a/webapp/src/components/Metrics/PerformanceAnalysis.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysis.tsx
@@ -82,6 +82,8 @@ type Props = {
   jobId: string;
   pipeline: Required<QueryPipelineState>;
   availableDatasetSplits: AvailableDatasetSplits | undefined;
+  datasetSplitName: DatasetSplitName;
+  setDatasetSplitName: (name: DatasetSplitName) => void;
 };
 
 type Row = MetricsPerFilterValue & { id: number };
@@ -90,9 +92,9 @@ const PerformanceAnalysis: React.FC<Props> = ({
   jobId,
   pipeline,
   availableDatasetSplits,
+  datasetSplitName,
+  setDatasetSplitName,
 }) => {
-  const [selectedDatasetSplit, setSelectedDatasetSplit] =
-    React.useState<DatasetSplitName>("eval");
   const [selectedMetricPerFilterOption, setSelectedMetricPerFilterOption] =
     React.useState<FilterByViewOption>("label");
 
@@ -100,7 +102,7 @@ const PerformanceAnalysis: React.FC<Props> = ({
 
   const { data, isFetching, error } = getMetricsPerFilterEndpoint.useQuery({
     jobId,
-    datasetSplitName: selectedDatasetSplit,
+    datasetSplitName,
     ...pipeline,
   });
 
@@ -280,7 +282,7 @@ const PerformanceAnalysis: React.FC<Props> = ({
   const RowLink = (props: RowProps<Row>) => (
     <Link
       style={{ color: "unset", textDecoration: "unset" }}
-      to={`/${jobId}/dataset_splits/${selectedDatasetSplit}/prediction_overview${constructSearchString(
+      to={`/${jobId}/dataset_splits/${datasetSplitName}/prediction_overview${constructSearchString(
         {
           ...(props.row.id !== OVERALL_ROW_ID && {
             [selectedMetricPerFilterOption]: [props.row.filterValue],
@@ -308,8 +310,8 @@ const PerformanceAnalysis: React.FC<Props> = ({
         <Box width={340}>
           <DatasetSplitToggler
             availableDatasetSplits={availableDatasetSplits}
-            value={selectedDatasetSplit}
-            onChange={setSelectedDatasetSplit}
+            value={datasetSplitName}
+            onChange={setDatasetSplitName}
           />
         </Box>
       </Box>

--- a/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
+++ b/webapp/src/components/Metrics/PerformanceAnalysisTable.tsx
@@ -89,6 +89,8 @@ type Props = {
   pipeline: Required<QueryPipelineState>;
   availableDatasetSplits: AvailableDatasetSplits | undefined;
   isLoading: boolean;
+  datasetSplitName: DatasetSplitName;
+  setDatasetSplitName: (name: DatasetSplitName) => void;
 };
 
 type Row = {
@@ -102,10 +104,9 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
   pipeline,
   availableDatasetSplits,
   isLoading,
+  datasetSplitName,
+  setDatasetSplitName,
 }) => {
-  const [selectedDatasetSplit, setSelectedDatasetSplit] =
-    React.useState<DatasetSplitName>("eval");
-
   const [selectedMetricPerFilterOption, setSelectedMetricPerFilterOption] =
     React.useState<FilterByViewOption>("label");
 
@@ -127,7 +128,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
     error: errorFetchingBasePipelineData,
   } = getMetricsPerFilterEndpoint.useQuery({
     jobId,
-    datasetSplitName: selectedDatasetSplit,
+    datasetSplitName,
     ...pipeline,
   });
 
@@ -138,7 +139,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
   } = getMetricsPerFilterEndpoint.useQuery(
     {
       jobId,
-      datasetSplitName: selectedDatasetSplit,
+      datasetSplitName,
       pipelineIndex: comparedPipeline!,
     },
     { skip: comparedPipeline === undefined }
@@ -462,7 +463,7 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
   const RowLink = (props: RowProps<Row>) => (
     <Link
       style={{ color: "unset", textDecoration: "unset" }}
-      to={`/${jobId}/dataset_splits/${selectedDatasetSplit}/prediction_overview${constructSearchString(
+      to={`/${jobId}/dataset_splits/${datasetSplitName}/prediction_overview${constructSearchString(
         {
           ...(props.row.id !== OVERALL_ROW_ID && {
             [selectedMetricPerFilterOption]: [
@@ -547,8 +548,8 @@ const PerformanceAnalysisTable: React.FC<Props> = ({
         <Box width={340}>
           <DatasetSplitToggler
             availableDatasetSplits={availableDatasetSplits}
-            value={selectedDatasetSplit}
-            onChange={setSelectedDatasetSplit}
+            value={datasetSplitName}
+            onChange={setDatasetSplitName}
           />
         </Box>
         {config?.pipelines && config.pipelines.length > 1 && (

--- a/webapp/src/components/PageHeader.tsx
+++ b/webapp/src/components/PageHeader.tsx
@@ -96,12 +96,16 @@ const PageHeader = () => {
           name: "Behavioral Testing Summary",
         },
         {
-          pathname: `/${jobId}/class_overlap`,
+          pathname: `/${jobId}/dataset_splits/${datasetSplitName}/class_overlap`,
           name: "Class Overlap",
         },
         {
-          pathname: `/${jobId}/pipeline_metrics`,
+          pathname: `/${jobId}/dataset_splits/${datasetSplitName}/pipeline_metrics`,
           name: "Pipeline Metrics by Data Subpopulation",
+        },
+        {
+          pathname: `/${jobId}/dataset_splits/${datasetSplitName}/smart_tags`,
+          name: "Smart Tag Analysis",
         },
         {
           pathname: `/${jobId}/settings`,

--- a/webapp/src/components/SmartTagsTable.tsx
+++ b/webapp/src/components/SmartTagsTable.tsx
@@ -51,9 +51,15 @@ const SmartTagsTable: React.FC<{
   jobId: string;
   pipeline: Required<QueryPipelineState>;
   availableDatasetSplits: AvailableDatasetSplits | undefined;
-}> = ({ jobId, pipeline, availableDatasetSplits }) => {
-  const [datasetSplitName, setDatasetSplitName] =
-    React.useState<DatasetSplitName>("eval");
+  datasetSplitName: DatasetSplitName;
+  setDatasetSplitName: (name: DatasetSplitName) => void;
+}> = ({
+  jobId,
+  pipeline,
+  availableDatasetSplits,
+  datasetSplitName,
+  setDatasetSplitName,
+}) => {
   const [transpose, setTranspose] = React.useState(false);
 
   const [selectedMetricPerFilterOption, setSelectedMetricPerFilterOption] =

--- a/webapp/src/components/WithDatasetSplitNameState.tsx
+++ b/webapp/src/components/WithDatasetSplitNameState.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { DatasetSplitName } from "types/api";
+
+const WithDatasetSplitNameState: React.FC<{
+  defaultDatasetSplitName: DatasetSplitName;
+  render: (
+    datasetSplitName: DatasetSplitName,
+    setDatasetSplitName: (name: DatasetSplitName) => void
+  ) => React.ReactElement;
+}> = ({ defaultDatasetSplitName, render }) => {
+  const [datasetSplitName, setDatasetSplitName] =
+    React.useState<DatasetSplitName>(defaultDatasetSplitName);
+
+  return render(datasetSplitName, setDatasetSplitName);
+};
+
+export default React.memo(WithDatasetSplitNameState);

--- a/webapp/src/pages/ClassOverlap.tsx
+++ b/webapp/src/pages/ClassOverlap.tsx
@@ -32,6 +32,7 @@ const ClassOverlap = () => {
 
   const { data, error, isFetching } = getClassOverlapPlotEndpoint.useQuery({
     jobId,
+    datasetSplitName: "train",
     ...classOverlap,
   });
 

--- a/webapp/src/pages/ClassOverlap.tsx
+++ b/webapp/src/pages/ClassOverlap.tsx
@@ -20,19 +20,24 @@ import useQueryState from "hooks/useQueryState";
 import React from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { getClassOverlapPlotEndpoint } from "services/api";
+import { DatasetSplitName } from "types/api";
 import { QueryClassOverlapState } from "types/models";
+import { DATASET_SPLIT_PRETTY_NAMES } from "utils/const";
 import { constructSearchString } from "utils/helpers";
 
 const OVERLAP_THRESHOLD_INPUT_PROPS = { step: 0.01, min: 0, max: 1 };
 
 const ClassOverlap = () => {
   const history = useHistory();
-  const { jobId } = useParams<{ jobId: string }>();
+  const { jobId, datasetSplitName } = useParams<{
+    jobId: string;
+    datasetSplitName: DatasetSplitName;
+  }>();
   const { classOverlap, pipeline } = useQueryState();
 
   const { data, error, isFetching } = getClassOverlapPlotEndpoint.useQuery({
     jobId,
-    datasetSplitName: "train",
+    datasetSplitName,
     ...classOverlap,
   });
 
@@ -47,13 +52,11 @@ const ClassOverlap = () => {
   const setQuery = React.useCallback(
     (newClassOverlap: QueryClassOverlapState) =>
       history.push(
-        `/${jobId}/class_overlap${constructSearchString({
-          ...pipeline,
-          ...classOverlap,
-          ...newClassOverlap,
-        })}`
+        `/${jobId}/dataset_splits/${datasetSplitName}/class_overlap${constructSearchString(
+          { ...pipeline, ...classOverlap, ...newClassOverlap }
+        )}`
       ),
-    [history, jobId, pipeline, classOverlap]
+    [history, jobId, datasetSplitName, pipeline, classOverlap]
   );
 
   const commitOverlapThreshold = useDebounced(
@@ -62,6 +65,14 @@ const ClassOverlap = () => {
       [setQuery]
     )
   );
+
+  if (datasetSplitName !== "train") {
+    return (
+      <Typography>
+        Only available on {DATASET_SPLIT_PRETTY_NAMES.train} set
+      </Typography>
+    );
+  }
 
   const checkValid = data?.plot.data[0].node.x.length > 0;
 

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -156,7 +156,8 @@ const Dashboard = () => {
             </Box>
           </PreviewCard>
         )}
-      {isPipelineSelected(pipeline) &&
+      {datasetInfo?.availableDatasetSplits.eval &&
+        isPipelineSelected(pipeline) &&
         datasetInfo?.postprocessingEditable?.[pipeline.pipelineIndex] && (
           <PreviewCard
             title="Post-processing Analysis"

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -100,7 +100,11 @@ const Dashboard = () => {
               />
             }
           >
-            <ClassOverlapTable jobId={jobId} pipeline={pipeline} />
+            <ClassOverlapTable
+              jobId={jobId}
+              pipeline={pipeline}
+              availableDatasetSplits={datasetInfo?.availableDatasetSplits}
+            />
           </PreviewCard>
         )}
       {isPipelineSelected(pipeline) && (

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -10,10 +10,12 @@ import Loading from "components/Loading";
 import PerformanceAnalysis from "components/Metrics/PerformanceAnalysis";
 import SmartTagsTable from "components/SmartTagsTable";
 import ThresholdPlot from "components/ThresholdPlot";
+import WithDatasetSplitNameState from "components/WithDatasetSplitNameState";
 import useQueryState from "hooks/useQueryState";
 import React from "react";
 import { Link, useParams } from "react-router-dom";
 import { getConfigEndpoint, getDatasetInfoEndpoint } from "services/api";
+import { DATASET_SPLIT_NAMES, UNKNOWN_ERROR } from "utils/const";
 import { isPipelineSelected } from "utils/helpers";
 import { performanceAnalysisDescription } from "./PerformanceAnalysis";
 import { behavioralTestingDescription } from "./PerturbationTestingSummary";
@@ -36,14 +38,18 @@ const Dashboard = () => {
 
   if (isFetching) {
     return <Loading />;
-  } else if (error) {
+  } else if (error || datasetInfo === undefined) {
     return (
       <Box alignItems="center" display="grid" justifyItems="center">
         <img src={noData} width="50%" alt="no dataset info" />
-        <Typography>{error.message}</Typography>
+        <Typography>{error?.message || UNKNOWN_ERROR}</Typography>
       </Box>
     );
   }
+
+  const firstAvailableDatasetSplit = DATASET_SPLIT_NAMES.find(
+    (datasetSplitName) => datasetInfo.availableDatasetSplits[datasetSplitName]
+  )!;
 
   return (
     <Box display="flex" flexDirection="column" gap={2}>
@@ -65,14 +71,14 @@ const Dashboard = () => {
           color="secondary"
           variant="contained"
           component={Link}
-          to={`/${jobId}/dataset_splits/eval/prediction_overview${searchString}`}
+          to={`/${jobId}/dataset_splits/${firstAvailableDatasetSplit}/prediction_overview${searchString}`}
           sx={{ gap: 1 }}
         >
           <Telescope fontSize="large" />
           Go to exploration space
         </Button>
       </Box>
-      {datasetInfo?.availableDatasetSplits.train && (
+      {datasetInfo.availableDatasetSplits.train && (
         <PreviewCard
           title="Dataset Warnings"
           to={`/${jobId}/dataset_warnings${searchString}`}
@@ -88,11 +94,11 @@ const Dashboard = () => {
           </Box>
         </PreviewCard>
       )}
-      {datasetInfo?.availableDatasetSplits.train &&
-        datasetInfo?.similarityAvailable && (
+      {datasetInfo.availableDatasetSplits.train &&
+        datasetInfo.similarityAvailable && (
           <PreviewCard
             title="Class Overlap"
-            to={`/${jobId}/class_overlap${searchString}`}
+            to={`/${jobId}/dataset_splits/train/class_overlap${searchString}`}
             description={
               <Description
                 text="Assess semantic overlap between class pairs and compare to pipeline confusion."
@@ -103,49 +109,59 @@ const Dashboard = () => {
             <ClassOverlapTable
               jobId={jobId}
               pipeline={pipeline}
-              availableDatasetSplits={datasetInfo?.availableDatasetSplits}
+              availableDatasetSplits={datasetInfo.availableDatasetSplits}
             />
           </PreviewCard>
         )}
       {isPipelineSelected(pipeline) && (
-        <PreviewCard
-          title="Pipeline Metrics by Data Subpopulation"
-          to={`/${jobId}/pipeline_metrics${searchString}`}
-          linkButtonText={
-            config?.pipelines && config.pipelines.length > 1
-              ? "Compare pipelines"
-              : undefined
-          }
-          description={performanceAnalysisDescription}
-        >
-          <PerformanceAnalysis
-            jobId={jobId}
-            pipeline={pipeline}
-            availableDatasetSplits={datasetInfo?.availableDatasetSplits}
-          />
-        </PreviewCard>
+        <WithDatasetSplitNameState
+          defaultDatasetSplitName={firstAvailableDatasetSplit}
+          render={(datasetSplitName, setDatasetSplitName) => (
+            <PreviewCard
+              title="Pipeline Metrics by Data Subpopulation"
+              to={`/${jobId}/dataset_splits/${datasetSplitName}/pipeline_metrics${searchString}`}
+              linkButtonText={
+                config?.pipelines && config.pipelines.length > 1
+                  ? "Compare pipelines"
+                  : undefined
+              }
+              description={performanceAnalysisDescription}
+            >
+              <PerformanceAnalysis
+                jobId={jobId}
+                pipeline={pipeline}
+                availableDatasetSplits={datasetInfo.availableDatasetSplits}
+                datasetSplitName={datasetSplitName}
+                setDatasetSplitName={setDatasetSplitName}
+              />
+            </PreviewCard>
+          )}
+        />
       )}
       {isPipelineSelected(pipeline) && (
-        <PreviewCard
-          title="Smart Tag Analysis"
-          to={`/${jobId}/smart_tags${searchString}`}
-          description={smartTagsDescription}
-        >
-          <Box
-            display="flex"
-            flexDirection="column"
-            maxHeight={DEFAULT_PREVIEW_CONTENT_HEIGHT}
-          >
-            <SmartTagsTable
-              jobId={jobId}
-              pipeline={pipeline}
-              availableDatasetSplits={datasetInfo?.availableDatasetSplits}
-            />
-          </Box>
-        </PreviewCard>
+        <WithDatasetSplitNameState
+          defaultDatasetSplitName={firstAvailableDatasetSplit}
+          render={(datasetSplitName, setDatasetSplitName) => (
+            <PreviewCard
+              title="Smart Tag Analysis"
+              to={`/${jobId}/dataset_splits/${datasetSplitName}/smart_tags${searchString}`}
+              description={smartTagsDescription}
+            >
+              <Box maxHeight={DEFAULT_PREVIEW_CONTENT_HEIGHT}>
+                <SmartTagsTable
+                  jobId={jobId}
+                  pipeline={pipeline}
+                  availableDatasetSplits={datasetInfo.availableDatasetSplits}
+                  datasetSplitName={datasetSplitName}
+                  setDatasetSplitName={setDatasetSplitName}
+                />
+              </Box>
+            </PreviewCard>
+          )}
+        />
       )}
       {isPipelineSelected(pipeline) &&
-        datasetInfo?.perturbationTestingAvailable && (
+        datasetInfo.perturbationTestingAvailable && (
           <PreviewCard
             title="Behavioral Testing"
             to={`/${jobId}/behavioral_testing_summary${searchString}`}
@@ -160,9 +176,9 @@ const Dashboard = () => {
             </Box>
           </PreviewCard>
         )}
-      {datasetInfo?.availableDatasetSplits.eval &&
-        isPipelineSelected(pipeline) &&
-        datasetInfo?.postprocessingEditable?.[pipeline.pipelineIndex] && (
+      {isPipelineSelected(pipeline) &&
+        datasetInfo.availableDatasetSplits.eval &&
+        datasetInfo.postprocessingEditable?.[pipeline.pipelineIndex] && (
           <PreviewCard
             title="Post-processing Analysis"
             to={`/${jobId}/thresholds${searchString}`}

--- a/webapp/src/pages/PerformanceAnalysis.tsx
+++ b/webapp/src/pages/PerformanceAnalysis.tsx
@@ -3,8 +3,9 @@ import Description from "components/Description";
 import PerformanceAnalysisTable from "components/Metrics/PerformanceAnalysisTable";
 import useQueryState from "hooks/useQueryState";
 import React from "react";
-import { useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import { getDatasetInfoEndpoint } from "services/api";
+import { DatasetSplitName } from "types/api";
 import { PIPELINE_REQUIRED_TIP } from "utils/const";
 import { isPipelineSelected } from "utils/helpers";
 
@@ -15,12 +16,21 @@ export const performanceAnalysisDescription = (
   />
 );
 
-const PerformanceAnalysisComparison = () => {
-  const { jobId } = useParams<{ jobId: string }>();
-  const { pipeline } = useQueryState();
+const PerformanceAnalysis = () => {
+  const history = useHistory();
+  const { jobId, datasetSplitName } = useParams<{
+    jobId: string;
+    datasetSplitName: DatasetSplitName;
+  }>();
+  const { pipeline, searchString } = useQueryState();
 
   const { data: datasetInfo, isFetching: isFetchingDatasetInfo } =
     getDatasetInfoEndpoint.useQuery({ jobId });
+
+  const setDatasetSplitName = (name: DatasetSplitName) =>
+    history.push(
+      `/${jobId}/dataset_splits/${name}/pipeline_metrics${searchString}`
+    );
 
   return (
     <Box display="flex" flexDirection="column" height="100%">
@@ -34,6 +44,8 @@ const PerformanceAnalysisComparison = () => {
           pipeline={pipeline}
           availableDatasetSplits={datasetInfo?.availableDatasetSplits}
           isLoading={isFetchingDatasetInfo}
+          datasetSplitName={datasetSplitName}
+          setDatasetSplitName={setDatasetSplitName}
         />
       ) : (
         <Typography>{PIPELINE_REQUIRED_TIP}</Typography>
@@ -42,4 +54,4 @@ const PerformanceAnalysisComparison = () => {
   );
 };
 
-export default React.memo(PerformanceAnalysisComparison);
+export default React.memo(PerformanceAnalysis);

--- a/webapp/src/pages/SmartTags.tsx
+++ b/webapp/src/pages/SmartTags.tsx
@@ -3,8 +3,9 @@ import Description from "components/Description";
 import SmartTagsTable from "components/SmartTagsTable";
 import useQueryState from "hooks/useQueryState";
 import React from "react";
-import { useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import { getDatasetInfoEndpoint } from "services/api";
+import { DatasetSplitName } from "types/api";
 import { PIPELINE_REQUIRED_TIP } from "utils/const";
 import { isPipelineSelected } from "utils/helpers";
 
@@ -16,10 +17,17 @@ export const smartTagsDescription = (
 );
 
 const SmartTags = () => {
-  const { jobId } = useParams<{ jobId: string }>();
-  const { pipeline } = useQueryState();
+  const history = useHistory();
+  const { jobId, datasetSplitName } = useParams<{
+    jobId: string;
+    datasetSplitName: DatasetSplitName;
+  }>();
+  const { pipeline, searchString } = useQueryState();
 
   const { data: datasetInfo } = getDatasetInfoEndpoint.useQuery({ jobId });
+
+  const setDatasetSplitName = (name: DatasetSplitName) =>
+    history.push(`/${jobId}/dataset_splits/${name}/smart_tags${searchString}`);
 
   return (
     <Box display="flex" flexDirection="column" height="100%">
@@ -34,6 +42,8 @@ const SmartTags = () => {
             jobId={jobId}
             pipeline={pipeline}
             availableDatasetSplits={datasetInfo?.availableDatasetSplits}
+            datasetSplitName={datasetSplitName}
+            setDatasetSplitName={setDatasetSplitName}
           />
         </Paper>
       ) : (

--- a/webapp/src/services/api.ts
+++ b/webapp/src/services/api.ts
@@ -2,7 +2,7 @@ import { QueryReturnValue } from "@reduxjs/toolkit/dist/query/baseQueryTypes";
 import { createApi, fakeBaseQuery } from "@reduxjs/toolkit/query/react";
 import { AzimuthConfig, DataAction, DataActionResponse } from "types/api";
 import { Tags } from "types/models";
-import { GetUtterancesQueryState, fetchApi, TypedResponse } from "utils/api";
+import { fetchApi, GetUtterancesQueryState, TypedResponse } from "utils/api";
 import { DATA_ACTION_NONE_VALUE } from "utils/const";
 import { raiseSuccessToast } from "utils/helpers";
 
@@ -203,7 +203,7 @@ export const api = createApi({
       providesTags: () => [{ type: "ClassOverlap" }],
       queryFn: responseToData(
         fetchApi({
-          path: "/class_overlap",
+          path: "/dataset_splits/{dataset_split_name}/class_overlap",
           method: "get",
         }),
         "Something went wrong fetching class overlap"
@@ -213,7 +213,7 @@ export const api = createApi({
       providesTags: () => [{ type: "ClassOverlapPlot" }],
       queryFn: responseToData(
         fetchApi({
-          path: "/class_overlap/plot",
+          path: "/dataset_splits/{dataset_split_name}/class_overlap/plot",
           method: "get",
         }),
         "Something went wrong fetching spectral clustering class overlap data"

--- a/webapp/src/services/api.ts
+++ b/webapp/src/services/api.ts
@@ -156,7 +156,7 @@ export const api = createApi({
       providesTags: () => [{ type: "DatasetWarnings" }],
       queryFn: responseToData(
         fetchApi({ path: "/dataset_warnings", method: "get" }),
-        "Something went wrong fetching dataset class distribution analysis"
+        "Something went wrong fetching dataset warnings"
       ),
     }),
     getUtterances: build.query({
@@ -216,7 +216,7 @@ export const api = createApi({
           path: "/dataset_splits/{dataset_split_name}/class_overlap/plot",
           method: "get",
         }),
-        "Something went wrong fetching spectral clustering class overlap data"
+        "Something went wrong fetching class overlap plot"
       ),
     }),
     updateDataActions: build.mutation<
@@ -236,7 +236,7 @@ export const api = createApi({
       }) =>
         responseToData(
           fetchApi({ path: "/tags", method: "post" }),
-          "Something went wrong updating the resolution"
+          "Something went wrong updating proposed actions"
         )({
           jobId,
           body: {
@@ -362,7 +362,7 @@ export const api = createApi({
       providesTags: () => [{ type: "Status" }],
       queryFn: responseToData(
         fetchApi({ path: "/status", method: "get" }),
-        "Something went wrong fetching the status"
+        "Something went wrong fetching status"
       ),
     }),
   }),

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -26,13 +26,13 @@ export interface paths {
     /** Update the config using a changeset. */
     patch: operations["update_config_admin_config_patch"];
   };
-  "/class_overlap/plot": {
+  "/dataset_splits/{dataset_split_name}/class_overlap/plot": {
     /** Get a plot of class overlap using Spectral clustering and Monte-Carlo sampling (currently set to all samples). */
-    get: operations["get_class_overlap_plot_class_overlap_plot_get"];
+    get: operations["get_class_overlap_plot_dataset_splits__dataset_split_name__class_overlap_plot_get"];
   };
-  "/class_overlap": {
+  "/dataset_splits/{dataset_split_name}/class_overlap": {
     /** Get data for class overlap, confusion, and related utterance counts. */
-    get: operations["get_class_overlap_class_overlap_get"];
+    get: operations["get_class_overlap_dataset_splits__dataset_split_name__class_overlap_get"];
   };
   "/tags": {
     /** Post new data_action tags */
@@ -909,8 +909,11 @@ export interface operations {
     };
   };
   /** Get a plot of class overlap using Spectral clustering and Monte-Carlo sampling (currently set to all samples). */
-  get_class_overlap_plot_class_overlap_plot_get: {
+  get_class_overlap_plot_dataset_splits__dataset_split_name__class_overlap_plot_get: {
     parameters: {
+      path: {
+        dataset_split_name: components["schemas"]["DatasetSplitName"];
+      };
       query: {
         /** Whether to include overlap of a class with itself. */
         self_overlap?: boolean;
@@ -936,8 +939,11 @@ export interface operations {
     };
   };
   /** Get data for class overlap, confusion, and related utterance counts. */
-  get_class_overlap_class_overlap_get: {
+  get_class_overlap_dataset_splits__dataset_split_name__class_overlap_get: {
     parameters: {
+      path: {
+        dataset_split_name: components["schemas"]["DatasetSplitName"];
+      };
       query: {
         pipeline_index?: number;
       };


### PR DESCRIPTION
Resolve #362 

## Description:
* Support only a training set (no eval) for further flexibility. Look at the commits for the details of what was done.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
