### PR TITLE
Refactor general warnings

### DIFF
--- a/azimuth/modules/dataset_analysis/dataset_warnings.py
+++ b/azimuth/modules/dataset_analysis/dataset_warnings.py
@@ -109,14 +109,10 @@ class DatasetWarningsModule(ComparisonModule[DatasetWarningConfig]):
             count_norm_per_cls_per_split[DatasetSplitName.eval]
             - count_norm_per_cls_per_split[DatasetSplitName.train]
         )
-        alert_norm_per_cls = np.logical_or(
-            divergence_norm_per_cls > max_delta_representation,
-            divergence_norm_per_cls < -max_delta_representation,
-        )
+        alert_norm_per_cls = np.abs(divergence_norm_per_cls) > max_delta_representation
 
         first_dm = next(iter(dm_dict.values()))
         cls_names = first_dm.get_class_names(labels_only=True)
-        cls_indices = np.arange(first_dm.get_num_classes(labels_only=True))
         return [
             DatasetWarning(
                 name=f"Missing samples (<{min_count_per_cls})",
@@ -126,7 +122,7 @@ class DatasetWarningsModule(ComparisonModule[DatasetWarningConfig]):
                 format=FormatType.Integer,
                 comparisons=[
                     DatasetDistributionComparison(
-                        name=cls_names[i],
+                        name=cls_name,
                         alert=alert_min_per_cls[i],
                         data=[
                             DatasetDistributionComparisonValue(
@@ -136,7 +132,7 @@ class DatasetWarningsModule(ComparisonModule[DatasetWarningConfig]):
                             for s, count in reversed(sorted(count_per_cls_per_split.items()))
                         ],
                     )
-                    for i in cls_indices
+                    for i, cls_name in enumerate(cls_names)
                 ],
                 plots=min_sample_count_plot(
                     count_per_cls_per_split,
@@ -154,7 +150,7 @@ class DatasetWarningsModule(ComparisonModule[DatasetWarningConfig]):
                 format=FormatType.Percentage,
                 comparisons=[
                     DatasetDistributionComparison(
-                        name=cls_names[i],
+                        name=cls_name,
                         alert=alert_imb_per_cls[i],
                         data=[
                             DatasetDistributionComparisonValue(
@@ -164,7 +160,7 @@ class DatasetWarningsModule(ComparisonModule[DatasetWarningConfig]):
                             for s, imb in reversed(sorted(imb_per_cls_per_split.items()))
                         ],
                     )
-                    for i in cls_indices
+                    for i, cls_name in enumerate(cls_names)
                 ],
                 plots=class_imbalance_plot(
                     count_per_cls_per_split,
@@ -183,7 +179,7 @@ class DatasetWarningsModule(ComparisonModule[DatasetWarningConfig]):
                 format=FormatType.Percentage,
                 comparisons=[
                     DatasetDistributionComparison(
-                        name=cls_names[i],
+                        name=cls_name,
                         alert=alert_norm_per_cls[i],
                         data=[
                             DatasetDistributionComparisonValue(
@@ -192,7 +188,7 @@ class DatasetWarningsModule(ComparisonModule[DatasetWarningConfig]):
                             )
                         ],
                     )
-                    for i in cls_indices
+                    for i, cls_name in enumerate(cls_names)
                 ],
                 plots=class_representation(
                     count_per_cls_per_split,

--- a/azimuth/plots/dataset_warnings.py
+++ b/azimuth/plots/dataset_warnings.py
@@ -74,16 +74,17 @@ def sample_count_plot(
 
     # Generate warning indicators on the left axis
     alert_text_per_split = {DatasetSplitName.eval: "◓", DatasetSplitName.train: "◒"}
-    common_args = dict(
-        xref="paper",
-        showarrow=False,
-        x=-0.037,
-        font=dict(color=Colors.Orange, size=AXIS_FONT_SIZE),
-    )
     for split, alert in alert_per_cls_per_split.items():
         for idx, cls in enumerate(order):
             if alert[cls]:
-                fig.add_annotation(text=alert_text_per_split[split], y=idx, **common_args)
+                fig.add_annotation(
+                    text=alert_text_per_split[split],
+                    y=idx,
+                    xref="paper",
+                    showarrow=False,
+                    x=-0.037,
+                    font=dict(color=Colors.Orange, size=AXIS_FONT_SIZE),
+                )
 
     y_legend_1 = Y_LEGEND_LINE_1 + 3 * Y_LEGEND_LINE_HEIGHT
     y_legend_2 = Y_LEGEND_LINE_1 + 4 * Y_LEGEND_LINE_HEIGHT

--- a/azimuth/plots/dataset_warnings.py
+++ b/azimuth/plots/dataset_warnings.py
@@ -13,35 +13,30 @@ from azimuth.types.dataset_warnings import Agg, DatasetWarningPlots
 from azimuth.utils.plots import (
     AXIS_FONT_SIZE,
     DATASET_SPLIT_COLORS,
+    DATASET_SPLIT_OFFSETS,
     DATASET_SPLIT_PRETTY_NAMES,
-    PAPER_MARGINS,
     X_LEFT_LEGEND,
     X_RIGHT_LEGEND,
     Y_LEGEND_LINE_1,
     Y_LEGEND_LINE_HEIGHT,
     Colors,
     fig_default,
+    plot_height_based_on_cls_count,
     shorten_cls_names,
 )
 
 
-def nb_samples_plot(
-    train_nb_sample: np.ndarray,
-    eval_nb_sample: np.ndarray,
-    alert_train: List[bool],
-    alert_eval: List[bool],
+def sample_count_plot(
+    count_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
+    alert_per_cls_per_split: Dict[DatasetSplitName, List[bool]],
     cls_names: List[str],
-    order: np.ndarray,
 ):
-    """Generate the figure with the number of samples per label.
+    """Generate the figure with the number of samples per class.
 
     Args:
-        train_nb_sample: Distribution of the nb of samples per label in the training set.
-        eval_nb_sample:  Distribution of the nb of samples per label in the eval set.
-        alert_train: Indicator if there is an alert per label in the training set.
-        alert_eval: Indicator if there is an alert per label in the evaluation set.
+        count_per_cls_per_split: Sample count per class per split.
+        alert_per_cls_per_split: Indicator if there is an alert per class per split.
         cls_names: Class names.
-        order: Display order of the class indices
 
     Returns:
         Plot.
@@ -49,30 +44,23 @@ def nb_samples_plot(
     """
 
     cls_names = shorten_cls_names(cls_names)
+    order = count_per_cls_per_split[DatasetSplitName.eval].argsort()
 
     fig = go.Figure()
+    for split, count in sorted(count_per_cls_per_split.items()):
+        fig.add_bar(
+            y=[cls_names[x] for x in order],
+            x=count[order],
+            name=DATASET_SPLIT_PRETTY_NAMES[split],
+            offset=DATASET_SPLIT_OFFSETS[split],
+            marker=dict(color=DATASET_SPLIT_COLORS[split]),
+        )
 
-    fig.add_bar(
-        y=[cls_names[x] for x in order],
-        x=eval_nb_sample[order],
-        name="evaluation set",
-        width=0.4,
-        offset=0,
-    )
-
-    fig.add_bar(
-        y=[cls_names[x] for x in order],
-        x=train_nb_sample[order],
-        name="training set",
-        width=0.4,
-        offset=-0.4,
-    )
-
-    fig.update_traces(orientation="h")
+    fig.update_traces(orientation="h", width=0.4)
 
     fig.update_layout(
         title="Number of samples per class in both sets",
-        height=PAPER_MARGINS["t"] + PAPER_MARGINS["b"] + max(len(train_nb_sample), 6) * 23,
+        height=plot_height_based_on_cls_count(len(cls_names)),
     )
 
     fig.update_xaxes(
@@ -85,19 +73,17 @@ def nb_samples_plot(
     fig.update_yaxes(ticks="outside", ticklen=24, tickcolor="white")
 
     # Generate warning indicators on the left axis
-    x_warning = -0.037
-    for idx, label in enumerate(order):
-        common_args = dict(
-            xref="paper",
-            showarrow=False,
-            x=x_warning,
-            y=idx,
-            font=dict(color=Colors.Orange, size=AXIS_FONT_SIZE),
-        )
-        if alert_train[label]:
-            fig.add_annotation(text="◒", **common_args)
-        if alert_eval[label]:
-            fig.add_annotation(text="◓", **common_args)
+    alert_text_per_split = {DatasetSplitName.eval: "◓", DatasetSplitName.train: "◒"}
+    common_args = dict(
+        xref="paper",
+        showarrow=False,
+        x=-0.037,
+        font=dict(color=Colors.Orange, size=AXIS_FONT_SIZE),
+    )
+    for split, alert in alert_per_cls_per_split.items():
+        for idx, cls in enumerate(order):
+            if alert[cls]:
+                fig.add_annotation(text=alert_text_per_split[split], y=idx, **common_args)
 
     y_legend_1 = Y_LEGEND_LINE_1 + 3 * Y_LEGEND_LINE_HEIGHT
     y_legend_2 = Y_LEGEND_LINE_1 + 4 * Y_LEGEND_LINE_HEIGHT
@@ -113,90 +99,67 @@ def nb_samples_plot(
         showarrow=False,
     )
 
-    fig.add_annotation(
-        x=X_LEFT_LEGEND,
-        yshift=y_legend_2,
-        text="◓",
-        font=dict(color=Colors.Orange),
-        **common_args,
-    )
-    fig.add_annotation(
-        x=X_LEFT_LEGEND,
-        yshift=y_legend_3,
-        text="◒",
-        font=dict(color=Colors.Orange),
-        **common_args,
-    )
-    fig.add_annotation(
-        x=X_LEFT_LEGEND,
-        yshift=y_legend_4,
-        text="◓",
-        font=dict(color=Colors.Orange),
-        **common_args,
-    )
-    fig.add_annotation(
-        x=X_LEFT_LEGEND,
-        yshift=y_legend_4,
-        text="◒",
-        font=dict(color=Colors.Orange),
-        **common_args,
-    )
+    for y in [y_legend_2, y_legend_4]:
+        fig.add_annotation(
+            x=X_LEFT_LEGEND,
+            yshift=y,
+            text=alert_text_per_split[DatasetSplitName.eval],
+            font=dict(color=Colors.Orange),
+            **common_args,
+        )
+    for y in [y_legend_3, y_legend_4]:
+        fig.add_annotation(
+            x=X_LEFT_LEGEND,
+            yshift=y,
+            text=alert_text_per_split[DatasetSplitName.train],
+            font=dict(color=Colors.Orange),
+            **common_args,
+        )
+
     fig.add_annotation(
         x=X_LEFT_LEGEND,
         yshift=y_legend_1,
         text="Warning due to:",
         **common_args,
     )
-    fig.add_annotation(
-        x=X_RIGHT_LEGEND,
-        yshift=y_legend_2,
-        text="evaluation set",
-        **common_args,
-    )
-    fig.add_annotation(
-        x=X_RIGHT_LEGEND,
-        yshift=y_legend_3,
-        text="training set",
-        **common_args,
-    )
-    fig.add_annotation(
-        x=X_RIGHT_LEGEND,
-        yshift=y_legend_4,
-        text="both sets",
-        **common_args,
-    )
+    for y, text in zip(
+        [y_legend_2, y_legend_3, y_legend_4],
+        [
+            DATASET_SPLIT_PRETTY_NAMES[DatasetSplitName.eval],
+            DATASET_SPLIT_PRETTY_NAMES[DatasetSplitName.train],
+            "both sets",
+        ],
+    ):
+        fig.add_annotation(
+            x=X_RIGHT_LEGEND,
+            yshift=y,
+            text=text,
+            **common_args,
+        )
 
     fig = fig_default(fig)
     return fig
 
 
-def min_nb_samples_plot(
-    train_nb_sample: np.ndarray,
-    eval_nb_sample: np.ndarray,
+def min_sample_count_plot(
+    count_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
     threshold: int,
-    alert_train: List[bool],
-    alert_eval: List[bool],
+    alert_per_cls_per_split: Dict[DatasetSplitName, List[bool]],
     cls_names: List[str],
 ) -> DatasetWarningPlots:
-    """Generate the plot for the minimal number of samples per label.
+    """Generate the plot for the minimal number of samples per class.
 
     Args:
-        train_nb_sample: Distribution of the nb of samples per label in the training set.
-        eval_nb_sample:  Distribution of the nb of samples per label in the eval set.
-        threshold: Threshold below which a label has an associated alert.
-        alert_train: Indicator if there is an alert per label in the training set.
-        alert_eval: Indicator if there is an alert per label in the evaluation set.
+        count_per_cls_per_split: Sample count per class per split.
+        threshold: Threshold below which a class has an associated alert.
+        alert_per_cls_per_split: Indicator if there is an alert per class per split.
         cls_names: Class names.
 
     Returns:
         Plot.
 
     """
-    order = eval_nb_sample.argsort()
-
-    fig = nb_samples_plot(
-        train_nb_sample, eval_nb_sample, alert_train, alert_eval, cls_names, order
-    )
+    fig = sample_count_plot(count_per_cls_per_split, alert_per_cls_per_split, cls_names)
     fig.add_vline(x=threshold, line_width=1, line_dash="dot", line_color=Colors.Orange)
     fig.add_annotation(
         text=threshold,
@@ -212,101 +175,76 @@ def min_nb_samples_plot(
 
 
 def class_imbalance_plot(
-    train_nb_sample: np.ndarray,
-    eval_nb_sample: np.ndarray,
-    train_mean: float,
-    eval_mean: float,
+    count_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
+    mean_per_split: Dict[DatasetSplitName, float],
     max_perc_delta: float,
-    alert_train: List[bool],
-    alert_eval: List[bool],
+    alert_per_cls_per_split: Dict[DatasetSplitName, List[bool]],
     cls_names: List[str],
 ) -> DatasetWarningPlots:
     """Generate the plot for the class imbalance warnings.
 
     Args:
-        train_nb_sample: Distribution of the number of samples per label in the training set.
-        eval_nb_sample:  Distribution of the number of samples per label in the eval set.
-        train_mean: Mean of the number of samples in the training set.
-        eval_mean: Mean of the number of samples in the evaluation set.
+        count_per_cls_per_split: Sample count per class per split.
+        mean_per_split: Mean of the sample count per split.
         max_perc_delta: Percentage around the mean where values need to be.
-        alert_train: Indicator if there is an alert per label in the training set.
-        alert_eval: Indicator if there is an alert per label in the evaluation set.
+        alert_per_cls_per_split: Indicator if there is an alert per class per split.
         cls_names: Class names.
 
     Returns:
         Plot.
 
     """
-    order = eval_nb_sample.argsort()
+    fig = sample_count_plot(count_per_cls_per_split, alert_per_cls_per_split, cls_names)
 
-    fig = nb_samples_plot(
-        train_nb_sample, eval_nb_sample, alert_train, alert_eval, cls_names, order
-    )
-    num_classes = len(cls_names)
-    y1_eval = num_classes + 2
-    y1_train = num_classes + 1
     common_args = dict(layer="below", line_width=1, y0=-1)
-    common_args_rect = dict(type="rect", opacity=0.3, **common_args)
-    fig.add_shape(
-        x0=eval_mean * (1 - max_perc_delta),
-        x1=eval_mean * (1 + max_perc_delta),
-        y1=y1_eval,
-        line_color=Colors.DataViz1,
-        fillcolor=Colors.DataViz1,
-        **common_args_rect,
-    )
-    fig.add_shape(
-        x0=train_mean * (1 - max_perc_delta),
-        x1=train_mean * (1 + max_perc_delta),
-        y1=y1_train,
-        line_color=Colors.DataViz2,
-        fillcolor=Colors.DataViz2,
-        **common_args_rect,
-    )
-    common_args_line = dict(type="line", line_dash="dot", **common_args)
-    fig.add_shape(
-        x0=eval_mean,
-        x1=eval_mean,
-        y1=y1_eval,
-        line_color=Colors.DataViz1,
-        **common_args_line,
-    )
-    fig.add_shape(
-        x0=train_mean,
-        x1=train_mean,
-        y1=y1_train,
-        line_color=Colors.DataViz2,
-        **common_args_line,
-    )
-    common_args_ann = dict(yanchor="top", font=dict(color=Colors.Text), showarrow=False)
-    fig.add_annotation(
-        text=f"Mean in eval: {eval_mean:.2f}", x=eval_mean, y=y1_eval, **common_args_ann
-    )
-    fig.add_annotation(
-        text=f"Mean in train: {train_mean:.2f}", x=train_mean, y=y1_train, **common_args_ann
-    )
+    cls_count = len(cls_names)
+    y1_per_split = {DatasetSplitName.eval: cls_count + 2, DatasetSplitName.train: cls_count + 1}
+    for split, mean in sorted(mean_per_split.items()):
+        fig.add_shape(
+            x0=mean * (1 - max_perc_delta),
+            x1=mean * (1 + max_perc_delta),
+            y1=y1_per_split[split],
+            line_color=DATASET_SPLIT_COLORS[split],
+            fillcolor=DATASET_SPLIT_COLORS[split],
+            type="rect",
+            opacity=0.3,
+            **common_args,
+        )
+        fig.add_shape(
+            x0=mean,
+            x1=mean,
+            y1=y1_per_split[split],
+            line_color=DATASET_SPLIT_COLORS[split],
+            type="line",
+            line_dash="dot",
+            **common_args,
+        )
+        fig.add_annotation(
+            text=f"Mean in {split}: {mean:.2f}",
+            x=mean,
+            y=y1_per_split[split],
+            yanchor="top",
+            font=dict(color=Colors.Text),
+            showarrow=False,
+        )
 
     return DatasetWarningPlots(overall=json.loads(fig.to_json()), per_class=None)
 
 
 def class_representation(
-    train_nb_sample: np.ndarray,
-    eval_nb_sample: np.ndarray,
-    train_dist_norm: np.ndarray,
-    eval_dist_norm: np.ndarray,
+    count_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
+    count_norm_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
     divergence_norm: np.ndarray,
     threshold: float,
     cls_names: List[str],
 ) -> DatasetWarningPlots:
-    """Generate the plot for the minimal representation of samples per label.
+    """Generate the plot for the minimal representation of samples per class.
 
     Args:
-        train_nb_sample: Distribution of the nb of samples per label in the training set.
-        eval_nb_sample: Distribution of the nb of samples per label in the eval set.
-        train_dist_norm: Distribution of the percentage of samples per label in the training set.
-        eval_dist_norm: Distribution of the percentage of samples per label in the eval set.
-        divergence_norm: Difference in percentage per label between train and eval.
-        threshold: Threshold below which a label has an associated alert.
+        count_per_cls_per_split: Sample count per class per split.
+        count_norm_per_cls_per_split: Normalized sample count per class per split.
+        divergence_norm: Difference in percentage per class between train and eval.
+        threshold: Threshold below which a class has an associated alert.
         cls_names: Class names.
 
     Returns:
@@ -318,27 +256,18 @@ def class_representation(
 
     fig = make_subplots(rows=1, cols=2, column_widths=[0.3, 0.7])
 
-    fig.add_bar(
-        y=[cls_names[x] for x in order],
-        x=eval_dist_norm[order],
-        text=eval_nb_sample[order],
-        name="evaluation set",
-        xaxis="x2",
-        hoverinfo="x+y+text",
-        width=0.4,
-        offset=0,
-    )
-
-    fig.add_bar(
-        y=[cls_names[x] for x in order],
-        x=train_dist_norm[order],
-        text=train_nb_sample[order],
-        name="training set",
-        xaxis="x2",
-        hoverinfo="x+y+text",
-        width=0.4,
-        offset=-0.4,
-    )
+    for split, c_norm in sorted(count_norm_per_cls_per_split.items()):
+        fig.add_bar(
+            y=[cls_names[x] for x in order],
+            x=c_norm,
+            text=count_per_cls_per_split[split][order],
+            name=DATASET_SPLIT_PRETTY_NAMES[split],
+            xaxis="x2",
+            hoverinfo="x+y+text",
+            width=0.4,
+            offset=DATASET_SPLIT_OFFSETS[split],
+            marker=dict(color=DATASET_SPLIT_COLORS[split]),
+        )
 
     fig.add_bar(
         y=[cls_names[x] for x in order],
@@ -353,28 +282,17 @@ def class_representation(
         xaxis="x1",
     )
 
-    fig.update_traces(orientation="h")
-
-    fig.update_layout(
-        title="Delta in class representation between both sets",
-        height=PAPER_MARGINS["t"] + PAPER_MARGINS["b"] + max(len(train_nb_sample), 6) * 23,
-    )
-
-    fig.update_xaxes(
-        tickformat=",.0%",
-        zeroline=True,
-        zerolinecolor=Colors.Axis,
-        zerolinewidth=1,
-        showgrid=True,
-        gridcolor=Colors.Gray_transparent,
-    )
-
-    fig.add_vline(
-        x=threshold, line_width=1, line_dash="dot", line_color=Colors.Orange, col=1, row=1
-    )
-    fig.add_vline(
-        x=-threshold, line_width=1, line_dash="dot", line_color=Colors.Orange, col=1, row=1
-    )
+    for mult in [-1, 1]:
+        fig.add_vline(
+            x=mult * threshold,
+            line_width=1,
+            line_dash="dot",
+            line_color=Colors.Orange,
+            col=1,
+            row=1,
+        )
+        # These transparent lines make sure that the left plot is centered and with a min. range.
+        fig.add_vline(x=mult * 0.2, line_color="rgba(0,0,0,0)", col=1, row=1)
 
     fig.add_annotation(
         text=f"±{100 * threshold}%",
@@ -386,12 +304,8 @@ def class_representation(
         showarrow=False,
     )
 
-    # These transparent lines make sure that the left plot is centered and with a min. range.
-    fig.add_vline(x=-0.2, line_color="rgba(0,0,0,0)", col=1, row=1)
-    fig.add_vline(x=0.2, line_color="rgba(0,0,0,0)", col=1, row=1)
-
-    for idx, label in enumerate(order):
-        if divergence_norm[label] > threshold or divergence_norm[label] < -threshold:
+    for idx, cls in enumerate(order):
+        if divergence_norm[cls] > threshold or divergence_norm[cls] < -threshold:
             fig.add_annotation(
                 text="⬤",
                 font=dict(color=Colors.Orange, size=AXIS_FONT_SIZE - 3),
@@ -410,25 +324,37 @@ def class_representation(
         xanchor="left",
         yanchor="middle",
         showarrow=False,
+        yshift=y_legend,
     )
 
     fig.add_annotation(
         x=X_LEFT_LEGEND,
-        yshift=y_legend,
         text="⬤",
         font=dict(color=Colors.Orange, size=AXIS_FONT_SIZE - 3),
         **common_args,
     )
     fig.add_annotation(
         x=X_RIGHT_LEGEND,
-        yshift=y_legend,
         text="warning",
         font=dict(color=Colors.Text, size=AXIS_FONT_SIZE),
         **common_args,
     )
 
+    fig.update_traces(orientation="h")
+    fig.update_layout(
+        title="Delta in class representation between both sets",
+        height=plot_height_based_on_cls_count(len(cls_names)),
+    )
+    fig.update_xaxes(
+        tickformat=",.0%",
+        zeroline=True,
+        zerolinecolor=Colors.Axis,
+        zerolinewidth=1,
+        showgrid=True,
+        gridcolor=Colors.Gray_transparent,
+    )
     fig = fig_default(fig)
-    fig.update_yaxes(ticks="outside", ticklen=15, tickcolor="white")
+    fig.update_yaxes(ticks="outside", ticklen=15, tickcolor="white")  # Override default
 
     return DatasetWarningPlots(overall=json.loads(fig.to_json()), per_class=None)
 
@@ -438,16 +364,16 @@ def create_histogram_mean_std(
     value_per_agg_per_split: Dict[DatasetSplitName, Dict[Agg, float]],
     divergence_per_agg: Optional[Dict[Agg, float]] = None,
 ) -> PlotSpecification:
-    """Create the histogram traces and annotations for each label (and "all").
+    """Create the histogram traces and annotations for each class (and "all").
 
     Args:
-        hist_per_split: Histogram values for the selected label per split.
-        value_per_agg_per_split: Mean and std dev for the selected label per split.
+        hist_per_split: Histogram values for the selected class per split.
+        value_per_agg_per_split: Mean and std dev for the selected class per split.
         divergence_per_agg: Difference in the mean and std dev. None means that we are generating
-            the plot for 'all' labels.
+            the plot for 'all' classes.
 
     Returns:
-        Plot for one label.
+        Plot for one class.
 
     """
     fig = go.Figure()
@@ -528,49 +454,49 @@ def create_histogram_mean_std(
 
 
 def word_count_plot(
-    hist_per_label_per_split: Dict[DatasetSplitName, np.ndarray],
+    hist_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
     value_per_agg_per_split: Dict[DatasetSplitName, Dict[Agg, float]],
-    value_per_label_per_agg_per_split: Dict[DatasetSplitName, Dict[Agg, np.ndarray]],
-    divergence_per_label_per_agg: Dict[Agg, np.ndarray],
-    class_names: List[str],
+    value_per_cls_per_agg_per_split: Dict[DatasetSplitName, Dict[Agg, np.ndarray]],
+    divergence_per_cls_per_agg: Dict[Agg, np.ndarray],
+    cls_names: List[str],
 ) -> DatasetWarningPlots:
-    """Create the plot with the dropdown for all labels.
+    """Create the plot with the dropdown for all classes.
 
     Args:
-        hist_per_label_per_split: Histogram of word count per label per split.
+        hist_per_cls_per_split: Histogram of word count per class per split.
         value_per_agg_per_split: Mean and std dev per split.
-        value_per_label_per_agg_per_split: Mean and std dev per label per split.
-        divergence_per_label_per_agg: Alert value for the mean and std dev per label.
-        class_names: List of class names.
+        value_per_cls_per_agg_per_split: Mean and std dev per class per split.
+        divergence_per_cls_per_agg: Alert value for the mean and std dev per class.
+        cls_names: List of class names.
 
     Returns:
         Plot for all classes combined, and plot per class.
 
     """
     # Sanitize values for the plot.
-    sanitized_value_per_label_per_agg_per_split = {
+    sanitized_value_per_cls_per_agg_per_split = {
         split: {agg: np.nan_to_num(value) for agg, value in per_split_value.items()}
-        for split, per_split_value in value_per_label_per_agg_per_split.items()
+        for split, per_split_value in value_per_cls_per_agg_per_split.items()
     }
 
-    hist_per_split = {split: h.sum(axis=0) for split, h in hist_per_label_per_split.items()}
+    hist_per_split = {split: h.sum(axis=0) for split, h in hist_per_cls_per_split.items()}
 
-    # Traces and Annotations across all labels
+    # Traces and Annotations across all classes
     fig_all = create_histogram_mean_std(
         hist_per_split,
         value_per_agg_per_split,
     )
 
-    # Traces and Annotations for each label
+    # Traces and Annotations for each class
     figs_dict = {}
-    for label_id in np.arange(len(class_names)):
-        figs_dict[class_names[label_id]] = create_histogram_mean_std(
-            {split: value[label_id] for split, value in hist_per_label_per_split.items()},
+    for cls_id in np.arange(len(cls_names)):
+        figs_dict[cls_names[cls_id]] = create_histogram_mean_std(
+            {split: value[cls_id] for split, value in hist_per_cls_per_split.items()},
             {
-                split: {agg: value[label_id] for agg, value in per_split_value.items()}
-                for split, per_split_value in sanitized_value_per_label_per_agg_per_split.items()
+                split: {agg: value[cls_id] for agg, value in per_split_value.items()}
+                for split, per_split_value in sanitized_value_per_cls_per_agg_per_split.items()
             },
-            {agg: value[label_id] for agg, value in divergence_per_label_per_agg.items()},
+            {agg: value[cls_id] for agg, value in divergence_per_cls_per_agg.items()},
         )
 
     return DatasetWarningPlots(overall=fig_all, per_class=figs_dict)

--- a/azimuth/utils/plots.py
+++ b/azimuth/utils/plots.py
@@ -52,11 +52,15 @@ DATASET_SPLIT_COLORS = {
     DatasetSplitName.eval: Colors.DataViz1,
     DatasetSplitName.train: Colors.DataViz2,
 }
-
 DATASET_SPLIT_PRETTY_NAMES = {
     DatasetSplitName.eval: "evaluation set",
     DatasetSplitName.train: "training set",
 }
+DATASET_SPLIT_OFFSETS = {DatasetSplitName.eval: 0, DatasetSplitName.train: -0.4}
+
+
+def plot_height_based_on_cls_count(cls_count):
+    return PAPER_MARGINS["t"] + PAPER_MARGINS["b"] + max(cls_count, 6) * 23
 
 
 def fig_default(fig):


### PR DESCRIPTION
Part of  #383 

## Description:
* Similar refactoring to the general warnings, to eventually allow this module to only run on one dataset split.
* I further refactored syntactic warnings a bit, to use `cls` instead of `label` throughout, for consistency.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
