### PR TITLE
Test `Description`

### DIFF
--- a/webapp/src/components/AccordionLayout.test.tsx
+++ b/webapp/src/components/AccordionLayout.test.tsx
@@ -20,7 +20,8 @@ describe("AccordionLayout", () => {
       )
     ).toBeVisible();
     const link: HTMLAnchorElement = screen.getByRole("link");
-    expect(link.href).toContain(
+    expect(link).toHaveAttribute(
+      "href",
       "https://servicenow.github.io/azimuth/main/reference/configuration/project/"
     );
     screen.getByText("Learn more");

--- a/webapp/src/components/Description.test.tsx
+++ b/webapp/src/components/Description.test.tsx
@@ -10,17 +10,15 @@ describe("Description", () => {
   });
 
   it("should display description with both link and text", async () => {
-    renderWithTheme(
-      <Description
-        text="test description"
-        link="https://servicenow.github.io/azimuth/"
-      />
-    );
+    renderWithTheme(<Description text="test description" link="potato" />);
 
     screen.getByText("test description");
 
     const link: HTMLAnchorElement = screen.getByRole("link");
-    expect(link.href).toContain("https://servicenow.github.io/azimuth/");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://servicenow.github.io/azimuth/main/potato"
+    );
     screen.getByText("Learn more");
     screen.getByTestId("OpenInNewIcon");
   });


### PR DESCRIPTION
## Description:

The `expect(link.href).toContain(...)` in `Description.test.tsx` wasn't actually testing anything. With `link="https://servicenow.github.io/azimuth/"`, the resulting `href` ended up being `https://servicenow.github.io/azimuth/main/https://servicenow.github.io/azimuth/`, so of course it contained `https://servicenow.github.io/azimuth/`. This test would pass even if we changed the base documentation URL.

Solution: Let's assert equality instead of `toContain`.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
