### PR TITLE
Remove `model_contract` from `artifact_path`

### DIFF
--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -252,8 +252,6 @@ class ProjectConfig(AzimuthBaseSettings):
     name: str = Field("New project", exclude_from_cache=True)
     # Dataset object definition.
     dataset: CustomObject
-    # Which model_contract the application is using.
-    model_contract: SupportedModelContract = SupportedModelContract.hf_text_classification
     # Column names config in dataset
     columns: ColumnConfiguration = ColumnConfiguration()
     # Name of the rejection class.
@@ -302,12 +300,14 @@ class CommonFieldsConfig(ProjectConfig, extra=Extra.ignore):
         Returns:
             Path to a folder where it is safe to store data.
         """
-        path = pjoin(self.artifact_path, f"{self.name}_{self.model_contract}_{self.to_hash()[:5]}")
+        path = pjoin(self.artifact_path, f"{self.name}_{self.to_hash()[:5]}")
         os.makedirs(path, exist_ok=True)
         return path
 
 
 class ModelContractConfig(CommonFieldsConfig):
+    # Which model_contract the application is using.
+    model_contract: SupportedModelContract = SupportedModelContract.hf_text_classification
     # Model object definition.
     pipelines: Optional[List[PipelineDefinition]] = Field(None, nullable=True)
     # Uncertainty configuration

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -126,7 +126,6 @@ export interface components {
     AzimuthConfig: {
       name: string;
       dataset: components["schemas"]["CustomObject"];
-      model_contract: components["schemas"]["SupportedModelContract"];
       columns: components["schemas"]["ColumnConfiguration"];
       rejection_class: string | null;
       artifact_path: string;
@@ -134,6 +133,7 @@ export interface components {
       use_cuda: "auto" | boolean;
       large_dask_cluster: boolean;
       read_only_config: boolean;
+      model_contract: components["schemas"]["SupportedModelContract"];
       pipelines: components["schemas"]["PipelineDefinition"][] | null;
       uncertainty: components["schemas"]["UncertaintyOptions"];
       saliency_layer: string | null;


### PR DESCRIPTION
## Description:
* `model-contract` was not in the right config scope. It was there for the `artifact_path`, but as we discussed, we should not include anything that is not related to the dataset in the `artifact_path`.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
