### PR TITLE
Replace "simple" emojis shortcodes

### DIFF
--- a/docs/docs/about-us.md
+++ b/docs/docs/about-us.md
@@ -5,7 +5,7 @@ ServiceNow. We are open source since April 2022. Our motivation in developing th
 beyond the traditional model quality assessment based solely on high-level metrics. We strongly
 believe that much more can be discovered and understood from our dataset and models if we have the
 right tools, visualizations, and interfaces. We hope this can be helpful to you, and that you enjoy
-Azimuth! :smiley:
+Azimuth! 😃
 
 ## The Team
 

--- a/docs/docs/reference/configuration/analyses/behavioral_testing.md
+++ b/docs/docs/reference/configuration/analyses/behavioral_testing.md
@@ -1,6 +1,6 @@
 # Behavioral Testing Config
 
-:blue_circle: **Default value:** `BehavioralTestingOptions()`
+🔵 **Default value:** `BehavioralTestingOptions()`
 
 **Environment Variable**: `BEHAVIORAL_TESTING`
 

--- a/docs/docs/reference/configuration/analyses/dataset_warnings.md
+++ b/docs/docs/reference/configuration/analyses/dataset_warnings.md
@@ -1,6 +1,6 @@
 # Dataset Warnings Config
 
-:blue_circle: **Default value:** `DatasetWarningsOptions()`
+🔵 **Default value:** `DatasetWarningsOptions()`
 
 Some thresholds can be set to modify the number of warnings in the
 [:material-link: Dataset Warnings](../../../user-guide/dataset-warnings.md).

--- a/docs/docs/reference/configuration/analyses/similarity.md
+++ b/docs/docs/reference/configuration/analyses/similarity.md
@@ -1,6 +1,6 @@
 # Similarity Analysis Config
 
-:blue_circle: **Default value:** `SimilarityOptions()`
+🔵 **Default value:** `SimilarityOptions()`
 
 **Environment Variable**: `SIMILARITY`
 

--- a/docs/docs/reference/configuration/analyses/syntax.md
+++ b/docs/docs/reference/configuration/analyses/syntax.md
@@ -1,6 +1,6 @@
 # Syntax Analysis Config
 
-:blue_circle: **Default value:** `SyntaxOptions()`
+🔵 **Default value:** `SyntaxOptions()`
 
 In the Syntax config, users can modify thresholds to determine what is considered a short
 or a long sentence, as well as select the spaCy model and the dependency tags used for certain

--- a/docs/docs/reference/configuration/common.md
+++ b/docs/docs/reference/configuration/common.md
@@ -26,7 +26,7 @@ These fields are generic and can be adapted based on the user's machine.
 
 ## Artifact Path
 
-:blue_circle: **Default value**: `/cache`
+🔵 **Default value**: `/cache`
 
 Where to store the caching artifacts (`HDF5` files and HF datasets). The value needs to be available
 inside Docker (see `docker-compose.yml`). `/cache` is available by default on the docker image.
@@ -38,27 +38,27 @@ inside Docker (see `docker-compose.yml`). `/cache` is available by default on th
 
 ## Batch Size
 
-:blue_circle: **Default value**: 32
+🔵 **Default value**: 32
 
 Batch size to use during inference. A higher batch size will make computation faster, depending on
 the memory available on your machine.
 
 ## Use Cuda
 
-:blue_circle: **Default value**: `auto`
+🔵 **Default value**: `auto`
 
 If cuda is available on your machine, set to `true`, otherwise `false`. Can also be set to "auto"
 and let the user-code take care of it.
 
 ## Large Dask Cluster
 
-:blue_circle: **Default value**: False
+🔵 **Default value**: False
 
 The memory of the dask cluster is usually 6GB. If your models are big or if you encounter garbage collection errors,  you can set the memory to 12GB by setting `large_dask_cluster` to `True`.
 
 ## Read-Only Config
 
-:blue_circle: **Default value**: False
+🔵 **Default value**: False
 
 This field allows to block the changes to the config when set to `True`. This can be useful in certain context, such as when hosting a demo.
 

--- a/docs/docs/reference/configuration/index.md
+++ b/docs/docs/reference/configuration/index.md
@@ -9,33 +9,32 @@ another in a chain, the last one being `AzimuthConfig`, which contains all field
 To help with detecting the mandatory fields in the config, the following legend is shown throughout
 the reference.
 
-* :red_circle: : **Mandatory** fields in the config.
-* :orange_circle: : Only **mandatory** if Azimuth is used to analyze **models**, and not just a
+* 🔴 : **Mandatory** fields in the config.
+* 🟠 : Only **mandatory** if Azimuth is used to analyze **models**, and not just a
   dataset.
-* :yellow_circle: : **Usually mandatory** fields, but default values exist that may work for some
+* 🟡 : **Usually mandatory** fields, but default values exist that may work for some
   use cases.
-* :blue_circle: : The **default values** should work for most use cases.
+* 🔵 : The **default values** should work for most use cases.
 
 ## Config Scopes
 
-1. [:material-link: Project Config](./project.md) :red_circle:
+1. [:material-link: Project Config](./project.md) 🔴
     * Mainly mandatory fields to define the name of the project and the dataset information.
-2. [:material-link: Language Config](./language.md) :yellow_circle:
+2. [:material-link: Language Config](./language.md) 🟡
     * Specifies the model and dataset language used to set several language-based defaults.
-3. [:material-link: Model Contract Config](./model_contract.md) :orange_circle:
+3. [:material-link: Model Contract Config](./model_contract.md) 🟠
     * Defines how Azimuth interacts with the models/pipelines.
-4. [:material-link: Common Fields Config](./common.md) :blue_circle:
+4. [:material-link: Common Fields Config](./common.md) 🔵
     * Fields that are common to many applications (batch size for example).
 5. [:material-link: Customize Azimuth Analyses](analyses/index.md):
    In these sections, different analyses in Azimuth can be configured.
-    1. [:material-link: Behavioral Testing Config](analyses/behavioral_testing.md) :blue_circle:
+    1. [:material-link: Behavioral Testing Config](analyses/behavioral_testing.md) 🔵
         * Defines how the behavioral tests are generated.
-    2. [:material-link: Similarity Analysis Config](analyses/similarity.md) :blue_circle:
+    2. [:material-link: Similarity Analysis Config](analyses/similarity.md) 🔵
         * Modifies the similarity analysis.
-    3. [:material-link: Dataset Warnings Config](analyses/dataset_warnings.md)
-       :blue_circle:
+    3. [:material-link: Dataset Warnings Config](analyses/dataset_warnings.md) 🔵
         * Configure the dataset warnings.
-    4. [:material-link: Syntax Analysis Config](analyses/syntax.md) :blue_circle:
+    4. [:material-link: Syntax Analysis Config](analyses/syntax.md) 🔵
         * Modify the defaults for the syntax analysis.
 
 --8<-- "includes/abbreviations.md"

--- a/docs/docs/reference/configuration/model_contract.md
+++ b/docs/docs/reference/configuration/model_contract.md
@@ -64,7 +64,7 @@ Fields from this scope defines how Azimuth interacts with the ML pipelines and t
 
 ## Model Contract
 
-:orange_circle: **Mandatory field** with an ML pipeline.
+🟠 **Mandatory field** with an ML pipeline.
 
 **Default value**: `hf_text_classification`
 
@@ -81,7 +81,7 @@ in [:material-link: Define a Model](../custom-objects/model.md).
 
 ## Pipelines
 
-:orange_circle: **Mandatory field** with an ML pipeline.
+🟠 **Mandatory field** with an ML pipeline.
 
 **Default value**: `None`
 
@@ -171,7 +171,7 @@ Objects**](index.md).
 
 ## Uncertainty
 
-:blue_circle: **Default value**: `UncertaintyOptions()`
+🔵 **Default value**: `UncertaintyOptions()`
 
 Azimuth has some simple uncertainty estimation capabilities. By default, they are disabled given
 that it can be computationally expensive.
@@ -208,7 +208,7 @@ in [:material-link: Uncertainty Estimation](../../key-concepts/uncertainty.md).
 
 ## Saliency Layer
 
-:yellow_circle: **Default value**: `None`
+🟡 **Default value**: `None`
 
 If using a Pytorch model, [:material-link: Saliency Maps](../../key-concepts/saliency.md) can be
 available. Specify the name of the embedding layer on which to compute them.
@@ -217,7 +217,7 @@ Example: `distilbert.embeddings.word_embeddings`.
 
 ## Metrics
 
-:blue_circle: **Default value**: Accuracy, Precision, Recall and F1. See in the config example below.
+🔵 **Default value**: Accuracy, Precision, Recall and F1. See in the config example below.
 
 By default, Azimuth will compute the metrics listed above. `metrics` leverages custom
 objects, with an additional field which allow defining `kwargs`

--- a/docs/docs/reference/configuration/project.md
+++ b/docs/docs/reference/configuration/project.md
@@ -40,7 +40,7 @@ Azimuth and details about the way it is handled by the app.
 
 ## Name
 
-:yellow_circle: **Default value**: `New project`
+🟡 **Default value**: `New project`
 
 **Environment Variable**: `NAME`
 
@@ -49,7 +49,7 @@ model. Ex: `Banking77 Model v4`.
 
 ## Dataset
 
-:red_circle: **Mandatory field**
+🔴 **Mandatory field**
 
 To define which dataset to load in the application, Azimuth
 uses [:material-link: Custom Objects](../custom-objects/index.md).
@@ -92,7 +92,7 @@ explained in [:material-link: Defining Dataset](../custom-objects/dataset.md).
 
 ## Columns
 
-:yellow_circle: **Default value**: `ColumnConfiguration()`
+🟡 **Default value**: `ColumnConfiguration()`
 
 All dataset column names are configurable. The mandatory columns and their descriptions are as
 follows:
@@ -137,7 +137,7 @@ follows:
 
 ## Rejection class
 
-:yellow_circle: **Default value**: `REJECTION_CLASS`
+🟡 **Default value**: `REJECTION_CLASS`
 
 The field `rejection_class` requires the class to be present in the dataset. If your dataset doesn't
 have a rejection class, set the value to `null`. More details on the rejection class are available

--- a/docs/docs/user-guide/exploration-space/utterance-details.md
+++ b/docs/docs/user-guide/exploration-space/utterance-details.md
@@ -38,7 +38,7 @@ see [:material-link: Similarity Analysis](../../key-concepts/similarity.md).
 * The toggle buttons control whether to search for similar utterances in the evaluation set or the
   training set.
 * Utterances that are similar but have different labels or predictions can indicate possible
-  problems with the dataset or the model. An :warning: icon indicates utterances that are **from a
+  problems with the dataset or the model. An ⚠ icon indicates utterances that are **from a
   different class** than the base utterance.
 * Clicking on the row of an utterance in the table will open the details page for that utterance.
 

--- a/docs/docs/user-guide/index.md
+++ b/docs/docs/user-guide/index.md
@@ -21,7 +21,8 @@ The top banner contains useful information and links.
 * The **project name** from the config file is shown.
 * A dropdown :material-arrow-down-drop-circle-outline: allows you to select the different pipelines
   defined in the config. It also allows you to select no pipelines.
-* The [**settings**](settings.md) :gear: allow you to enable/disable different analyses.
+* The [**settings**](settings.md) :fontawesome-solid-gear: allow you to enable/disable different analyses.
+<!-- TODO The settings do more than that now. -->
 * A link to the support Slack channel and to the documentation is available in the help
   :material-help-circle: option.
 

--- a/docs/docs/user-guide/index.md
+++ b/docs/docs/user-guide/index.md
@@ -21,8 +21,7 @@ The top banner contains useful information and links.
 * The **project name** from the config file is shown.
 * A dropdown :material-arrow-down-drop-circle-outline: allows you to select the different pipelines
   defined in the config. It also allows you to select no pipelines.
-* The [**settings**](settings.md) :fontawesome-solid-gear: allow you to enable/disable different analyses.
-<!-- TODO The settings do more than that now. -->
+* The [**settings**](settings.md) :fontawesome-solid-gear: allows you to edit the config.
 * A link to the support Slack channel and to the documentation is available in the help
   :material-help-circle: option.
 


### PR DESCRIPTION
## Description:

Replace "simple" emojis shortcodes with actual emojis, as the shortcodes are broken
![image](https://user-images.githubusercontent.com/8386369/211970135-217110cc-b781-4d72-9a1f-45427dce85a5.png)
(even on mkdocs website, see https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#using-emojis)
![image](https://user-images.githubusercontent.com/8386369/211970185-0f2c9495-7355-4b9c-bbff-92a57e4a8ae4.png)


I located them by searching for `:(?!fontawesome-|material-|octicons-)[\w-]+:` under `/docs`.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
