### PR TITLE
Improve config modal

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -14,6 +14,7 @@ import {
 } from "@mui/material/styles";
 import AppLayout from "components/AppLayout";
 import BasicLayout from "components/BasicLayout";
+import PageHeader from "components/PageHeader";
 import WarningsOverview from "pages/WarningsOverview";
 import UtteranceDetail from "pages/UtteranceDetail";
 import customTheme, { GlobalCss } from "styles/theme";
@@ -77,6 +78,7 @@ export default class App extends React.Component<Props> {
                     <Route path="/:jobId">
                       <StatusCheck>
                         <PipelineCheck>
+                          <PageHeader />
                           <Switch>
                             <Route path="/:jobId" exact>
                               <BasicLayout maxWidth="md">

--- a/webapp/src/components/BasicLayout.tsx
+++ b/webapp/src/components/BasicLayout.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Box, Breakpoint, Container } from "@mui/material";
-import PageHeader from "components/PageHeader";
 
 type Props = {
   maxWidth?: Breakpoint;
@@ -8,14 +7,11 @@ type Props = {
 };
 
 const BasicLayout: React.FC<Props> = ({ maxWidth = "xl", children }) => (
-  <>
-    <PageHeader />
-    <Box height="100%" display="flex" flexDirection="column" overflow="auto">
-      <Container maxWidth={maxWidth} sx={{ flex: 1, minHeight: 0, padding: 2 }}>
-        {children}
-      </Container>
-    </Box>
-  </>
+  <Box height="100%" display="flex" flexDirection="column" overflow="auto">
+    <Container maxWidth={maxWidth} sx={{ flex: 1, minHeight: 0, padding: 2 }}>
+      {children}
+    </Container>
+  </Box>
 );
 
 export default React.memo(BasicLayout);

--- a/webapp/src/components/Controls/FilterSelector.tsx
+++ b/webapp/src/components/Controls/FilterSelector.tsx
@@ -232,9 +232,8 @@ const FilterSelector = <FilterValue extends string>({
           {options && (
             <motion.ul
               className={classes.options}
-              animate={{
-                maxHeight: numberVisible * 28,
-              }}
+              animate={{ maxHeight: numberVisible * 28 }}
+              initial={{ maxHeight: 0 }}
               transition={transition}
             >
               {options.map(renderOption)}

--- a/webapp/src/components/PageHeader.tsx
+++ b/webapp/src/components/PageHeader.tsx
@@ -1,12 +1,5 @@
 import { Settings as SettingsIcon } from "@mui/icons-material";
-import {
-  Box,
-  Breadcrumbs,
-  Dialog,
-  IconButton,
-  Link,
-  Typography,
-} from "@mui/material";
+import { Box, Breadcrumbs, IconButton, Link, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import useQueryState from "hooks/useQueryState";
 import React from "react";
@@ -87,7 +80,7 @@ const PageHeader = () => {
       })}`
     );
   };
-  const [openConfigModal, setOpenConfigModal] = React.useState(false);
+  const [configOpen, setConfigOpen] = React.useState(false);
   const dashboardPathname = `/${jobId}`;
 
   const isDashboard = location.pathname === dashboardPathname;
@@ -184,7 +177,7 @@ const PageHeader = () => {
             <IconButton
               size="small"
               color="primary"
-              onClick={() => setOpenConfigModal(true)}
+              onClick={() => setConfigOpen(true)}
               sx={{
                 padding: 0,
                 "&:hover > svg": {
@@ -197,14 +190,7 @@ const PageHeader = () => {
             </IconButton>
             <HelpMenu />
           </Box>
-          <Dialog
-            aria-labelledby="config-dialog-title"
-            maxWidth="md"
-            fullWidth
-            open={openConfigModal}
-          >
-            <Settings onClose={() => setOpenConfigModal(false)} />
-          </Dialog>
+          <Settings open={configOpen} onClose={() => setConfigOpen(false)} />
         </div>
       )}
     </div>

--- a/webapp/src/pages/Exploration.tsx
+++ b/webapp/src/pages/Exploration.tsx
@@ -6,7 +6,6 @@ import ConfusionMatrix from "components/ConfusionMatrix";
 import Controls from "components/Controls/Controls";
 import Description from "components/Description";
 import Metrics from "components/Metrics/Metrics";
-import PageHeader from "components/PageHeader";
 import TabPipelineRequired from "components/TabPipelineRequired";
 import useQueryState from "hooks/useQueryState";
 import React from "react";
@@ -77,109 +76,106 @@ const Exploration = () => {
   }, [setMainView, mainView, pipeline]);
 
   return (
-    <>
-      <PageHeader />
-      <div className={classes.container}>
-        <div className={classes.layout}>
-          <Controls
-            confusionMatrix={confusionMatrix}
-            filters={filters}
-            pagination={pagination}
-            pipeline={pipeline}
-            postprocessing={postprocessing}
-            searchString={searchString}
-          />
-          <div className={classes.content}>
-            <Paper
-              variant="outlined"
-              sx={{
-                flex: 1,
-                minHeight: 0,
-                display: "flex",
-                flexDirection: "column",
-                gap: 4,
-                padding: 4,
-                paddingTop: 2.5,
-              }}
-            >
-              <Box borderBottom={1} borderColor="divider">
-                <Tabs
-                  indicatorColor="secondary"
-                  value={mainView}
-                  onChange={(_, value) => setMainView(value)}
-                >
-                  <TabPipelineRequired
-                    value="prediction_overview"
-                    label="Prediction Overview"
-                    pipeline={pipeline}
-                  />
-                  <TabPipelineRequired
-                    value="confusion_matrix"
-                    label="Confusion Matrix"
-                    pipeline={pipeline}
-                  />
-                  <Tab value="utterances" label="Utterance Table" />
-                </Tabs>
-              </Box>
-              {mainView === "prediction_overview" &&
-                isPipelineSelected(pipeline) && (
-                  <>
-                    <Description
-                      text="Analyze metrics for different data subpopulations, visualize the confidence distribution, and discover annotation artifacts."
-                      link="user-guide/exploration-space/#prediction-overview"
-                    />
-                    <Metrics
-                      jobId={jobId}
-                      datasetSplitName={datasetSplitName}
-                      filters={filters}
-                      pipeline={pipeline}
-                      postprocessing={postprocessing}
-                    />
-                    <ConfidenceHistogramTopWords
-                      baseUrl={baseUrl}
-                      confusionMatrix={confusionMatrix}
-                      filters={filters}
-                      pagination={pagination}
-                      pipeline={pipeline}
-                      postprocessing={postprocessing}
-                    />
-                  </>
-                )}
-              {mainView === "confusion_matrix" && isPipelineSelected(pipeline) && (
+    <div className={classes.container}>
+      <div className={classes.layout}>
+        <Controls
+          confusionMatrix={confusionMatrix}
+          filters={filters}
+          pagination={pagination}
+          pipeline={pipeline}
+          postprocessing={postprocessing}
+          searchString={searchString}
+        />
+        <div className={classes.content}>
+          <Paper
+            variant="outlined"
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+              padding: 4,
+              paddingTop: 2.5,
+            }}
+          >
+            <Box borderBottom={1} borderColor="divider">
+              <Tabs
+                indicatorColor="secondary"
+                value={mainView}
+                onChange={(_, value) => setMainView(value)}
+              >
+                <TabPipelineRequired
+                  value="prediction_overview"
+                  label="Prediction Overview"
+                  pipeline={pipeline}
+                />
+                <TabPipelineRequired
+                  value="confusion_matrix"
+                  label="Confusion Matrix"
+                  pipeline={pipeline}
+                />
+                <Tab value="utterances" label="Utterance Table" />
+              </Tabs>
+            </Box>
+            {mainView === "prediction_overview" &&
+              isPipelineSelected(pipeline) && (
                 <>
                   <Description
-                    text="Visualize the model confusion between each pair of intents."
-                    link="user-guide/exploration-space/#confusion-matrix"
+                    text="Analyze metrics for different data subpopulations, visualize the confidence distribution, and discover annotation artifacts."
+                    link="user-guide/exploration-space/#prediction-overview"
                   />
-                  <ConfusionMatrix
+                  <Metrics
                     jobId={jobId}
                     datasetSplitName={datasetSplitName}
-                    confusionMatrix={confusionMatrix}
                     filters={filters}
                     pipeline={pipeline}
-                    predictionFilters={filters.prediction}
-                    labelFilters={filters.label}
+                    postprocessing={postprocessing}
+                  />
+                  <ConfidenceHistogramTopWords
+                    baseUrl={baseUrl}
+                    confusionMatrix={confusionMatrix}
+                    filters={filters}
+                    pagination={pagination}
+                    pipeline={pipeline}
                     postprocessing={postprocessing}
                   />
                 </>
               )}
-              {mainView === "utterances" && (
-                <UtterancesTable
+            {mainView === "confusion_matrix" && isPipelineSelected(pipeline) && (
+              <>
+                <Description
+                  text="Visualize the model confusion between each pair of intents."
+                  link="user-guide/exploration-space/#confusion-matrix"
+                />
+                <ConfusionMatrix
                   jobId={jobId}
-                  datasetInfo={datasetInfo}
                   datasetSplitName={datasetSplitName}
                   confusionMatrix={confusionMatrix}
                   filters={filters}
-                  pagination={pagination}
                   pipeline={pipeline}
+                  predictionFilters={filters.prediction}
+                  labelFilters={filters.label}
                   postprocessing={postprocessing}
                 />
-              )}
-            </Paper>
-          </div>
+              </>
+            )}
+            {mainView === "utterances" && (
+              <UtterancesTable
+                jobId={jobId}
+                datasetInfo={datasetInfo}
+                datasetSplitName={datasetSplitName}
+                confusionMatrix={confusionMatrix}
+                filters={filters}
+                pagination={pagination}
+                pipeline={pipeline}
+                postprocessing={postprocessing}
+              />
+            )}
+          </Paper>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description:

* [Put loading and error states inside the `Dialog` box](https://github.com/ServiceNow/azimuth/pull/487/commits/83aeb4ed6d19b3c10b6096d0ba3ed22e87319565)
  - Before, if there was an error, you would not be able to close de `Dialog` box, since the `X`button wouldn't show up.
  - ⚠️ The diff in Settings.tsx seems overwhelming, but the code is just moving around, with no real changes.
* [Render `PageHeader` in only one place](https://github.com/ServiceNow/azimuth/pull/487/commits/c2449621fa3883670faa6ca85b54f8eb477c6d89) (as opposed to once in `BasicLayout` and once in `Exploration`) so that the config modal stays in place if we use the browser back and forward buttons, to avoid losing unsaved changes in the config.
  - ⚠️ The diff in Exploration.tsx seems overwhelming, but it's just the indentation, with no real changes.
* [Resolve warning](https://github.com/ServiceNow/azimuth/pull/487/commits/0ecadf93fd496cd9ce5b3ac46cb7a2c6f050ad33)
  - ⚠️ Not related to the config.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
