### PR TITLE
Enforce mypy in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,6 @@ repos:
         name: mypy
         language: system
         verbose: true
-        entry: bash -c 'poetry run mypy "azimuth" || true' --
+        entry: bash -c 'poetry run mypy "azimuth"'
         files: azimuth
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,6 @@ repos:
         name: mypy
         language: system
         verbose: true
-        entry: bash -c 'poetry run mypy "azimuth"'
+        entry: poetry run mypy azimuth
         files: azimuth
         pass_filenames: false


### PR DESCRIPTION
## Description:
`mypy` was never enforced in the pre-commit because, at a certain time, we couldn't put the errors to 0 easily. This is no longer the case, and I don't think we should be able to commit with `mypy` errors. 

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
