### PR TITLE
Compute syntax smart tags for utterances with multiple sentences.

### DIFF
--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -182,8 +182,8 @@ class DatasetWarningsOptions(AzimuthBaseSettings):
 
 
 class SyntaxOptions(AzimuthBaseSettings):
-    short_sentence_max_word: int = 3
-    long_sentence_min_word: int = 12
+    short_utterance_max_word: int = 3
+    long_utterance_min_word: int = 12
     spacy_model: SupportedSpacyModels = SupportedSpacyModels.use_default  # Language-based default
     subj_tags: List[str] = []  # Language-based dynamic default value
     obj_tags: List[str] = []  # Language-based dynamic default value
@@ -382,7 +382,7 @@ class DatasetWarningConfig(CommonFieldsConfig):
 
 
 class SyntaxConfig(CommonFieldsConfig):
-    # Syntax configuration to change thresholds that determine short and long sentences.
+    # Syntax configuration to change thresholds that determine short and long utterances.
     syntax: SyntaxOptions = SyntaxOptions()
 
 

--- a/azimuth/types/tag.py
+++ b/azimuth/types/tag.py
@@ -36,8 +36,8 @@ class DataAction(Tag, Enum):
 class SmartTag(Tag, Enum):
     # Syntax
     multi_sent = "multiple_sentences"
-    long = "long_sentence"
-    short = "short_sentence"
+    long = "long_utterance"
+    short = "short_utterance"
     no_subj = "missing_subj"
     no_obj = "missing_obj"
     no_verb = "missing_verb"

--- a/docs/docs/key-concepts/index.md
+++ b/docs/docs/key-concepts/index.md
@@ -24,7 +24,7 @@ types of analyses that Azimuth provides.
 
     Examples of **individual** smart tags:
 
-    * `long_sentences` identifies utterances with more than X words.
+    * `long_utterance` identifies utterances with more than X words.
     * `failed_punctuation` identifies utterances that failed at least one punctuation test.
 
 The full list of smart tags is available in [:material-link: Smart Tags](smart-tags.md).

--- a/docs/docs/key-concepts/smart-tags.md
+++ b/docs/docs/key-concepts/smart-tags.md
@@ -15,19 +15,18 @@ The current list of supported smart tag, and their families, is detailed below.
 [:material-link: Syntax Analysis](syntax-analysis.md) gives more details on how the syntactic
 information is computed.
 
-* `multiple_sentences`: The number of sentences is above 1. All other syntactic smart tags will be
-  disabled when this is the case.
-* `long_sentence`: The number of words is greater than or equal to the defined threshold (default is 12).
-* `short_sentence`: The number of words is less than or equal to the defined threshold (default is 3).
+* `multiple_sentences`: The number of sentences is above 1.
+* `long_utterance`: The number of words is greater than or equal to the defined threshold (default is 12).
+* `short_utterance`: The number of words is less than or equal to the defined threshold (default is 3).
 
 ## Partial Syntax <svg width="1.4em" viewBox="0 0 24 24" style="vertical-align: bottom;"><path d="M12,22 A10,10 0,0,0 12,2 V4 A8,8 0,0,1 12,20 Z M6.593591825444028,20.412535328311815 A10,10 0,0,0 9.182674431585703,21.594929736144973 L9.746139545268562,19.67594378891598 A8,8 0,0,1 7.674873460355222,18.73002826264945 Z M2.9036800464548183,16.154150130018866 A10,10 0,0,0 4.442504256457418,18.54860733945285 L5.954003405165935,17.23888587156228 A8,8 0,0,1 4.722944037163854,15.323320104015094 Z M2.101785581190672,10.57685161726715 A10,10 0,0,0 2.101785581190674,13.423148382732851 L4.0814284649525385,13.138518706186282 A8,8 0,0,1 4.081428464952538,10.861481293813721 Z M4.442504256457417,5.45139266054715 A10,10 0,0,0 2.9036800464548165,7.845849869981135 L4.722944037163853,8.676679895984908 A8,8 0,0,1 5.954003405165933,6.76111412843772 Z M9.182674431585703,2.405070263855027 A10,10 0,0,0 6.593591825444026,3.5874646716881866 L7.6748734603552204,5.2699717373505495 A8,8 0,0,1 9.746139545268562,4.324056211084021 Z M8,7 H16 V9 H13 V17 H11 V9 H8 V7 Z" fill="currentColor"/></svg>
 
 [:material-link: Syntax Analysis](syntax-analysis.md) gives more details on how the syntactic
 information is computed.
 
-* `missing_subj`: The sentence is missing a subject.
-* `missing_verb`: The sentence is missing a verb.
-* `missing_obj`: The sentence is missing an object.
+* `missing_subj`: The utterance is missing a subject.
+* `missing_verb`: The utterance is missing a verb.
+* `missing_obj`: The utterance is missing an object.
 
 ## Dissimilar <svg width="1.4em" viewBox="0 0 24 24" style="vertical-align: bottom;"><path d="M12,2 A10,10 0,0,0 12,22 A10,10 0,0,0 12,2 Z M12,4 A8,8 0,0,1 12,20 Z" fill="currentColor"/></svg>
 

--- a/docs/docs/key-concepts/syntax-analysis.md
+++ b/docs/docs/key-concepts/syntax-analysis.md
@@ -41,11 +41,10 @@ doc = spacy_model(utterance)
 tokens = [token.text for token in doc if not token.is_punct]
 word_count = len(tokens)
 ```
-Based on the word count, the `long_sentence` and `short_sentence` smart tags are computed.
+Based on the word count, the `long_utterance` and `short_utterance` smart tags are computed.
 
 ### Sentence Count
- The smart
-tag `multiple_sentences` is based on a spaCy sentencizer:
+The smart tag `multiple_sentences` is based on a spaCy sentencizer:
 
 ```python
 from spacy.lang.en import English
@@ -58,7 +57,7 @@ spacy_sentencizer_en.add_pipe("sentencizer")
 ## Configuration
 
 [:material-link: Syntax Analysis Config](../reference/configuration/analyses/syntax.md)
-explains how to edit the thresholds to determine what is considered a short or long sentence,
+explains how to edit the thresholds to determine what is considered a short or long utterance,
 the tags used to detect subjects and objects, and the spaCy model used to parse utterances.
 
 

--- a/docs/docs/reference/configuration/analyses/syntax.md
+++ b/docs/docs/reference/configuration/analyses/syntax.md
@@ -3,7 +3,7 @@
 🔵 **Default value:** `SyntaxOptions()`
 
 In the Syntax config, users can modify thresholds to determine what is considered a short
-or a long sentence, as well as select the spaCy model and the dependency tags used for certain
+or a long utterance, as well as select the spaCy model and the dependency tags used for certain
 syntax-related smart tags. More details are explained in
 [:material-link: Syntax Analysis](../../../key-concepts/syntax-analysis.md).
 
@@ -17,15 +17,15 @@ dependency tag lists will generally not need to be modified.
     from pydantic import BaseModel
 
     class SyntaxOptions(BaseModel):
-        short_sentence_max_word int = 3 # (1)
-        long_sentence_min_word: int = 12 # (2)
+        short_utterance_max_word int = 3 # (1)
+        long_utterance_min_word: int = 12 # (2)
         spacy_model: SupportedSpacyModels = SupportedSpacyModels.use_default  # Language-based default (3)
         subj_tags: List[str] = []  # Language-based default value (4)
         obj_tags: List[str] = []  # Language-based default value (5)
     ```
 
-    1. Maximum number of words for a sentence to be tagged as short (e.g <=3 for the default)
-    2. Minimum number of words for a sentence to be tagged as long (e.g >=12 for the default)
+    1. Maximum number of words for an utterance to be tagged as short (e.g <=3 for the default)
+    2. Minimum number of words for an utterance to be tagged as long (e.g >=12 for the default)
     3. spaCy model to use for syntax tagging.
     4. spaCy dependency tags used to determine whether a word is a subject (noun).
     5. spaCy dependency tags used to determine whether a word is an object (noun).
@@ -35,7 +35,7 @@ dependency tag lists will generally not need to be modified.
     ```json
     {
       "syntax": {
-        "short_sentence_max_word": 5
+        "short_utterance_max_word": 5
       }
     }
     ```

--- a/docs/docs/user-guide/exploration-space/utterance-details.md
+++ b/docs/docs/user-guide/exploration-space/utterance-details.md
@@ -20,7 +20,7 @@ The top section shows the utterance details:
           be added as a 4th element at the top.
     * By clicking on the blue chevrons, the prediction results after each post-processing step can be viewed, including the model's output before any post-processing.
 * **Smart tags** (where applicable): An automatically computed tag highlighting a certain
-  characteristic of the utterance (e.g., long sentences, utterance is missing a verb, utterance
+  characteristic of the utterance (e.g., long utterances, utterance is missing a verb, utterance
   contains multiple sentences). For more information,
   see [Smart Tags](../../key-concepts/smart-tags.md).
 * **Proposed Action** (editable): You can add a proposed action to identify further steps required

--- a/tests/test_modules/test_dataset_analysis/test_syntax_tagging.py
+++ b/tests/test_modules/test_dataset_analysis/test_syntax_tagging.py
@@ -1,16 +1,19 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
+from itertools import zip_longest
+
 from azimuth.modules.dataset_analysis.syntax_tagging import SyntaxTaggingModule
 from azimuth.types import DatasetColumn, DatasetSplitName
 from azimuth.types.tag import SmartTag
 
 
 def verify_syntax_results(json_output, smart_tags_per_idx, token_count_per_idx):
-    for idx, res in enumerate(json_output):
-        assert all(v for k, v in res.tags.items() if k in smart_tags_per_idx[idx])
-        assert not any(v for k, v in res.tags.items() if k not in smart_tags_per_idx[idx])
-        assert res.adds[DatasetColumn.word_count] == token_count_per_idx[idx]
+    for res, smart_tags, token_count in zip_longest(
+        json_output, smart_tags_per_idx, token_count_per_idx
+    ):
+        assert list(res.tags.values()) == [k in smart_tags for k in res.tags.keys()]
+        assert res.adds[DatasetColumn.word_count] == token_count
 
 
 def test_syntax_tagging(tiny_text_config):

--- a/tests/test_routers/admin/test_admin.py
+++ b/tests/test_routers/admin/test_admin.py
@@ -28,8 +28,8 @@ def test_get_default_config(app: FastAPI):
         "read_only_config": False,
         "language": "en",
         "syntax": {
-            "short_sentence_max_word": 3,
-            "long_sentence_min_word": 12,
+            "short_utterance_max_word": 3,
+            "long_utterance_min_word": 12,
             "spacy_model": "en_core_web_sm",
             "subj_tags": ["nsubj", "nsubjpass"],
             "obj_tags": ["dobj", "pobj", "obj"],
@@ -213,8 +213,8 @@ def test_get_config(app: FastAPI):
             "no_close_threshold": 0.5,
         },
         "syntax": {
-            "long_sentence_min_word": 12,
-            "short_sentence_max_word": 3,
+            "long_utterance_min_word": 12,
+            "short_utterance_max_word": 3,
             "spacy_model": "en_core_web_sm",
             "subj_tags": ["nsubj", "nsubjpass"],
             "obj_tags": ["dobj", "pobj", "obj"],

--- a/tests/test_utils/test_dataset_filtering.py
+++ b/tests/test_utils/test_dataset_filtering.py
@@ -167,24 +167,24 @@ def test_dataset_filtering_confidence(simple_text_config):
 def test_dataset_filtering_smart_tags_uses_or_within_family(simple_text_config):
     dm = generate_mocked_dm(simple_text_config)
     ds = dm.get_dataset_split(get_table_key(simple_text_config))
-    ds_filtered_long_sentence = filter_dataset_split(
+    ds_filtered_long_utterance = filter_dataset_split(
         ds,
-        DatasetFilters(smart_tags={SmartTagFamily.extreme_length: ["long_sentence"]}),
+        DatasetFilters(smart_tags={SmartTagFamily.extreme_length: ["long_utterance"]}),
         config=dm.config,
     )
-    ds_filtered_short_sentence = filter_dataset_split(
+    ds_filtered_short_utterance = filter_dataset_split(
         ds,
-        DatasetFilters(smart_tags={SmartTagFamily.extreme_length: ["short_sentence"]}),
+        DatasetFilters(smart_tags={SmartTagFamily.extreme_length: ["short_utterance"]}),
         config=dm.config,
     )
     ds_filtered = filter_dataset_split(
         ds,
         DatasetFilters(
-            smart_tags={SmartTagFamily.extreme_length: ["long_sentence", "short_sentence"]}
+            smart_tags={SmartTagFamily.extreme_length: ["long_utterance", "short_utterance"]}
         ),
         config=dm.config,
     )
-    assert len(ds_filtered) == len(ds_filtered_long_sentence) + len(ds_filtered_short_sentence)
+    assert len(ds_filtered) == len(ds_filtered_long_utterance) + len(ds_filtered_short_utterance)
 
 
 def test_dataset_filtering_without_postprocessing(simple_text_config):

--- a/webapp/src/mocks/api/mockMetricsAPI.ts
+++ b/webapp/src/mocks/api/mockMetricsAPI.ts
@@ -1,5 +1,5 @@
 import { rest } from "msw";
-import { MetricsPerFilterAPIResponse, MetricInfo } from "types/api";
+import { MetricInfo, MetricsPerFilterAPIResponse } from "types/api";
 
 const baseUrl = "http://localhost/api/local";
 
@@ -232,7 +232,7 @@ export const getMetricsPerFilterAPIResponse = rest.get(
           },
           {
             utteranceCount: 3,
-            filterValue: "short_sentence",
+            filterValue: "short_utterance",
             outcomeCount: {
               CorrectAndPredicted: 3,
               CorrectAndRejected: 0,

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -53,8 +53,8 @@ const FIELDS: Record<
   max_delta_representation: PERCENTAGE,
   max_delta_mean_words: { ...FLOAT, units: "words" },
   max_delta_std_words: { ...FLOAT, units: "words" },
-  short_sentence_max_word: { ...INT, units: "words" },
-  long_sentence_min_word: { ...INT, units: "words" },
+  short_utterance_max_word: { ...INT, units: "words" },
+  long_utterance_min_word: { ...INT, units: "words" },
   temperature: FLOAT,
   threshold: PERCENTAGE,
 };

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -724,8 +724,8 @@ export interface components {
     /** An enumeration. */
     SmartTag:
       | "multiple_sentences"
-      | "long_sentence"
-      | "short_sentence"
+      | "long_utterance"
+      | "short_utterance"
       | "missing_subj"
       | "missing_obj"
       | "missing_verb"
@@ -765,8 +765,8 @@ export interface components {
      * Heroku and any 12 factor app design.
      */
     SyntaxOptions: {
-      short_sentence_max_word: number;
-      long_sentence_min_word: number;
+      short_utterance_max_word: number;
+      long_utterance_min_word: number;
       spacy_model: components["schemas"]["SupportedSpacyModels"];
       subj_tags: string[];
       obj_tags: string[];


### PR DESCRIPTION
Resolve #434 

## Description:
*  This will make it easier for datasets with long utterances (with multiple sentences) to have meaningful syntax smart tags.
* This will enable us to display the long/short utterances on the token count plot.
* I took this opportunity to refactor the syntax tagging tests, so they test all results (they also weren't working because of using `all` instead of `any`.)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
