### PR TITLE
Improve optimistic update of `datasetInfo`

### DIFF
--- a/webapp/src/services/api.ts
+++ b/webapp/src/services/api.ts
@@ -327,10 +327,19 @@ export const api = createApi({
         );
         const patchDatasetInfo = dispatch(
           api.util.updateQueryData("getDatasetInfo", { jobId }, (draft) => {
+            if (partialConfig.name !== undefined) {
+              draft.projectName = partialConfig.name;
+            }
+            if (partialConfig.model_contract !== undefined) {
+              draft.modelContract = partialConfig.model_contract;
+            }
             if ("behavioral_testing" in partialConfig) {
               draft.perturbationTestingAvailable = Boolean(
                 partialConfig.behavioral_testing
               );
+            }
+            if ("pipelines" in partialConfig) {
+              draft.predictionAvailable = Boolean(partialConfig.pipelines);
             }
             if ("similarity" in partialConfig) {
               draft.similarityAvailable = Boolean(partialConfig.similarity);


### PR DESCRIPTION
## Description:

Improve optimistic update of `datasetInfo`. For example, if you update the project name in the config page (not yet possible), it will update instantly in the top navigation bar.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
