### PR TITLE
Fix unshrinking labels

### DIFF
--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -151,6 +151,7 @@ const displayReadonlyFields = (label: string, value: string | null) => (
     size="small"
     variant="standard"
     label={label}
+    InputLabelProps={{ shrink: true }}
     value={String(value)}
     InputProps={{
       readOnly: true,
@@ -190,6 +191,7 @@ const NumberField: React.FC<
       type="number"
       className="fixedWidthInput"
       title="" // Overwrite any default input validation tooltip
+      InputLabelProps={{ shrink: true }}
       value={stringValue}
       {...(units && {
         InputProps: {


### PR DESCRIPTION
## Description:

Fix unshrinking labels when an input field is empty in the config. Here is a video with before and after:

https://user-images.githubusercontent.com/8386369/225029770-3ce49ac4-cdcd-4a8b-abd7-5bc568d815f3.mov

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
