### PR TITLE
Fix `patch_utterances` being a `POST`

### DIFF
--- a/azimuth/routers/v1/utterances.py
+++ b/azimuth/routers/v1/utterances.py
@@ -265,7 +265,7 @@ def get_utterances(
     )
 
 
-@router.post(
+@router.patch(
     "",
     summary="Patch utterances",
     description="Patch utterances, such as updating proposed actions.",

--- a/tests/test_routers/test_export.py
+++ b/tests/test_routers/test_export.py
@@ -45,7 +45,7 @@ def test_get_proposed_actions(app: FastAPI) -> None:
         {"persistent_id": 0, "data_action": "remove"},
         {"persistent_id": 1, "data_action": "relabel"},
     ]
-    resp = client.post("/dataset_splits/eval/utterances", json=request)
+    resp = client.patch("/dataset_splits/eval/utterances", json=request)
     assert resp.status_code == HTTP_200_OK, resp.text
 
     resp = client.get("/export/dataset_splits/eval/proposed_actions")

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -150,16 +150,16 @@ def test_perturbed_utterances(app: FastAPI, monkeypatch):
     assert len(resp) == 11
 
 
-def test_post_utterances(app: FastAPI) -> None:
+def test_patch_utterances(app: FastAPI) -> None:
     client = TestClient(app)
 
     request = [{"persistentId": 0, "dataAction": "remove"}]
-    resp = client.post("/dataset_splits/eval/utterances", json=request)
+    resp = client.patch("/dataset_splits/eval/utterances", json=request)
     assert resp.status_code == HTTP_200_OK, resp.text
     assert resp.json() == request
 
     # Reset tag to NO_ACTION
     request = [{"persistentId": 0, "dataAction": "NO_ACTION"}]
-    resp = client.post("/dataset_splits/eval/utterances", json=request)
+    resp = client.patch("/dataset_splits/eval/utterances", json=request)
     assert resp.status_code == HTTP_200_OK, resp.text
     assert resp.json() == request

--- a/webapp/src/services/api.ts
+++ b/webapp/src/services/api.ts
@@ -202,7 +202,7 @@ export const api = createApi({
         responseToData(
           fetchApi({
             path: "/dataset_splits/{dataset_split_name}/utterances",
-            method: "post",
+            method: "patch",
           }),
           "Something went wrong updating proposed actions"
         )({

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -70,7 +70,7 @@ export interface paths {
     /** Get a table view of the utterances according to filters. */
     get: operations["get_utterances_dataset_splits__dataset_split_name__utterances_get"];
     /** Patch utterances, such as updating proposed actions. */
-    post: operations["patch_utterances_dataset_splits__dataset_split_name__utterances_post"];
+    patch: operations["patch_utterances_dataset_splits__dataset_split_name__utterances_patch"];
   };
   "/dataset_splits/{dataset_split_name}/utterances/{index}/perturbed_utterances": {
     /** Get a perturbed utterances for a single utterance. */
@@ -1316,7 +1316,7 @@ export interface operations {
     };
   };
   /** Patch utterances, such as updating proposed actions. */
-  patch_utterances_dataset_splits__dataset_split_name__utterances_post: {
+  patch_utterances_dataset_splits__dataset_split_name__utterances_patch: {
     parameters: {
       path: {
         dataset_split_name: components["schemas"]["DatasetSplitName"];


### PR DESCRIPTION
## Description:

- `POST` is usually reserved for creating a new item, the new item being the body.
- `PATCH` is perfect for editing the existing utterances, in this case changing the proposed action.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
