### PR TITLE
Add persistent id to front end

### DIFF
--- a/azimuth/routers/v1/utterances.py
+++ b/azimuth/routers/v1/utterances.py
@@ -405,6 +405,7 @@ def get_similar(
     similar_utterances = [
         SimilarUtterance(
             index=data[DatasetColumn.row_idx],
+            persistent_id=data[config.columns.persistent_id],
             utterance=data[config.columns.text_input],
             label=data[config.columns.label],
             postprocessed_prediction=data.get(DatasetColumn.postprocessed_prediction, None),

--- a/azimuth/types/similarity_analysis.py
+++ b/azimuth/types/similarity_analysis.py
@@ -7,12 +7,10 @@ from typing import List, Optional, Tuple
 from pydantic import Field
 
 from azimuth.types import AliasModel, Array, ModuleResponse
+from azimuth.types.utterance import BaseUtterance
 
 
-class SimilarUtterance(AliasModel):
-    index: int
-    utterance: str
-    label: str
+class SimilarUtterance(BaseUtterance):
     postprocessed_prediction: Optional[str] = Field(..., nullable=True)
     postprocessed_confidence: Optional[float] = Field(..., nullable=True)
     similarity: float

--- a/azimuth/types/utterance.py
+++ b/azimuth/types/utterance.py
@@ -37,20 +37,28 @@ class ModelSaliency(AliasModel):
     saliencies: List[float] = Field(..., title="Saliency")
 
 
-class UtterancePatch(AliasModel):
+class UtterancePersistentId(AliasModel):
     # Union[int, str] in this order so FastAPI tries to cast to int() first, then defaults to str().
     persistent_id: Union[int, str] = Field(..., title="Persistent id")
+
+
+class UtterancePatch(UtterancePersistentId):
     data_action: DataAction = Field(..., title="Data action tag")
 
 
-class Utterance(ValuePerDatasetSmartTag[str], ValuePerPipelineSmartTag[str], UtterancePatch):
-    index: int = Field(..., title="Index", description="Row index computed by Azimuth..")
+class BaseUtterance(UtterancePersistentId):
+    index: int = Field(..., title="Index", description="Row index created by Azimuth")
+    utterance: str = Field(..., title="Utterance")
+    label: str = Field(..., title="Label")
+
+
+class Utterance(
+    ValuePerDatasetSmartTag[str], ValuePerPipelineSmartTag[str], UtterancePatch, BaseUtterance
+):
     model_prediction: Optional[ModelPrediction] = Field(
         ..., title="Model prediction", nullable=True
     )
     model_saliency: Optional[ModelSaliency] = Field(..., title="Model saliency", nullable=True)
-    label: str = Field(..., title="Label")
-    utterance: str = Field(..., title="Utterance")
 
 
 class GetUtterancesResponse(AliasModel):

--- a/docs/docs/reference/configuration/project.md
+++ b/docs/docs/reference/configuration/project.md
@@ -117,11 +117,11 @@ follows:
         persistent_id: str = "row_idx" # (5)
     ```
 
-    1. Optional column for the text input that will be send to the pipeline.
+    1. Column for the text input that will be send to the pipeline.
     2. Optional column for the raw text input (before any pre-processing). Unused at the moment.
-    3. Optional column for the label
+    3. Features column for the label
     4. Optional column to specify whether an example has failed preprocessing. Unused at the moment.
-    5. Optional column with a unique identifier for every example that should be persisted if the dataset is modified, such as if new examples are added or if examples are modified or removed.
+    5. Column with a unique identifier for every example that should be persisted if the dataset is modified, such as if new examples are added or if examples are modified or removed.
 
 === "Config Example"
 

--- a/docs/docs/reference/configuration/project.md
+++ b/docs/docs/reference/configuration/project.md
@@ -102,7 +102,7 @@ follows:
 |------------|-----------|-------------------------------------------------------------------|
 | `text_input` | `utterance` | The preprocessed utterance.                                       |
 | `label`      | `label`     | The class label for the utterance, as type `datasets.ClassLabel`. |
-| `persistent_id`      | `persistent_id`     | A unique identifier for each utterance, as type `datasets.Value("int16")` or `datasets.Value("string")`. |
+| `persistent_id` | `row_idx` | A unique identifier for each utterance, as type `datasets.Value("int16")` or `datasets.Value("string")`. |
 
 === "Class Definition"
 
@@ -117,11 +117,11 @@ follows:
         persistent_id: str = "row_idx" # (5)
     ```
 
-    1. Column for the text input that will be send to the pipeline.
+    1. Optional column for the text input that will be send to the pipeline.
     2. Optional column for the raw text input (before any pre-processing). Unused at the moment.
-    3. Features column for the label
+    3. Optional column for the label
     4. Optional column to specify whether an example has failed preprocessing. Unused at the moment.
-    5. Unique identifier for every example that should be persisted if the dataset is modified, such as if new examples are added or if examples are modified or removed.
+    5. Optional column with a unique identifier for every example that should be persisted if the dataset is modified, such as if new examples are added or if examples are modified or removed.
 
 === "Config Example"
 

--- a/webapp/src/components/Analysis/HoverableDataCell.tsx
+++ b/webapp/src/components/Analysis/HoverableDataCell.tsx
@@ -9,10 +9,11 @@ const isOverflown = (element: Element) =>
 type GridCellExpandProps = {
   autoWidth?: boolean;
   children: React.ReactNode;
+  title?: React.ReactNode; // Named after Tooltip's title prop
 };
 
 const HoverableDataCell = (props: GridCellExpandProps) => {
-  const { autoWidth = false, children } = props;
+  const { autoWidth = false, children, title } = props;
 
   const wrapper = React.useRef<HTMLDivElement | null>(null);
   const cellDiv = React.useRef(null);
@@ -23,7 +24,8 @@ const HoverableDataCell = (props: GridCellExpandProps) => {
 
   const handleMouseEnter = () => {
     const isCurrentlyOverflown = isOverflown(cellValue.current!);
-    setShowPopper(isCurrentlyOverflown);
+    // If a title is specified, ignore overflow and always show popper.
+    setShowPopper(isCurrentlyOverflown || Boolean(title));
     setAnchorEl(cellDiv.current);
     setShowFullCell(true);
   };
@@ -95,7 +97,7 @@ const HoverableDataCell = (props: GridCellExpandProps) => {
               outline: "none",
             }}
           >
-            {children}
+            {title || children}
           </Paper>
         </Popper>
       )}
@@ -103,4 +105,4 @@ const HoverableDataCell = (props: GridCellExpandProps) => {
   );
 };
 
-export default HoverableDataCell;
+export default React.memo(HoverableDataCell);

--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -52,6 +52,9 @@ const useStyles = makeStyles((theme) => ({
   hoverableDataCell: {
     position: "relative",
   },
+  idCell: {
+    direction: "rtl", // To get ellipsis on the left, e.g. ...001, ...002, etc.
+  },
   gridContainer: {
     width: "100%",
     height: "100%",
@@ -256,7 +259,7 @@ const UtterancesTable: React.FC<Props> = ({
       sortable: false,
       align: "center",
       headerAlign: "center",
-      cellClassName: classes.hoverableDataCell,
+      cellClassName: `${classes.hoverableDataCell} ${classes.idCell}`,
       renderCell: renderHoverableDataCell,
     },
     {

--- a/webapp/src/components/Utterance/SimilarUtterances.tsx
+++ b/webapp/src/components/Utterance/SimilarUtterances.tsx
@@ -12,6 +12,7 @@ import { SimilarUtterance, Utterance } from "types/api";
 import { QueryPipelineState } from "types/models";
 import { ID_TOOLTIP } from "utils/const";
 import { formatRatioAsPercentageString } from "utils/format";
+import { getUtteranceIdTooltip } from "utils/getUtteranceIdTooltip";
 import { constructSearchString, isPipelineSelected } from "utils/helpers";
 
 const useStyles = makeStyles(() => ({
@@ -23,6 +24,9 @@ const useStyles = makeStyles(() => ({
   hoverableDataCell: {
     position: "relative",
   },
+  idCell: {
+    direction: "rtl", // To get ellipsis on the left, e.g. ...001, ...002, etc.
+  },
 }));
 
 type Row = SimilarUtterance & { id: number };
@@ -30,6 +34,7 @@ type Row = SimilarUtterance & { id: number };
 type Props = {
   baseUrl: string;
   baseUtterance: Utterance;
+  persistentIdColumn: string;
   pipeline: QueryPipelineState;
   utterances: SimilarUtterance[];
 };
@@ -37,6 +42,7 @@ type Props = {
 const SimilarUtterances: React.FC<Props> = ({
   baseUrl,
   baseUtterance,
+  persistentIdColumn,
   pipeline,
   utterances,
 }) => {
@@ -56,6 +62,18 @@ const SimilarUtterances: React.FC<Props> = ({
       sortable: false,
       align: "center",
       headerAlign: "center",
+      cellClassName: `${classes.hoverableDataCell} ${classes.idCell}`,
+      renderCell: ({ value, row }: GridCellParams<number, Row>) => (
+        <HoverableDataCell
+          autoWidth
+          title={getUtteranceIdTooltip({
+            utterance: row,
+            persistentIdColumn: persistentIdColumn,
+          })}
+        >
+          {value}
+        </HoverableDataCell>
+      ),
     },
     {
       field: "utterance",

--- a/webapp/src/pages/UtteranceDetail.tsx
+++ b/webapp/src/pages/UtteranceDetail.tsx
@@ -23,6 +23,7 @@ import useQueryState from "hooks/useQueryState";
 import React from "react";
 import { useParams } from "react-router-dom";
 import {
+  getConfigEndpoint,
   getDatasetInfoEndpoint,
   getSimilarUtterancesEndpoint,
   getUtterancesEndpoint,
@@ -36,6 +37,7 @@ import {
   SMART_TAG_FAMILIES,
 } from "utils/const";
 import { camelToTitleCase, formatRatioAsPercentageString } from "utils/format";
+import { getUtteranceIdTooltip } from "utils/getUtteranceIdTooltip";
 import { isPipelineSelected } from "utils/helpers";
 
 const UTTERANCE_DETAIL_TAB_DESCRIPTION = {
@@ -105,6 +107,11 @@ export const UtteranceDetail = () => {
   // Index from the right, so we can initialize to the last step
   // without the need for postprocessingSteps.length before it is loaded.
   const [postprocessingStepRaw, setPostprocessingStep] = React.useState(0);
+
+  const { data: config } = getConfigEndpoint.useQuery({ jobId });
+
+  // If config was undefined, PipelineCheck would not even render the page.
+  if (config === undefined) return null;
 
   if (!utterance) {
     // utterance will be defined while utteranceIsFetching after changing the
@@ -189,7 +196,14 @@ export const UtteranceDetail = () => {
             Id
           </Typography>
         </Tooltip>
-        <Typography variant="body2">{utteranceId}</Typography>
+        <Tooltip
+          title={getUtteranceIdTooltip({
+            utterance: utterance,
+            persistentIdColumn: config.columns.persistent_id,
+          })}
+        >
+          <Typography variant="body2">{utteranceId}</Typography>
+        </Tooltip>
 
         <Box className="header">
           <Typography variant="subtitle2">Utterance</Typography>
@@ -344,6 +358,7 @@ export const UtteranceDetail = () => {
             <SimilarUtterances
               baseUrl={`/${jobId}/dataset_splits/${neighborsDatasetSplitName}/utterances`}
               baseUtterance={utterance}
+              persistentIdColumn={config.columns.persistent_id}
               pipeline={pipeline}
               utterances={similarUtterances?.utterances || []}
             />

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -667,6 +667,8 @@ export interface components {
      * that all fields are represented correctly.
      */
     SimilarUtterance: {
+      persistentId: number | string;
+      /** Row index created by Azimuth */
       index: number;
       utterance: string;
       label: string;
@@ -816,6 +818,10 @@ export interface components {
      */
     Utterance: {
       persistentId: number | string;
+      /** Row index created by Azimuth */
+      index: number;
+      utterance: string;
+      label: string;
       dataAction: components["schemas"]["DataAction"];
       almostCorrect: string[];
       behavioralTesting: string[];
@@ -824,12 +830,8 @@ export interface components {
       extremeLength: string[];
       partialSyntax: string[];
       dissimilar: string[];
-      /** Row index computed by Azimuth.. */
-      index: number;
       modelPrediction: components["schemas"]["ModelPrediction"] | null;
       modelSaliency: components["schemas"]["ModelSaliency"] | null;
-      label: string;
-      utterance: string;
     };
     /**
      * This model should be used as the base for any model that defines aliases to ensure

--- a/webapp/src/utils/const.ts
+++ b/webapp/src/utils/const.ts
@@ -8,6 +8,8 @@ import {
   Uncertain,
 } from "components/Icons/SmartTagFamily";
 
+export const AZIMUTH_ID_COLUMN = "row_idx";
+
 export const DATASET_SPLIT_NAMES = ["eval", "train"] as const;
 
 export const DATASET_SPLIT_PRETTY_NAMES = {
@@ -18,7 +20,7 @@ export const DATASET_SPLIT_PRETTY_NAMES = {
 export const UNKNOWN_ERROR = "An unknown error occurred";
 
 export const ID_TOOLTIP =
-  "This id created by Azimuth corresponds to the row_idx column in the dataset split export";
+  "This id created by Azimuth corresponds to the row_idx column in the dataset split export. If a persistent_id column is configured, it will show up on hover.";
 
 export const ECE_TOOLTIP = `
 The ECE measures the calibration of the model, meaning if the confidence of the model matches its accuracy.

--- a/webapp/src/utils/getUtteranceIdTooltip.tsx
+++ b/webapp/src/utils/getUtteranceIdTooltip.tsx
@@ -1,0 +1,21 @@
+import { Box } from "@mui/system";
+import { Utterance, SimilarUtterance } from "types/api";
+import { AZIMUTH_ID_COLUMN } from "./const";
+
+export const getUtteranceIdTooltip = ({
+  persistentIdColumn,
+  utterance,
+}: {
+  persistentIdColumn: string;
+  utterance: Utterance | SimilarUtterance;
+}) =>
+  persistentIdColumn === AZIMUTH_ID_COLUMN ? (
+    ""
+  ) : (
+    <Box display="grid" gridTemplateColumns="auto auto" columnGap={1}>
+      <span>Azimuth id:</span>
+      <span>{utterance.index}</span>
+      <span>{persistentIdColumn}:</span>
+      <span>{utterance.persistentId}</span>
+    </Box>
+  );


### PR DESCRIPTION
Resolve #377

## Description:

* [Add persistent_id to class SimilarUtterance](https://github.com/ServiceNow/azimuth/pull/385/commits/4c2605cdb3f5294fc27843ea049234bf580bba14) using a new `BaseUtterance` class to avoid duplication of field definitions.
* [Move ellipsis to the left of utterance ids](https://github.com/ServiceNow/azimuth/pull/385/commits/9d341e1a8e08beea369f1e676639d49291509288) so for example we see `...001`, `...002`, `...003` (and infer the remaining digits from the page number) instead of `100...`, `100...`, `100...`.

https://user-images.githubusercontent.com/8386369/213814143-a16fe87d-0974-4e9e-95fb-58b0bd6b0088.mov
* [Show persistent id on hover](https://github.com/ServiceNow/azimuth/pull/385/commits/63f22559556848164445c6e19acd3425faea68dd) in utterance table, utterance details, and similar utterances.
  - Only when the user has defined a `persistent_id` column (different that Azimuth's default `row_idx`), otherwise the tooltip is the same as before.

https://user-images.githubusercontent.com/8386369/213814151-919b35e7-7910-42d3-b214-fc12aab7d52e.mov

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [ ] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
