### PR TITLE
Add truncation=True to HFPipelines

### DIFF
--- a/azimuth/modules/model_contracts/hf_text_classification.py
+++ b/azimuth/modules/model_contracts/hf_text_classification.py
@@ -74,7 +74,12 @@ class HFTextClassificationModule(TextClassificationModule):
                 predictions = np.stack(
                     [
                         self.extract_probs_from_output(
-                            model(utterances, num_workers=0, batch_size=self.config.batch_size)
+                            model(
+                                utterances,
+                                num_workers=0,
+                                batch_size=self.config.batch_size,
+                                truncation=True,
+                            )
                         )
                         for _ in range(self.config.uncertainty.iterations)
                     ],
@@ -85,7 +90,9 @@ class HFTextClassificationModule(TextClassificationModule):
 
         else:
             epistemic = [0.0] * len(utterances)
-            pipeline_out = model(utterances, num_workers=0, batch_size=self.config.batch_size)
+            pipeline_out = model(
+                utterances, num_workers=0, batch_size=self.config.batch_size, truncation=True
+            )
         (
             model_output,
             postprocessed_output,
@@ -121,7 +128,10 @@ class HFTextClassificationModule(TextClassificationModule):
         pipeline = self.get_model()
 
         inputs = pipeline.tokenizer(
-            batch[self.config.columns.text_input], return_tensors="pt", padding=True
+            batch[self.config.columns.text_input],
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
         )
         all_tokens = [pipeline.tokenizer.convert_ids_to_tokens(i) for i in inputs["input_ids"]]
 

--- a/tests/fixtures/distilbert-tokenizer-files/config.json
+++ b/tests/fixtures/distilbert-tokenizer-files/config.json
@@ -1,4 +1,5 @@
 {
   "model_max_length": 512,
+  "max_position_embeddings": 512,
   "do_lower_case": true
 }

--- a/tests/fixtures/distilbert-tokenizer-files/config.json
+++ b/tests/fixtures/distilbert-tokenizer-files/config.json
@@ -1,5 +1,3 @@
 {
-  "model_max_length": 512,
-  "max_position_embeddings": 512,
   "do_lower_case": true
 }

--- a/tests/fixtures/distilbert-tokenizer-files/tokenizer_config.json
+++ b/tests/fixtures/distilbert-tokenizer-files/tokenizer_config.json
@@ -1,0 +1,3 @@
+{
+  "model_max_length": 512
+}

--- a/tests/test_loading_resources.py
+++ b/tests/test_loading_resources.py
@@ -24,7 +24,7 @@ from azimuth.config import AzimuthConfig
 from azimuth.utils.ml.seeding import RandomContext
 from azimuth_shr.loading_resources import align_labels
 
-_CURRENT_DIR = "/tmp"
+_CURRENT_DIR = "/tmp/az_mddel"
 _MAX_DATASET_LEN = 42
 
 
@@ -49,7 +49,7 @@ def load_hf_text_classif_pipeline(checkpoint_path: str, azimuth_config: AzimuthC
     # As of Jan 6, 2021, pipelines didn't support fast tokenizers
     # See https://github.com/huggingface/transformers/issues/7735
     tokenizer = DistilBertTokenizer.from_pretrained(
-        checkpoint_path, use_fast=False, cache_dir=_CURRENT_DIR
+        checkpoint_path, use_fast=False, model_max_length=model.config.max_position_embeddings
     )
     device = 0 if use_cuda else -1
 

--- a/tests/test_loading_resources.py
+++ b/tests/test_loading_resources.py
@@ -138,7 +138,9 @@ def config_structured_output(num_classes, threshold=0.8):
             self.threshold = threshold
             self.no_prediction_idx = no_prediction_idx
 
-        def __call__(self, utterances: List[str], num_workers=0, batch_size=32) -> MyOutputFormat:
+        def __call__(
+            self, utterances: List[str], num_workers=0, batch_size=32, truncation=True
+        ) -> MyOutputFormat:
             # Random logits based on the first letter
             initial_logits = np.stack(
                 [np.random.RandomState(ord(s[0])).randn(self.num_classes) * 2 for s in utterances]

--- a/tests/test_modules/test_model_contracts/test_hf_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_hf_text_classification.py
@@ -264,9 +264,12 @@ def test_long_utterances_truncated(simple_text_config):
             pipeline_index=0, model_contract_method_name=SupportedMethod.Predictions
         ),
     )
-
-    max_input_size = max(mod.get_model().tokenizer.max_model_input_sizes.values())
-    batch = Dataset.from_dict({"utterance": ["potato " * max_input_size], "label": [0]})
+    batch = Dataset.from_dict(
+        {
+            simple_text_config.columns.text_input: ["Hello " * 1000],
+            simple_text_config.columns.label: [0],
+        }
+    )
     _ = mod.compute(batch)
 
     mod = HFTextClassificationModule(
@@ -276,4 +279,7 @@ def test_long_utterances_truncated(simple_text_config):
             pipeline_index=0, model_contract_method_name=SupportedMethod.Saliency
         ),
     )
-    mod.compute(batch)
+    res = mod.compute(batch)[0]
+    assert (
+        len(res.saliency) == len(res.tokens) == mod.get_model().model.config.max_position_embeddings
+    )

--- a/tests/test_modules/test_model_contracts/test_hf_text_classification.py
+++ b/tests/test_modules/test_model_contracts/test_hf_text_classification.py
@@ -254,3 +254,26 @@ def test_load_CLINC150_dataset(clinc_text_config):
     assert "NO_INTENT" in labels_str and "oos" not in labels_str
     # only 3 classes in the subset: "transfer", "transactions" and "NO_INTENT"
     assert len(ds) == 5
+
+
+def test_long_utterances_truncated(simple_text_config):
+    mod = HFTextClassificationModule(
+        DatasetSplitName.eval,
+        simple_text_config,
+        mod_options=ModuleOptions(
+            pipeline_index=0, model_contract_method_name=SupportedMethod.Predictions
+        ),
+    )
+
+    max_input_size = max(mod.get_model().tokenizer.max_model_input_sizes.values())
+    batch = Dataset.from_dict({"utterance": ["potato " * max_input_size], "label": [0]})
+    _ = mod.compute(batch)
+
+    mod = HFTextClassificationModule(
+        DatasetSplitName.eval,
+        simple_text_config,
+        mod_options=ModuleOptions(
+            pipeline_index=0, model_contract_method_name=SupportedMethod.Saliency
+        ),
+    )
+    mod.compute(batch)


### PR DESCRIPTION
Resolve #439 

## Description:

For long utterances, we need to add truncation=True.

For saliency, we will only show the processed tokens, the utterance will be cut.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
