### PR TITLE
Support ignoring missing persistent-ids in patch utterances route

### DIFF
--- a/azimuth/dataset_split_manager.py
+++ b/azimuth/dataset_split_manager.py
@@ -262,11 +262,32 @@ class DatasetSplitManager:
         )
         return dataset_split
 
-    def get_row_indices_from_persistent_id(self, persistent_ids: List[Union[int, str]]):
-        ds = self.get_dataset_split()
-        all_persistent_ids = ds[self.config.columns.persistent_id]
-        indices = [all_persistent_ids.index(persistent_id) for persistent_id in persistent_ids]
-        return indices
+    def get_row_indices_from_persistent_id(
+        self, persistent_ids: List[Union[int, str]], ignore_not_found: bool = False
+    ) -> List[Optional[int]]:
+        """Get the list of row_idx from a list of persistent_id.
+
+        Args:
+            persistent_ids: List to process
+            ignore_not_found: Ignore if the persistent_id is not present in the dataset split.
+
+        Returns:
+            List of row_idx. May contain None if persistent_id not found.
+
+        Raises:
+            If ignore_not_found is set to False and the persistent_id is not in the dataset.
+        """
+        all_persistent_ids = self.get_dataset_split()[self.config.columns.persistent_id]
+        all_indices: List[Optional[int]] = []
+        for persistent_id in persistent_ids:
+            try:
+                all_indices.append(all_persistent_ids.index(persistent_id))
+            except ValueError:
+                if ignore_not_found:
+                    all_indices.append(None)
+                else:
+                    raise
+        return all_indices
 
     def add_tags(
         self,

--- a/azimuth/routers/v1/utterances.py
+++ b/azimuth/routers/v1/utterances.py
@@ -276,15 +276,22 @@ def patch_utterances(
     utterances: List[UtterancePatch] = Body(...),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     task_manager: TaskManager = Depends(get_task_manager),
+    ignore_not_found: bool = False,
 ) -> List[UtterancePatch]:
     persistent_ids = [utterance.persistent_id for utterance in utterances]
     try:
-        row_indices = dataset_split_manager.get_row_indices_from_persistent_id(persistent_ids)
+        row_indices = dataset_split_manager.get_row_indices_from_persistent_id(
+            persistent_ids, ignore_not_found
+        )
     except ValueError as e:
         raise HTTPException(HTTP_404_NOT_FOUND, detail=f"Persistent id not found: {e}.")
 
+    row_indices_found = [idx for idx in row_indices if idx is not None]
+    utterances_found = [
+        utterance for idx, utterance in zip(row_indices, utterances) if idx is not None
+    ]
     data_actions = {}
-    for row_idx, utterance in zip(row_indices, utterances):
+    for row_idx, utterance in zip(row_indices_found, utterances_found):
         data_actions[row_idx] = {data_action: False for data_action in ALL_DATA_ACTIONS}
         if utterance.data_action != DataAction.no_action:
             data_actions[row_idx][utterance.data_action] = True
@@ -292,8 +299,9 @@ def patch_utterances(
     dataset_split_manager.add_tags(data_actions)
 
     task_manager.clear_worker_cache()
-    updated_tags = dataset_split_manager.get_tags(row_indices)
+    updated_tags = dataset_split_manager.get_tags(row_indices_found)
 
+    persistent_ids_found = [utterance.persistent_id for utterance in utterances_found]
     return [
         UtterancePatch(
             persistent_id=persistent_id,
@@ -302,7 +310,7 @@ def patch_utterances(
                 DataAction.no_action,
             ),
         )
-        for persistent_id, tags in zip(persistent_ids, updated_tags.values())
+        for persistent_id, tags in zip(persistent_ids_found, updated_tags.values())
     ]
 
 

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -431,6 +431,12 @@ def test_convert_persistent_id_to_row_idx(a_text_dataset, simple_text_config):
     row_indices = dm.get_row_indices_from_persistent_id(persistent_ids)
     assert row_indices == random_rows
 
+    with pytest.raises(ValueError):
+        _ = dm.get_row_indices_from_persistent_id(["I love potatoes"])
+    assert [None] == dm.get_row_indices_from_persistent_id(
+        ["I love potatoes"], ignore_not_found=True
+    )
+
 
 def test_export_proposed_actions(simple_text_config, a_text_dataset):
     dm = DatasetSplitManager(

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -1330,6 +1330,9 @@ export interface operations {
       path: {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
+      query: {
+        ignore_not_found?: boolean;
+      };
     };
     responses: {
       /** Successful Response */


### PR DESCRIPTION
Part of #297 

## Description:
- I put `False` as a default. I think the method should have False as a default, but we could put the default at `True` for the route. 

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
