### PR TITLE
Support dataset-only smart tag analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Released changes are shown in the
 - Outcome option to dropdown in Smart Tag Analysis.
 - Link from confusion matrix cells and row/column labels to utterance table.
 - Preserve edits done to the config via the API when relaunching Azimuth with the env var `LOAD_CONFIG_HISTORY=1`.
+- Support for dataset-only smart tag analysis.
 
 ### Changed
 - Change the outcome per threshold bar chart to area chart, making the x axis continuous, and add vertical dashed line marking current threshold.

--- a/webapp/src/components/Controls/FilterDistribution.tsx
+++ b/webapp/src/components/Controls/FilterDistribution.tsx
@@ -28,7 +28,7 @@ const FilterDistribution: React.FC<Props> = ({ maxCount, filter }) => {
         initial={false}
         transition={transition}
         bgcolor={
-          outcomeCount ? undefined : (theme) => theme.palette.primary.main
+          outcomeCount ? undefined : (theme) => theme.palette.secondary.dark
         }
       >
         {outcomeCount &&

--- a/webapp/src/components/SmartTagsTable.tsx
+++ b/webapp/src/components/SmartTagsTable.tsx
@@ -38,7 +38,10 @@ import { formatRatioAsPercentageString } from "utils/format";
 import { constructSearchString } from "utils/helpers";
 import DatasetSplitToggler from "./Controls/DatasetSplitToggler";
 
+type MetricPerFilterOption = "label" | "prediction" | "outcome";
+
 type SortBy = "filterValue" | "utteranceCount" | "accuracy" | SmartTagFamily;
+
 type Row = {
   filterValue: string;
   utteranceCount: number;
@@ -64,7 +67,7 @@ const SmartTagsTable: React.FC<{
   const [transpose, setTranspose] = React.useState(false);
 
   const [selectedMetricPerFilterOption, setSelectedMetricPerFilterOption] =
-    React.useState<"label" | "prediction" | "outcome">("label");
+    React.useState<MetricPerFilterOption>("label");
 
   const [ascending, setAscending] = React.useState(false);
   const [sortBy, setSortBy] = React.useState<SortBy>("utteranceCount");
@@ -457,7 +460,7 @@ const SmartTagsTable: React.FC<{
               value={selectedMetricPerFilterOption}
               onChange={(event) =>
                 setSelectedMetricPerFilterOption(
-                  event.target.value as "label" | "prediction"
+                  event.target.value as MetricPerFilterOption
                 )
               }
             >

--- a/webapp/src/components/SmartTagsTable.tsx
+++ b/webapp/src/components/SmartTagsTable.tsx
@@ -305,8 +305,8 @@ const SmartTagsTable: React.FC<{
           "& > *": { paddingX: 2 },
         }}
       >
-        {sortedRows?.map((classCount, classIndex) => (
-          <React.Fragment key={classCount.filterValue}>
+        {sortedRows?.map((row, rowIndex) => (
+          <React.Fragment key={row.filterValue}>
             <Typography
               variant="subtitle2"
               align={transpose ? "center" : "right"}
@@ -316,26 +316,26 @@ const SmartTagsTable: React.FC<{
               position="sticky"
               bgcolor={(theme) => theme.palette.background.paper}
               {...{
-                [`grid${transpose ? "Column" : "Row"}`]: classIndex + 2,
+                [`grid${transpose ? "Column" : "Row"}`]: rowIndex + 2,
                 [`grid${transpose ? "Row" : "Column"}`]: 1,
                 [transpose ? "top" : "left"]: 0,
               }}
             >
               {metricPerFilterOption === "outcome"
-                ? OUTCOME_PRETTY_NAMES[classCount.filterValue as Outcome]
-                : classCount.filterValue}
+                ? OUTCOME_PRETTY_NAMES[row.filterValue as Outcome]
+                : row.filterValue}
             </Typography>
-            {classCount.accuracy !== undefined && (
+            {row.accuracy !== undefined && (
               <Typography
                 variant="body2"
-                key={`accuracy${classCount.filterValue}`}
+                key={`accuracy${row.filterValue}`}
                 align="right"
                 {...{
-                  [`grid${transpose ? "Column" : "Row"}`]: classIndex + 2,
+                  [`grid${transpose ? "Column" : "Row"}`]: rowIndex + 2,
                   [`grid${transpose ? "Row" : "Column"}`]: 2,
                 }}
               >
-                {formatRatioAsPercentageString(classCount.accuracy, 1)}
+                {formatRatioAsPercentageString(row.accuracy, 1)}
               </Typography>
             )}
             {transpose ? (
@@ -343,24 +343,24 @@ const SmartTagsTable: React.FC<{
                 display="flex"
                 justifyContent="space-between"
                 alignItems="flex-end"
-                gridColumn={classIndex + 2}
+                gridColumn={rowIndex + 2}
                 gridRow={3}
               >
                 <Typography variant="subtitle2" lineHeight={1} fontSize={12}>
                   0
                 </Typography>
                 <Typography variant="subtitle2" lineHeight={1} fontSize={12}>
-                  {classCount.utteranceCount}
+                  {row.utteranceCount}
                 </Typography>
               </Box>
             ) : (
               <Typography
                 variant="body2"
                 align="right"
-                gridRow={classIndex + 2}
+                gridRow={rowIndex + 2}
                 gridColumn={3}
               >
-                {classCount.utteranceCount}
+                {row.utteranceCount}
               </Typography>
             )}
           </React.Fragment>
@@ -453,13 +453,13 @@ const SmartTagsTable: React.FC<{
                 </Box>
               )}
             </Box>
-            {sortedRows?.map((row, classIndex) => {
+            {sortedRows?.map((row, rowIndex) => {
               const cell = row.countPerSmartTagFamily[family];
               return (
                 <Box
                   key={row.filterValue}
                   {...{
-                    [`grid${transpose ? "Column" : "Row"}`]: classIndex + 2,
+                    [`grid${transpose ? "Column" : "Row"}`]: rowIndex + 2,
                     [`grid${transpose ? "Row" : "Column"}`]: familyIndex + 4,
                   }}
                 >

--- a/webapp/src/components/SmartTagsTable.tsx
+++ b/webapp/src/components/SmartTagsTable.tsx
@@ -246,11 +246,13 @@ const SmartTagsTable: React.FC<{
       <Box
         display="grid"
         gridTemplateColumns={`repeat(${transpose ? 1 : 3}, min-content)`}
-        gridAutoColumns={160}
+        gridAutoColumns={176}
         gridAutoRows="min-content"
         overflow="auto"
-        columnGap={4}
-        sx={{ overscrollBehaviorX: "contain" }} // Stops accidental navigation on horizontal scroll with touch pad
+        sx={{
+          overscrollBehaviorX: "contain", // Stops accidental navigation on horizontal scroll with touch pad
+          "& > *": { paddingX: 2 },
+        }}
       >
         {sortedRows?.map((classCount, classIndex) => (
           <React.Fragment key={classCount.filterValue}>
@@ -398,27 +400,31 @@ const SmartTagsTable: React.FC<{
               return (
                 <Box
                   key={row.filterValue}
-                  display="flex"
-                  borderLeft="solid 1px"
-                  borderRight="solid 1px"
-                  paddingY={0.5}
                   {...{
                     [`grid${transpose ? "Column" : "Row"}`]: classIndex + 2,
                     [`grid${transpose ? "Row" : "Column"}`]: familyIndex + 4,
                   }}
                 >
-                  {cell &&
-                    ALL_OUTCOMES.map((outcome) => (
-                      <Bar
-                        key={outcome}
-                        rowCount={row.utteranceCount}
-                        cellCount={cell.utteranceCount}
-                        barCount={cell.outcomeCount[outcome]}
-                        filterValue={row.filterValue}
-                        family={family}
-                        outcome={outcome}
-                      />
-                    ))}
+                  <Box
+                    height="100%"
+                    display="flex"
+                    borderLeft="solid 1px"
+                    borderRight="solid 1px"
+                    paddingY={0.5}
+                  >
+                    {cell &&
+                      ALL_OUTCOMES.map((outcome) => (
+                        <Bar
+                          key={outcome}
+                          rowCount={row.utteranceCount}
+                          cellCount={cell.utteranceCount}
+                          barCount={cell.outcomeCount[outcome]}
+                          filterValue={row.filterValue}
+                          family={family}
+                          outcome={outcome}
+                        />
+                      ))}
+                  </Box>
                 </Box>
               );
             })}

--- a/webapp/src/components/SmartTagsTable.tsx
+++ b/webapp/src/components/SmartTagsTable.tsx
@@ -228,12 +228,8 @@ const SmartTagsTable: React.FC<{
                 display="flex"
                 justifyContent="space-between"
                 alignItems="flex-end"
-                flexDirection={transpose ? undefined : "column-reverse"}
-                {...{ [transpose ? "width" : "height"]: "100%" }}
-                {...{
-                  [`grid${transpose ? "Column" : "Row"}`]: classIndex + 2,
-                  [`grid${transpose ? "Row" : "Column"}`]: 3,
-                }}
+                gridColumn={classIndex + 2}
+                gridRow={3}
               >
                 <Typography variant="subtitle2" lineHeight={1} fontSize={12}>
                   0
@@ -246,10 +242,8 @@ const SmartTagsTable: React.FC<{
               <Typography
                 variant="body2"
                 align="right"
-                {...{
-                  [`grid${transpose ? "Column" : "Row"}`]: classIndex + 2,
-                  [`grid${transpose ? "Row" : "Column"}`]: 3,
-                }}
+                gridRow={classIndex + 2}
+                gridColumn={3}
               >
                 {classCount.utteranceCount}
               </Typography>

--- a/webapp/src/components/SmartTagsTable.tsx
+++ b/webapp/src/components/SmartTagsTable.tsx
@@ -355,8 +355,10 @@ const SmartTagsTable: React.FC<{
                           <>
                             <Typography variant="inherit">
                               {`${cell.outcomeCount[outcome]} utterance${
-                                cell.outcomeCount[outcome] === 1 ? "" : "s"
-                              } are `}
+                                cell.outcomeCount[outcome] === 1
+                                  ? " is"
+                                  : "s are"
+                              } `}
                               <Typography
                                 variant="inherit"
                                 component="span"

--- a/webapp/src/components/SmartTagsTable.tsx
+++ b/webapp/src/components/SmartTagsTable.tsx
@@ -165,6 +165,63 @@ const SmartTagsTable: React.FC<{
     ...(transpose && { IconComponent: ArrowForward }),
   });
 
+  const Bar: React.FC<{
+    rowCount: number;
+    cellCount: number;
+    barCount: number;
+    filterValue: string;
+    family: SmartTagFamily;
+    outcome: Outcome;
+  }> = ({ rowCount, cellCount, barCount, filterValue, family, outcome }) => (
+    <Tooltip
+      title={
+        <>
+          <Typography variant="inherit">
+            {barCount} utterance{barCount === 1 ? " is " : "s are "}
+            <Typography variant="inherit" component="span" fontWeight="bold">
+              {OUTCOME_PRETTY_NAMES[outcome]}
+            </Typography>
+          </Typography>
+          <Typography variant="inherit">
+            out of {cellCount} utterance{cellCount === 1 ? "" : "s"} tagged{" "}
+            <Typography variant="inherit" component="span" fontWeight="bold">
+              {SMART_TAG_FAMILY_PRETTY_NAMES[family]}
+            </Typography>
+          </Typography>
+          <Typography variant="inherit">
+            out of {rowCount} utterance{rowCount === 1 ? "" : "s"} labeled{" "}
+            <Typography variant="inherit" component="span" fontWeight="bold">
+              {filterValue}
+            </Typography>
+          </Typography>
+        </>
+      }
+    >
+      <Box
+        component={motion.div}
+        bgcolor={(theme) => theme.palette[OUTCOME_COLOR[outcome]].main}
+        height="100%"
+        animate={{ width: `${rowCount && (100 * barCount) / rowCount}%` }}
+        initial={false}
+        transition={{ type: "tween" }}
+        display="flex"
+      >
+        <Link
+          component={RouterLink}
+          width="100%"
+          to={`/${jobId}/dataset_splits/${datasetSplitName}/prediction_overview${constructSearchString(
+            {
+              [selectedMetricPerFilterOption]: [filterValue],
+              outcome: [outcome],
+              [family]: smartTags(family),
+              ...pipeline,
+            }
+          )}`}
+        />
+      </Box>
+    </Tooltip>
+  );
+
   return (
     <Box display="flex" flexDirection="column" gap={4} minHeight={0}>
       <Box display="flex" gap={4}>
@@ -352,84 +409,15 @@ const SmartTagsTable: React.FC<{
                 >
                   {cell &&
                     ALL_OUTCOMES.map((outcome) => (
-                      <Tooltip
+                      <Bar
                         key={outcome}
-                        title={
-                          <>
-                            <Typography variant="inherit">
-                              {`${cell.outcomeCount[outcome]} utterance${
-                                cell.outcomeCount[outcome] === 1
-                                  ? " is"
-                                  : "s are"
-                              } `}
-                              <Typography
-                                variant="inherit"
-                                component="span"
-                                fontWeight="bold"
-                              >
-                                {OUTCOME_PRETTY_NAMES[outcome]}
-                              </Typography>
-                            </Typography>
-                            <Typography variant="inherit">
-                              {`out of ${cell.utteranceCount} utterance${
-                                cell.utteranceCount === 1 ? "" : "s"
-                              } tagged `}
-                              <Typography
-                                variant="inherit"
-                                component="span"
-                                fontWeight="bold"
-                              >
-                                {SMART_TAG_FAMILY_PRETTY_NAMES[family]}
-                              </Typography>
-                            </Typography>
-                            <Typography variant="inherit">
-                              {`out of ${row.utteranceCount} utterance${
-                                row.utteranceCount === 1 ? "" : "s"
-                              } labeled `}
-                              <Typography
-                                variant="inherit"
-                                component="span"
-                                fontWeight="bold"
-                              >
-                                {row.filterValue}
-                              </Typography>
-                            </Typography>
-                          </>
-                        }
-                      >
-                        <Box
-                          component={motion.div}
-                          bgcolor={(theme) =>
-                            theme.palette[OUTCOME_COLOR[outcome]].main
-                          }
-                          height="100%"
-                          animate={{
-                            width: `${
-                              row.utteranceCount &&
-                              (100 * cell.outcomeCount[outcome]) /
-                                row.utteranceCount
-                            }%`,
-                          }}
-                          initial={false}
-                          transition={{ type: "tween" }}
-                          display="flex"
-                        >
-                          <Link
-                            component={RouterLink}
-                            width="100%"
-                            to={`/${jobId}/dataset_splits/${datasetSplitName}/prediction_overview${constructSearchString(
-                              {
-                                [selectedMetricPerFilterOption]: [
-                                  row.filterValue,
-                                ],
-                                outcome: [outcome],
-                                [family]: smartTags(family),
-                                ...pipeline,
-                              }
-                            )}`}
-                          />
-                        </Box>
-                      </Tooltip>
+                        rowCount={row.utteranceCount}
+                        cellCount={cell.utteranceCount}
+                        barCount={cell.outcomeCount[outcome]}
+                        filterValue={row.filterValue}
+                        family={family}
+                        outcome={outcome}
+                      />
                     ))}
                 </Box>
               );

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -113,30 +113,6 @@ const Dashboard = () => {
             />
           </PreviewCard>
         )}
-      <WithDatasetSplitNameState
-        defaultDatasetSplitName={firstAvailableDatasetSplit}
-        render={(datasetSplitName, setDatasetSplitName) => (
-          <PreviewCard
-            title="Smart Tag Analysis"
-            to={`/${jobId}/dataset_splits/${datasetSplitName}/smart_tags${searchString}`}
-            description={smartTagsDescription}
-          >
-            <Box
-              display="flex"
-              flexDirection="column" // Important for the inner Box to overflow correctly
-              maxHeight={DEFAULT_PREVIEW_CONTENT_HEIGHT}
-            >
-              <SmartTagsTable
-                jobId={jobId}
-                pipeline={pipeline}
-                availableDatasetSplits={datasetInfo.availableDatasetSplits}
-                datasetSplitName={datasetSplitName}
-                setDatasetSplitName={setDatasetSplitName}
-              />
-            </Box>
-          </PreviewCard>
-        )}
-      />
       {isPipelineSelected(pipeline) && (
         <WithDatasetSplitNameState
           defaultDatasetSplitName={firstAvailableDatasetSplit}
@@ -162,6 +138,30 @@ const Dashboard = () => {
           )}
         />
       )}
+      <WithDatasetSplitNameState
+        defaultDatasetSplitName={firstAvailableDatasetSplit}
+        render={(datasetSplitName, setDatasetSplitName) => (
+          <PreviewCard
+            title="Smart Tag Analysis"
+            to={`/${jobId}/dataset_splits/${datasetSplitName}/smart_tags${searchString}`}
+            description={smartTagsDescription}
+          >
+            <Box
+              display="flex"
+              flexDirection="column" // Important for the inner Box to overflow correctly
+              maxHeight={DEFAULT_PREVIEW_CONTENT_HEIGHT}
+            >
+              <SmartTagsTable
+                jobId={jobId}
+                pipeline={pipeline}
+                availableDatasetSplits={datasetInfo.availableDatasetSplits}
+                datasetSplitName={datasetSplitName}
+                setDatasetSplitName={setDatasetSplitName}
+              />
+            </Box>
+          </PreviewCard>
+        )}
+      />
       {isPipelineSelected(pipeline) &&
         datasetInfo.perturbationTestingAvailable && (
           <PreviewCard

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -113,6 +113,30 @@ const Dashboard = () => {
             />
           </PreviewCard>
         )}
+      <WithDatasetSplitNameState
+        defaultDatasetSplitName={firstAvailableDatasetSplit}
+        render={(datasetSplitName, setDatasetSplitName) => (
+          <PreviewCard
+            title="Smart Tag Analysis"
+            to={`/${jobId}/dataset_splits/${datasetSplitName}/smart_tags${searchString}`}
+            description={smartTagsDescription}
+          >
+            <Box
+              display="flex"
+              flexDirection="column" // Important for the inner Box to overflow correctly
+              maxHeight={DEFAULT_PREVIEW_CONTENT_HEIGHT}
+            >
+              <SmartTagsTable
+                jobId={jobId}
+                pipeline={pipeline}
+                availableDatasetSplits={datasetInfo.availableDatasetSplits}
+                datasetSplitName={datasetSplitName}
+                setDatasetSplitName={setDatasetSplitName}
+              />
+            </Box>
+          </PreviewCard>
+        )}
+      />
       {isPipelineSelected(pipeline) && (
         <WithDatasetSplitNameState
           defaultDatasetSplitName={firstAvailableDatasetSplit}
@@ -134,32 +158,6 @@ const Dashboard = () => {
                 datasetSplitName={datasetSplitName}
                 setDatasetSplitName={setDatasetSplitName}
               />
-            </PreviewCard>
-          )}
-        />
-      )}
-      {isPipelineSelected(pipeline) && (
-        <WithDatasetSplitNameState
-          defaultDatasetSplitName={firstAvailableDatasetSplit}
-          render={(datasetSplitName, setDatasetSplitName) => (
-            <PreviewCard
-              title="Smart Tag Analysis"
-              to={`/${jobId}/dataset_splits/${datasetSplitName}/smart_tags${searchString}`}
-              description={smartTagsDescription}
-            >
-              <Box
-                display="flex"
-                flexDirection="column" // Important for the inner Box to overflow correctly
-                maxHeight={DEFAULT_PREVIEW_CONTENT_HEIGHT}
-              >
-                <SmartTagsTable
-                  jobId={jobId}
-                  pipeline={pipeline}
-                  availableDatasetSplits={datasetInfo.availableDatasetSplits}
-                  datasetSplitName={datasetSplitName}
-                  setDatasetSplitName={setDatasetSplitName}
-                />
-              </Box>
             </PreviewCard>
           )}
         />

--- a/webapp/src/pages/SmartTags.tsx
+++ b/webapp/src/pages/SmartTags.tsx
@@ -6,8 +6,6 @@ import React from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { getDatasetInfoEndpoint } from "services/api";
 import { DatasetSplitName } from "types/api";
-import { PIPELINE_REQUIRED_TIP } from "utils/const";
-import { isPipelineSelected } from "utils/helpers";
 
 export const smartTagsDescription = (
   <Description
@@ -33,22 +31,15 @@ const SmartTags = () => {
     <Box display="flex" flexDirection="column" height="100%">
       <Typography variant="h4">Smart Tag Analysis</Typography>
       {smartTagsDescription}
-      {isPipelineSelected(pipeline) ? (
-        <Paper
-          variant="outlined"
-          sx={{ marginTop: 4, minHeight: 0, padding: 4 }}
-        >
-          <SmartTagsTable
-            jobId={jobId}
-            pipeline={pipeline}
-            availableDatasetSplits={datasetInfo?.availableDatasetSplits}
-            datasetSplitName={datasetSplitName}
-            setDatasetSplitName={setDatasetSplitName}
-          />
-        </Paper>
-      ) : (
-        <Typography>{PIPELINE_REQUIRED_TIP}</Typography>
-      )}
+      <Paper variant="outlined" sx={{ marginTop: 4, minHeight: 0, padding: 4 }}>
+        <SmartTagsTable
+          jobId={jobId}
+          pipeline={pipeline}
+          availableDatasetSplits={datasetInfo?.availableDatasetSplits}
+          datasetSplitName={datasetSplitName}
+          setDatasetSplitName={setDatasetSplitName}
+        />
+      </Paper>
     </Box>
   );
 };

--- a/webapp/src/utils/helpers.ts
+++ b/webapp/src/utils/helpers.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { toast } from "react-toastify";
+import { CountPerFilterValue, OutcomeCountPerFilterValue } from "types/api";
 import {
   QueryClassOverlapState,
   QueryFilterState,
@@ -106,3 +107,8 @@ export const isPipelineSelected = (
 ): pipeline is Required<QueryPipelineState> => {
   return pipeline.pipelineIndex !== undefined;
 };
+
+export const isOutcomeCountPerFilterValue = (
+  countPerFilterValue: CountPerFilterValue
+): countPerFilterValue is OutcomeCountPerFilterValue =>
+  Boolean(countPerFilterValue.outcomeCount);


### PR DESCRIPTION
Resolve #433

## Description:

The overall diff is pretty messy, so I recommend looking at the different commits individually.

I made a couple of decisions what we can debate:
- Color the dataset-only bars (with no outcomes) dark blue (`palette.secondary.dark`) like other data visualizations.
- Hide the pipeline-specific columns, including accuracy and some smart tag families.
- Disable the `Prediction` and `Outcome` options from the menu (since hiding the options would result in a weird one-option menu).

Here is an example:
<img width="1520" alt="Screen Shot 2023-03-08 at 11 45 51 AM" src="https://user-images.githubusercontent.com/8386369/223783522-8d0a897b-05df-47a1-a964-66ea17a3db57.png">

For reference, here is how it looks with a pipeline:
<img width="1520" alt="Screen Shot 2023-03-08 at 11 46 04 AM" src="https://user-images.githubusercontent.com/8386369/223783540-9afc36e0-fe47-4656-a6d4-e7ebae084021.png">

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
