### PR TITLE
Add required_mod_options

### DIFF
--- a/azimuth/modules/README.md
+++ b/azimuth/modules/README.md
@@ -54,7 +54,8 @@ inherit from. Different options are available, with different particularities.
 
 - This is the parent module. No Module should directly inherit from it. It includes a lot of the
   basic methods that apply to all modules.
-- All module options are ignored by default (`allowed_mod_options` is empty) in this module.
+- All module options are ignored by default (`allowed_mod_options` and `required_mod_options` are
+  empty) in this module.
 
 ### Indexable Module
 
@@ -76,9 +77,8 @@ inherit from. Different options are available, with different particularities.
 - It inherits from Dataset Result Module, and is a module that wraps models.
 - These modules handle all the tasks which are in need of direct access to the model in order to
   compute their results (e.g. prediction, saliency).
-- `allowed_mod_options` include some default options that can affect models, such as the `threshold`
-  and the `pipeline_index`. The mod_options `model_contract_method_name` is mandatory as it
-  specifies which method should be called in the module.
+- `allowed_mod_options` include default options that can affect models, such as the `threshold`.
+- `required_mod_options` include both `model_contract_method_name` and `pipeline_index`.
 
 ### Aggregation Module
 - This module inherits from `Module`, and so the same methods and attributes are available.
@@ -88,6 +88,8 @@ inherit from. Different options are available, with different particularities.
 - This module inherits from `AggregationModule` and is similar in all points
 - However, `allowed_mod_options` include `filters`, which mean the dataset can be filtered using `DatasetFilters` (as opposed to regular modules which use indices only).
 - As such, `.get_dataset_split()` returns a subset of the `dataset_split`, based on `filters`.
+- `required_mod_options` include `pipeline_index` since all filterable modules require filtering on the dataset, which involve predictions.
+
 
 #### Comparison Module
 - This module inherits from `AggregationModule` and is similar in all points. The only difference it that it works on multiple dataset split at the same time. As such, it only accepts `DatasetSplitName.all`.
@@ -130,6 +132,9 @@ For example, it should throw if a module is called with the wrong dataset_split,
 `allowed_mod_options` is a set containing the list of `mod_options` that can affect a given module.
 * By default, the set is empty.
 * Different default values are available in the different parent modules below. When overriding the default values, the values from the parent module should be added to the set.
+
+### Required Mod Options
+Similarly, `required_mod_options` is a set containing all `mod_options` that are mandatory for this module.
 
 ## Artifact Manager
 
@@ -204,6 +209,6 @@ Every module result is cached in a HDF5 file. This allows for random-access to t
 re-computation. The caching is implemented in `azimuth.modules.caching.HDF5CacheMixin`. A new cache
 is generated everytime the `.name` of the module changes. The `.name` is generated automatically
 based on the `task_name`, the `dataset_split_name`, and two striped hash sequences, based on
-either `allowed_mod_options` values (minus `indices`) or `config` attribute values. By default, a
+either `allowed_mod_options`/`required_mod_options` values (minus `indices`) or `config` attribute values. By default, a
 new cache folder is created when one of the attribute value from the `ProjectConfig` is changed.
-This includes attributes such as the dataset and model paths.
+This includes attributes related to the dataset.

--- a/azimuth/modules/base_classes/aggregation_module.py
+++ b/azimuth/modules/base_classes/aggregation_module.py
@@ -14,8 +14,6 @@ from azimuth.utils.dataset_operations import filter_dataset_split
 class AggregationModule(Module[ConfigScope], ABC):
     """Same as Module, but caching is done over a set of indices."""
 
-    allowed_mod_options = {"pipeline_index"}
-
     def get_caching_indices(self) -> List[int]:
         return [-1]  # Aggregation Module cache on one index.
 
@@ -32,7 +30,8 @@ class ComparisonModule(AggregationModule[ConfigScope], ABC):
 class FilterableModule(AggregationModule[ConfigScope], ExpirableMixin, ABC):
     """Filterable Module are affected by filters in mod options."""
 
-    allowed_mod_options = {"filters", "pipeline_index", "without_postprocessing"}
+    allowed_mod_options = {"filters", "without_postprocessing"}
+    required_mod_options = {"pipeline_index"}
 
     def get_dataset_split(self, name: DatasetSplitName = None) -> Dataset:
         """Get the specified dataset_split, filtered according to mod_options.

--- a/azimuth/modules/base_classes/indexable_module.py
+++ b/azimuth/modules/base_classes/indexable_module.py
@@ -16,7 +16,6 @@ from azimuth.types import (
     DatasetColumn,
     DatasetSplitName,
     InputResponse,
-    ModuleOptions,
     ModuleResponse,
     SupportedMethod,
 )
@@ -75,25 +74,8 @@ class DatasetResultModule(IndexableModule[ConfigScope], ABC):
 
 
 class ModelContractModule(DatasetResultModule[ModelContractConfig], abc.ABC):
-    allowed_mod_options: Set[str] = DatasetResultModule.allowed_mod_options | {
-        "threshold",
-        "pipeline_index",
-        "model_contract_method_name",
-    }
-
-    def __init__(
-        self,
-        dataset_split_name: DatasetSplitName,
-        config: ModelContractConfig,
-        mod_options: Optional[ModuleOptions] = None,
-    ):
-
-        super().__init__(dataset_split_name, config, mod_options=mod_options)
-
-        if self.model_contract_method_name is None:
-            raise ValueError(
-                "A model_contract_method_name needs to be provided for ModelContractModule"
-            )
+    allowed_mod_options: Set[str] = DatasetResultModule.allowed_mod_options | {"threshold"}
+    required_mod_options: Set[str] = {"pipeline_index", "model_contract_method_name"}
 
     def compute(self, batch: Dataset) -> List[ModuleResponse]:
         my_func = self.route_request(assert_not_none(self.model_contract_method_name))

--- a/azimuth/modules/base_classes/module.py
+++ b/azimuth/modules/base_classes/module.py
@@ -35,7 +35,7 @@ class Module(DaskModule[ConfigScope]):
         defined_mod_options = set(self.mod_options.no_alias_dict(exclude_defaults=True).keys())
         if diff := (defined_mod_options - self.allowed_mod_options - self.required_mod_options):
             raise ValueError(f"Unexpected mod_options {diff} for {self.__class__.__name__}.")
-        if self.required_mod_options and self.required_mod_options.isdisjoint(defined_mod_options):
+        if not self.required_mod_options.issubset(defined_mod_options):
             raise ValueError(f"{self.__class__.__name__} requires {self.required_mod_options}.")
 
         self.model_contract_method_name = mod_options.model_contract_method_name
@@ -54,7 +54,7 @@ class Module(DaskModule[ConfigScope]):
         return ModuleEffectiveArguments(
             mod_options=self.mod_options.dict(
                 exclude={"indices", "model_contract_method_name"},
-                include=self.allowed_mod_options.union(self.required_mod_options),
+                include=self.allowed_mod_options | self.required_mod_options,
             ),
             config_scope=self.config.dict(
                 exclude=exclude_fields_from_cache(self.config),

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -119,7 +119,8 @@ class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
 class ConfidenceBinIndexModule(DatasetResultModule[ModelContractConfig]):
     """Return confidence bin indices for the selected dataset split."""
 
-    allowed_mod_options = DatasetResultModule.allowed_mod_options | {"threshold", "pipeline_index"}
+    allowed_mod_options = DatasetResultModule.allowed_mod_options | {"threshold"}
+    required_mod_options = {"pipeline_index"}
 
     def compute_on_dataset_split(self) -> List[int]:  # type: ignore
         """Get the bin indices for each utterance in the dataset split.

--- a/azimuth/modules/model_performance/metrics.py
+++ b/azimuth/modules/model_performance/metrics.py
@@ -186,6 +186,8 @@ class MetricsPerFilterModule(AggregationModule[MetricsPerFilterConfig]):
     affected by data actions.
     """
 
+    required_mod_options = {"pipeline_index"}
+
     def get_metrics_for_filter(
         self, filters_dict: Dict[str, DatasetFilters]
     ) -> List[MetricsPerFilterValue]:
@@ -205,6 +207,7 @@ class MetricsPerFilterModule(AggregationModule[MetricsPerFilterConfig]):
             metrics = MetricsModule(
                 dataset_split_name=self.dataset_split_name,
                 config=self.config,
+                mod_options=self.mod_options,
             ).compute_metrics(ds_filtered)[0]
             accumulator.append(
                 MetricsPerFilterValue(

--- a/azimuth/modules/model_performance/outcome_count.py
+++ b/azimuth/modules/model_performance/outcome_count.py
@@ -181,7 +181,8 @@ class OutcomeCountPerFilterModule(FilterableModule[ModelContractConfig]):
 class OutcomeCountPerThresholdModule(AggregationModule[ModelContractConfig]):
     """Compute the outcome count per threshold."""
 
-    allowed_mod_options = {"nb_bins", "pipeline_index"}
+    allowed_mod_options = {"nb_bins"}
+    required_mod_options = {"pipeline_index"}
 
     def compute_on_dataset_split(self) -> List[OutcomeCountPerThresholdResponse]:  # type: ignore
         if not postprocessing_editable(self.config, self.mod_options.pipeline_index):

--- a/azimuth/modules/model_performance/outcomes.py
+++ b/azimuth/modules/model_performance/outcomes.py
@@ -21,10 +21,8 @@ from azimuth.utils.validation import assert_not_none
 class OutcomesModule(DatasetResultModule[ModelContractConfig]):
     """Computes the outcome for each utterance in the dataset split."""
 
-    allowed_mod_options = DatasetResultModule.allowed_mod_options | {
-        "threshold",
-        "pipeline_index",
-    }
+    allowed_mod_options = DatasetResultModule.allowed_mod_options | {"threshold"}
+    required_mod_options = {"pipeline_index"}
 
     def _get_predictions(self, without_postprocessing: bool) -> ndarray:
         mod_options = self.mod_options.copy(deep=True)

--- a/azimuth/modules/perturbation_testing/perturbation_testing.py
+++ b/azimuth/modules/perturbation_testing/perturbation_testing.py
@@ -57,7 +57,8 @@ class PerturbationTestingModule(DatasetResultModule[PerturbationTestingConfig]):
 
     """
 
-    allowed_mod_options = DatasetResultModule.allowed_mod_options | {"pipeline_index"}
+    allowed_mod_options = DatasetResultModule.allowed_mod_options
+    required_mod_options = {"pipeline_index"}
 
     def __init__(
         self,

--- a/azimuth/modules/perturbation_testing/perturbation_testing_summary.py
+++ b/azimuth/modules/perturbation_testing/perturbation_testing_summary.py
@@ -45,6 +45,8 @@ PERTURBATION_TEST_GROUPING = ["family", "name", "perturbation_type", "dataset_sp
 class PerturbationTestingSummaryModule(ComparisonModule[PerturbationTestingConfig]):
     """Summary of perturbation tests per dataset split."""
 
+    required_mod_options = {"pipeline_index"}
+
     def compute_on_dataset_split(  # type: ignore
         self,
     ) -> List[PerturbationTestingSummaryResponse]:

--- a/azimuth/modules/utilities/validation.py
+++ b/azimuth/modules/utilities/validation.py
@@ -35,6 +35,8 @@ class ExceptionGatherer:
 
 
 class ValidationModule(AggregationModule[ModelContractConfig]):
+    allowed_mod_options = {"pipeline_index"}
+
     def compute_on_dataset_split(self) -> List[ValidationResponse]:  # type: ignore
         cuda_available = torch.cuda.is_available()
         exception_gatherer = ExceptionGatherer()

--- a/azimuth/modules/word_analysis/tokens_to_words.py
+++ b/azimuth/modules/word_analysis/tokens_to_words.py
@@ -19,7 +19,8 @@ from azimuth.types.word_analysis import TokensToWordsResponse
 class TokensToWordsModule(IndexableModule[ModelContractConfig]):
     """Returns the words in an utterance with their saliency values."""
 
-    allowed_mod_options = IndexableModule.allowed_mod_options | {"pipeline_index"}
+    allowed_mod_options = IndexableModule.allowed_mod_options
+    required_mod_options = {"pipeline_index"}
 
     def get_tokens_saliencies(self, indices: List[int]) -> List[SaliencyResponse]:
         """

--- a/azimuth/routers/v1/custom_utterances.py
+++ b/azimuth/routers/v1/custom_utterances.py
@@ -42,6 +42,8 @@ def get_perturbed_utterances(
     perturb_testing = PerturbationTestingModule(
         dataset_split_name=DatasetSplitName.eval,
         config=config,
+        # Mandatory mod_option, but the module doesn't compute any new prediction in this case.
+        mod_options=ModuleOptions(pipeline_index=0),
     )
     mocked_test_result = []
     for perturbation_test in perturb_testing.perturbation_tests:

--- a/tests/test_modules/test_model_contracts/test_file_based_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_file_based_text_classification.py
@@ -30,7 +30,9 @@ def test_loading_dataset(file_text_config_top3):
     train_task = FileBasedTextClassificationModule(
         DatasetSplitName.train,
         file_text_config_top3,
-        mod_options=ModuleOptions(model_contract_method_name=SupportedMethod.Predictions),
+        mod_options=ModuleOptions(
+            model_contract_method_name=SupportedMethod.Predictions, pipeline_index=0
+        ),
     )
 
     # Make sure the training set is read as usual

--- a/tests/test_modules/test_model_contracts/test_hf_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_hf_text_classification.py
@@ -235,7 +235,9 @@ def test_load_CLINC150_dataset(clinc_text_config):
     task = HFTextClassificationModule(
         DatasetSplitName.train,
         clinc_text_config,
-        mod_options=ModuleOptions(model_contract_method_name=SupportedMethod.Predictions),
+        mod_options=ModuleOptions(
+            model_contract_method_name=SupportedMethod.Predictions, pipeline_index=0
+        ),
     )
 
     ds = task.get_dataset_split()

--- a/tests/test_modules/test_model_contracts/test_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_text_classification.py
@@ -25,7 +25,9 @@ def test_create_dataset(simple_text_config):
     task = HFTextClassificationModule(
         DatasetSplitName.eval,
         simple_text_config,
-        mod_options=ModuleOptions(model_contract_method_name=SupportedMethod.Predictions),
+        mod_options=ModuleOptions(
+            model_contract_method_name=SupportedMethod.Predictions, pipeline_index=0
+        ),
     )
 
     assert task is not None
@@ -324,7 +326,9 @@ def test_extract_output(simple_text_config):
         DatasetSplitName.eval,
         simple_text_config,
         mod_options=ModuleOptions(
-            model_contract_method_name=SupportedMethod.Predictions, indices=[4, 9, 3]
+            model_contract_method_name=SupportedMethod.Predictions,
+            indices=[4, 9, 3],
+            pipeline_index=0,
         ),
     )
     real_output = np.array([[0.1, 0.9]])

--- a/tests/test_modules/test_module.py
+++ b/tests/test_modules/test_module.py
@@ -184,5 +184,16 @@ def test_validation_priority(simple_text_config):
     assert ds["utterance"] == ["h", "i", "j"]
 
 
+def test_mod_options(tiny_text_config):
+    with pytest.raises(ValueError, match="Unexpected mod_options"):
+        IndexableModule(
+            DatasetSplitName.eval,
+            config=tiny_text_config,
+            mod_options=ModuleOptions(pipeline_index=0),
+        )
+    with pytest.raises(ValueError, match="HFTextClassificationModule requires"):
+        HFTextClassificationModule(DatasetSplitName.eval, config=tiny_text_config)
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_modules/test_word_analysis/test_tokens_to_words.py
+++ b/tests/test_modules/test_word_analysis/test_tokens_to_words.py
@@ -44,7 +44,7 @@ def test_get_words(monkeypatch, simple_text_config, apply_mocked_startup_task):
     mod = TokensToWordsModule(
         dataset_split_name=DatasetSplitName.eval,
         config=simple_text_config,
-        mod_options=ModuleOptions(indices=[0]),
+        mod_options=ModuleOptions(pipeline_index=0, indices=[0]),
     )
     monkeypatch.setattr(mod, "get_tokens_saliencies", fake_saliency_record)
     assert mod is not None

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -109,6 +109,7 @@ def test_expired_task(tiny_text_task_manager, tiny_text_config):
     _, expirable_task = tiny_text_task_manager.get_task(
         "ExpirableModule",
         dataset_split_name=DatasetSplitName.eval,
+        mod_options=ModuleOptions(pipeline_index=0),
         last_update=current_update,
     )
     assert not not_expirable_task.done() and not expirable_task.done()
@@ -124,6 +125,7 @@ def test_expired_task(tiny_text_task_manager, tiny_text_config):
     _, expirable_task = tiny_text_task_manager.get_task(
         "ExpirableModule",
         dataset_split_name=DatasetSplitName.eval,
+        mod_options=ModuleOptions(pipeline_index=0),
         last_update=current_update,
     )
     assert not_expirable_task.done() and expirable_task.done()
@@ -139,6 +141,7 @@ def test_expired_task(tiny_text_task_manager, tiny_text_config):
     _, expirable_task = tiny_text_task_manager.get_task(
         "ExpirableModule",
         dataset_split_name=DatasetSplitName.eval,
+        mod_options=ModuleOptions(pipeline_index=0),
         last_update=current_update,
     )
     assert not_expirable_task.done() and not expirable_task.done()


### PR DESCRIPTION
Resolve #114 

## Description:
- When calling a module without mandatory mod_options, it would sometimes fail silently, or the error message would be hard to understand. This proposal makes it clear when specific mod_options are required.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
