### PR TITLE
Use `mktemp` to store the OpenAPI spec

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,7 +31,7 @@
     "test": "react-app-rewired test --coverage",
     "eject": "react-scripts eject",
     "fix": "make npm.audit.fix",
-    "types": "poetry run python ../openapi.py > openapi.json && openapi-typescript openapi.json --output src/types/generated/generatedTypes.ts && rm -f openapi.json"
+    "types": "temp=$(mktemp) && poetry run python ../openapi.py > $temp && openapi-typescript $temp --output src/types/generated/generatedTypes.ts"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Description:

Use `mktemp` to store the OpenAPI spec in a proper temporary file.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
