### PR TITLE
Link from confusion matrix to utterance table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Released changes are shown in the
 - New fields in config page.
 - The initial config file and all subsequent changes are saved in the caching folder.
 - Outcome option to dropdown in Smart Tag Analysis.
-- Link from confusion matrix cells to utterance table.
+- Link from confusion matrix cells and row/column labels to utterance table.
 
 ### Changed
 - Change the outcome per threshold bar chart to area chart, making the x axis continuous, and add vertical dashed line marking current threshold.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Released changes are shown in the
 - Persistent id.
 - New fields in config page.
 - The initial config file and all subsequent changes are saved in the caching folder.
-- Outcome option to dropdown in Smart Tag Analysis
+- Outcome option to dropdown in Smart Tag Analysis.
+- Link from confusion matrix cells to utterance table.
 
 ### Changed
 - Change the outcome per threshold bar chart to area chart, making the x axis continuous, and add vertical dashed line marking current threshold.

--- a/webapp/src/components/ConfusionMatrix.tsx
+++ b/webapp/src/components/ConfusionMatrix.tsx
@@ -65,7 +65,6 @@ const useStyles = makeStyles((theme) => ({
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
-    cursor: "default",
     width: "100%",
     height: "100%",
     backgroundColor: theme.palette.background.paper,
@@ -294,6 +293,14 @@ const ConfusionMatrix: React.FC<Props> = ({
 
           {data.classNames.flatMap((className, i) => [
             <Typography
+              component={Link}
+              to={`utterances${constructSearchString({
+                ...confusionMatrix,
+                ...filters,
+                ...pipeline,
+                ...postprocessing,
+                prediction: [data.classNames[i]],
+              })}`}
               key={`column-${i}`}
               className={classNames(
                 `column-${i}`,
@@ -313,11 +320,21 @@ const ConfusionMatrix: React.FC<Props> = ({
                   height: "auto",
                   overflow: "initial",
                 },
+                color: "unset",
+                textDecoration: "unset",
               }}
             >
               {className}
             </Typography>,
             <Typography
+              component={Link}
+              to={`utterances${constructSearchString({
+                ...confusionMatrix,
+                ...filters,
+                ...pipeline,
+                ...postprocessing,
+                label: [data.classNames[i]],
+              })}`}
               key={`row-${i}`}
               className={classNames(
                 `row-${i}`,
@@ -336,6 +353,8 @@ const ConfusionMatrix: React.FC<Props> = ({
                   width: "auto",
                   overflow: "initial",
                 },
+                color: "unset",
+                textDecoration: "unset",
               }}
             >
               {className}

--- a/webapp/src/components/ConfusionMatrix.tsx
+++ b/webapp/src/components/ConfusionMatrix.tsx
@@ -11,7 +11,7 @@ import {
 import makeStyles from "@mui/styles/makeStyles";
 import noData from "assets/void.svg";
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { Link, useHistory, useLocation } from "react-router-dom";
 import { getConfusionMatrixEndpoint } from "services/api";
 import { DatasetSplitName } from "types/api";
 import {
@@ -147,6 +147,15 @@ const ConfusionMatrix: React.FC<Props> = ({
 
   const renderCell = (value: number, rowIndex: number, columnIndex: number) => (
     <Box
+      component={Link}
+      to={`utterances${constructSearchString({
+        ...confusionMatrix,
+        ...filters,
+        ...pipeline,
+        ...postprocessing,
+        prediction: [data.classNames[columnIndex]],
+        label: [data.classNames[rowIndex]],
+      })}`}
       key={`column-${columnIndex} row-${rowIndex}`}
       className={`column-${columnIndex} row-${rowIndex}`}
       gridColumn={columnIndex + CONFUSION_COLUMN_OFFSET + 1}
@@ -169,6 +178,8 @@ const ConfusionMatrix: React.FC<Props> = ({
           ].main,
           value / maxCount
         ),
+        color: "unset",
+        textDecoration: "unset",
       })}
     >
       {value > 0 && (


### PR DESCRIPTION
Resolve #469

## Description:

* [Link from confusion matrix cells to utterance table](https://github.com/ServiceNow/azimuth/pull/470/commits/623a9dfe180f460a90a54fdc56ad790612cde942)
* [Link from confusion matrix row/column labels to utterance table](https://github.com/ServiceNow/azimuth/pull/470/commits/8389265f4ef5e8df0fce300de4768db849b603f7)

That was very easy. To be honest, GitHub Copilot (Codex) almost got it on its own. 😅 Here (suggestion in gray), it figured out that the `label` and `prediction` filters should be the class names, and which of the `rowIndex` and the `columnIndex` represents the `label` and the `prediction`:
<img width="627" alt="Screen Shot 2023-02-27 at 7 57 52 PM" src="https://user-images.githubusercontent.com/8386369/221728745-dee63c9c-784b-485f-922f-b11fa0071252.png">
It was only missing wrapping the `prediction` in an array (expecting `string[]` and not `string`). After I added it and I hit enter, GitHub Colipot suggested the `label` correctly, with the added array:
<img width="627" alt="Screen Shot 2023-02-27 at 8 31 48 PM" src="https://user-images.githubusercontent.com/8386369/221729525-0b8791e8-3a76-4b18-ab99-fbe763b01032.png">
My mind is blown. 🤯 

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
