### PR TITLE
Fix Utterance Details page collapsing with extra long utterances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@ Released changes are shown in the
 ### Removed
 
 ### Fixed
+- Fix Utterance Details page collapsing with extra long utterances.
 
 ### Security

--- a/webapp/src/components/FadeOutScrollY.tsx
+++ b/webapp/src/components/FadeOutScrollY.tsx
@@ -1,0 +1,17 @@
+import { Box, BoxProps } from "@mui/material";
+import React from "react";
+
+const FADE_HEIGHT = "24px";
+
+const FadeOutScrollY: React.FC<BoxProps> = (props) => (
+  <Box
+    overflow="auto"
+    paddingY={FADE_HEIGHT}
+    sx={{
+      mask: `linear-gradient(transparent, black ${FADE_HEIGHT} calc(100% - ${FADE_HEIGHT}), transparent)`,
+    }}
+    {...props}
+  />
+);
+
+export default React.memo(FadeOutScrollY);

--- a/webapp/src/pages/UtteranceDetail.tsx
+++ b/webapp/src/pages/UtteranceDetail.tsx
@@ -11,6 +11,7 @@ import noData from "assets/void.svg";
 import DatasetSplitToggler from "components/Controls/DatasetSplitToggler";
 import CopyButton from "components/CopyButton";
 import Description from "components/Description";
+import FadeOutScrollY from "components/FadeOutScrollY";
 import Loading from "components/Loading";
 import SmartTagFamilyBadge from "components/SmartTagFamilyBadge";
 import Steps from "components/Steps";
@@ -203,15 +204,16 @@ export const UtteranceDetail = () => {
             />
           )}
         </Box>
-        <Box display="flex" alignItems="center">
-          <UtteranceSaliency
-            variant="subtitle1"
-            tooltip
-            utterance={preprocessingSteps[preprocessingStep].text}
-            modelSaliency={
-              preprocessingStep === 0 ? utterance.modelSaliency : null
-            }
-          />
+        <Box display="flex">
+          <FadeOutScrollY maxHeight="13vh">
+            <UtteranceSaliency
+              tooltip
+              utterance={preprocessingSteps[preprocessingStep].text}
+              modelSaliency={
+                preprocessingStep === 0 ? utterance.modelSaliency : null
+              }
+            />
+          </FadeOutScrollY>
           <CopyButton text={preprocessingSteps[preprocessingStep].text} />
         </Box>
 


### PR DESCRIPTION
## Description:

Fix Utterance Details page collapsing with extra long utterances, by putting the utterance inside a scrollable container with a maximum height and some edges that fade out, so it is clear if the text is truncated.

https://user-images.githubusercontent.com/8386369/213100316-faf0731b-809c-476e-b3b8-6cdeb3babcaa.mov

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
