### PR TITLE
Adapt dataset warnings so it works with one dataset split

### DIFF
--- a/azimuth/plots/dataset_warnings.py
+++ b/azimuth/plots/dataset_warnings.py
@@ -28,7 +28,7 @@ from azimuth.utils.plots import (
 
 def sample_count_plot(
     count_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
-    alert_per_cls_per_split: Dict[DatasetSplitName, List[bool]],
+    alert_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
     cls_names: List[str],
 ):
     """Generate the figure with the number of samples per class.
@@ -44,7 +44,12 @@ def sample_count_plot(
     """
 
     cls_names = shorten_cls_names(cls_names)
-    order = count_per_cls_per_split[DatasetSplitName.eval].argsort()
+    order_split = (
+        DatasetSplitName.eval
+        if DatasetSplitName.eval in count_per_cls_per_split
+        else DatasetSplitName.train
+    )
+    order = count_per_cls_per_split[order_split].argsort()
 
     fig = go.Figure()
     for split, count in sorted(count_per_cls_per_split.items()):
@@ -145,7 +150,7 @@ def sample_count_plot(
 def min_sample_count_plot(
     count_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
     threshold: int,
-    alert_per_cls_per_split: Dict[DatasetSplitName, List[bool]],
+    alert_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
     cls_names: List[str],
 ) -> DatasetWarningPlots:
     """Generate the plot for the minimal number of samples per class.
@@ -179,7 +184,7 @@ def class_imbalance_plot(
     count_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
     mean_per_split: Dict[DatasetSplitName, float],
     max_perc_delta: float,
-    alert_per_cls_per_split: Dict[DatasetSplitName, List[bool]],
+    alert_per_cls_per_split: Dict[DatasetSplitName, np.ndarray],
     cls_names: List[str],
 ) -> DatasetWarningPlots:
     """Generate the plot for the class imbalance warnings.

--- a/azimuth/routers/v1/dataset_warnings.py
+++ b/azimuth/routers/v1/dataset_warnings.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends
 
-from azimuth.app import get_all_dataset_split_managers, get_task_manager
+from azimuth.app import get_dataset_split_manager_mapping, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
 from azimuth.types import DatasetSplitName, SupportedModule
@@ -29,20 +29,15 @@ TAGS = ["Dataset Warnings v1"]
 def get_dataset_warnings(
     task_manager: TaskManager = Depends(get_task_manager),
     dataset_split_managers: Dict[DatasetSplitName, DatasetSplitManager] = Depends(
-        get_all_dataset_split_managers
+        get_dataset_split_manager_mapping
     ),
 ) -> List[DatasetWarningGroup]:
-
-    dm_eval = dataset_split_managers.get(DatasetSplitName.eval)
-    dm_train = dataset_split_managers.get(DatasetSplitName.train)
-
-    last_update = get_last_update([dm_eval, dm_train])
 
     task_result: DatasetWarningsResponse = get_standard_task_result(
         SupportedModule.DatasetWarnings,
         dataset_split_name=DatasetSplitName.all,
         task_manager=task_manager,
-        last_update=last_update,
+        last_update=get_last_update(list(dataset_split_managers.values())),
     )[0]
 
     return task_result.warning_groups

--- a/tests/test_modules/test_dataset_analysis/test_dataset_warnings.py
+++ b/tests/test_modules/test_dataset_analysis/test_dataset_warnings.py
@@ -11,7 +11,7 @@ from datasets import ClassLabel
 
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.dataset_analysis.dataset_warnings import DatasetWarningsModule
-from azimuth.types import DatasetSplitName
+from azimuth.types import DatasetSplitName, ModuleOptions
 from tests.utils import generate_mocked_dm, get_tiny_text_config_one_ds_name
 
 
@@ -129,14 +129,27 @@ def test_dataset_warnings_with_one_ds(tiny_text_config_one_ds):
     general_warnings = output[0]
     assert len(general_warnings.warnings) == 2, "Only 2 general warnings with one dataset split"
     assert all(
-        [
-            len(comparison.data) == 1
-            for warning in general_warnings.warnings
-            for comparison in warning.comparisons
-        ]
+        len(comparison.data) == 1
+        for warning in general_warnings.warnings
+        for comparison in warning.comparisons
     ), "Only data for one split"
 
     syntactic_warnings = output[1]
-    assert not all(
-        [comparison.alert for comparison in syntactic_warnings.warnings[0].comparisons]
+    assert not any(
+        comparison.alert for comparison in syntactic_warnings.warnings[0].comparisons
     ), "No alert with one split"
+
+
+def test_with_dataset_and_indices(simple_text_config):
+    with pytest.raises(ValueError):
+        DatasetWarningsModule(
+            dataset_split_name=DatasetSplitName.eval,
+            config=simple_text_config,
+        )
+
+    with pytest.raises(ValueError):
+        DatasetWarningsModule(
+            dataset_split_name=DatasetSplitName.all,
+            config=simple_text_config,
+            mod_options=ModuleOptions(indices=[1, 2]),
+        )

--- a/tests/test_routers/test_dataset_warnings.py
+++ b/tests/test_routers/test_dataset_warnings.py
@@ -22,7 +22,7 @@ def test_dataset_warnings(app: FastAPI) -> None:
             "name": "General Warnings",
             "warnings": [
                 {
-                    "columns": ["training", "evaluation"],
+                    "columns": ["train", "eval"],
                     "comparisons": [
                         {
                             "alert": False,
@@ -41,7 +41,7 @@ def test_dataset_warnings(app: FastAPI) -> None:
                     "name": "Missing samples (<20)",
                 },
                 {
-                    "columns": ["training", "evaluation"],
+                    "columns": ["train", "eval"],
                     "comparisons": [
                         {
                             "alert": False,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -127,7 +127,7 @@ def get_table_key(config, use_bma=False):
 
 
 def generate_mocked_dm(config, dataset_split_name=DatasetSplitName.eval):
-    ds = load_dataset_from_config(config)[DatasetSplitName.eval]
+    ds = load_dataset_from_config(config)[dataset_split_name]
     ds = ds.map(
         lambda x, i: {
             DatasetColumn.model_predictions: [i % 2, 1 - i % 2],

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -78,7 +78,7 @@ const Dashboard = () => {
           Go to exploration space
         </Button>
       </Box>
-      {datasetInfo.availableDatasetSplits.train && (
+      {
         <PreviewCard
           title="Dataset Warnings"
           to={`/${jobId}/dataset_warnings${searchString}`}
@@ -93,7 +93,7 @@ const Dashboard = () => {
             <WarningsPreview jobId={jobId} />
           </Box>
         </PreviewCard>
-      )}
+      }
       {datasetInfo.availableDatasetSplits.train &&
         datasetInfo.similarityAvailable && (
           <PreviewCard

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -78,22 +78,20 @@ const Dashboard = () => {
           Go to exploration space
         </Button>
       </Box>
-      {
-        <PreviewCard
-          title="Dataset Warnings"
-          to={`/${jobId}/dataset_warnings${searchString}`}
-          description={
-            <Description
-              text="Investigate issues related to class size, class imbalance, or dataset shift between your training and evaluation sets."
-              link="user-guide/dataset-warnings/"
-            />
-          }
-        >
-          <Box height={DEFAULT_PREVIEW_CONTENT_HEIGHT}>
-            <WarningsPreview jobId={jobId} />
-          </Box>
-        </PreviewCard>
-      }
+      <PreviewCard
+        title="Dataset Warnings"
+        to={`/${jobId}/dataset_warnings${searchString}`}
+        description={
+          <Description
+            text="Investigate issues related to class size, class imbalance, or dataset shift between your training and evaluation sets."
+            link="user-guide/dataset-warnings/"
+          />
+        }
+      >
+        <Box height={DEFAULT_PREVIEW_CONTENT_HEIGHT}>
+          <WarningsPreview jobId={jobId} />
+        </Box>
+      </PreviewCard>
       {datasetInfo.availableDatasetSplits.train &&
         datasetInfo.similarityAvailable && (
           <PreviewCard


### PR DESCRIPTION
Resolve #383

## Description:
- Although the diff might look scary, there aren't that many code changes. I mostly moved stuff around by warning, so the representation mismatch is not called when there is only one split.
- Apart from that, I needed to create a bunch of `defaultdict` with NumPy arrays of `nan` or `False`, so that the code don't break if one split is not present.
- `mypy` decided to complain, so I needed to add a bunch of typing.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
