### PR TITLE
Hide TF info messages in logs

### DIFF
--- a/azimuth/__init__.py
+++ b/azimuth/__init__.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from datasets import disable_progress_bar
@@ -10,3 +11,4 @@ PROJECT_ROOT = str(Path(__file__).parent)
 set_verbosity_error()
 disable_progress_bar()
 set_logger_config()
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"  # INFO messages from TensorFlow are not printed


### PR DESCRIPTION
## Description:
Since updating Tensorflow, we had these logs:
```
I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
```
As detailed [here](https://stackoverflow.com/questions/65298241/what-does-this-tensorflow-message-mean-any-side-effect-was-the-installation-su), we can safely hide those.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
