### PR TITLE
Add default config to config page UI

### DIFF
--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -227,7 +227,8 @@ const Settings: React.FC = () => {
                 {
                   ...pipeline,
                   postprocessors: checked
-                    ? config.pipelines![pipelineIndex].postprocessors ?? []
+                    ? config.pipelines![pipelineIndex].postprocessors ??
+                      defaultConfig.pipelines![0].postprocessors
                     : null,
                 },
                 ...resultingConfig.pipelines!.slice(pipelineIndex + 1),
@@ -251,6 +252,7 @@ const Settings: React.FC = () => {
     <NumberField
       label={field}
       value={value}
+      disabled={!resultingConfig.pipelines![pipelineIndex].postprocessors}
       onChange={(newValue) =>
         setPartialConfig({
           ...partialConfig,
@@ -422,7 +424,10 @@ const Settings: React.FC = () => {
                 <FormControl>
                   {displayPostprocessorToggleSection(pipelineIndex, pipeline)}
                   <FormGroup sx={{ gap: 2 }}>
-                    {pipeline.postprocessors?.map((postprocessor, index) => (
+                    {(
+                      pipeline.postprocessors ??
+                      defaultConfig.pipelines![0].postprocessors
+                    )?.map((postprocessor, index) => (
                       <Paper key={index} variant="outlined" sx={{ padding: 2 }}>
                         <Columns columns={3}>
                           {displayReadonlyFields(

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -189,7 +189,7 @@ const Settings: React.FC = () => {
     Partial<AzimuthConfig>
   >({});
 
-  // If config or defaultConfig was undefined, PipelineCheck would not even render the page.
+  // If config was undefined, PipelineCheck would not even render the page.
   if (config === undefined) return null;
 
   if (isLoading) {

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -19,7 +19,9 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
+import noData from "assets/void.svg";
 import AccordionLayout from "components/AccordionLayout";
+import Loading from "components/Loading";
 import _ from "lodash";
 import React from "react";
 import { useParams } from "react-router-dom";
@@ -30,6 +32,7 @@ import {
 } from "services/api";
 import { AzimuthConfig, PipelineDefinition } from "types/api";
 import { PickByValue } from "types/models";
+import { UNKNOWN_ERROR } from "utils/const";
 
 const PERCENTAGE = { scale: 100, units: "%", inputProps: { min: 0, max: 100 } };
 const INT = { inputProps: { min: 0 } };
@@ -174,7 +177,11 @@ const NumberField: React.FC<
 
 const Settings: React.FC = () => {
   const { jobId } = useParams<{ jobId: string }>();
-  const { data: defaultConfig } = getDefaultConfigEndpoint.useQuery({ jobId });
+  const {
+    data: defaultConfig,
+    isLoading,
+    error,
+  } = getDefaultConfigEndpoint.useQuery({ jobId });
   const { data: config } = getConfigEndpoint.useQuery({ jobId });
   const [updateConfig] = updateConfigEndpoint.useMutation();
 
@@ -183,8 +190,18 @@ const Settings: React.FC = () => {
   >({});
 
   // If config or defaultConfig was undefined, PipelineCheck would not even render the page.
-  if (config === undefined || defaultConfig === undefined) return null;
+  if (config === undefined) return null;
 
+  if (isLoading) {
+    return <Loading />;
+  } else if (error || defaultConfig === undefined) {
+    return (
+      <Box alignItems="center" display="grid" justifyItems="center">
+        <img src={noData} width="50%" alt="No default config data available" />
+        <Typography>{error?.message || UNKNOWN_ERROR}</Typography>
+      </Box>
+    );
+  }
   const resultingConfig = Object.assign({}, config, partialConfig);
 
   const displayToggleSectionTitle = (

--- a/webapp/src/services/api.ts
+++ b/webapp/src/services/api.ts
@@ -293,6 +293,13 @@ export const api = createApi({
         "Something went wrong fetching config"
       ),
     }),
+    getDefaultConfig: build.query({
+      providesTags: [{ type: "Config" }],
+      queryFn: responseToData(
+        fetchApi({ path: "/admin/default_config", method: "get" }),
+        "Something went wrong fetching default config"
+      ),
+    }),
     updateConfig: build.mutation<
       AzimuthConfig,
       { jobId: string; body: Partial<AzimuthConfig> }
@@ -371,6 +378,7 @@ export const api = createApi({
 export const {
   getConfidenceHistogram: getConfidenceHistogramEndpoint,
   getConfig: getConfigEndpoint,
+  getDefaultConfig: getDefaultConfigEndpoint,
   getConfusionMatrix: getConfusionMatrixEndpoint,
   getDatasetInfo: getDatasetInfoEndpoint,
   getDatasetWarnings: getDatasetWarningsEndpoint,


### PR DESCRIPTION
Resolve #

## Description:

This PR is to call the default config API from the back end to display the default config subfields in scenarios like postprocessor or similarity being null
## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
