### PR TITLE
Add faiss to startup

### DIFF
--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -50,7 +50,8 @@ class Startup:
 START_UP_THREAD_NAME = "Azimuth_Startup"
 
 SIMILARITY_TASKS = [
-    Startup("neighbors_tags", SupportedModule.NeighborsTagging),
+    Startup("faiss", SupportedModule.FAISS),
+    Startup("neighbors_tags", SupportedModule.NeighborsTagging, dependency_names=["faiss"]),
     Startup(
         "class_overlap",
         SupportedModule.ClassOverlap,
@@ -96,7 +97,7 @@ POSTPROCESSING_TASKS = [
     Startup(
         "outcome_count_per_threshold",
         SupportedModule.OutcomeCountPerThreshold,
-        dependency_names=["prediction", "outcome_count"],
+        dependency_names=["prediction", "outcome"],
         run_on_all_pipelines=True,
         dataset_split_names=[DatasetSplitName.eval],
     )
@@ -109,7 +110,7 @@ SALIENCY_TASKS = [
 BASE_PREDICTION_TASKS = [
     Startup("prediction", SupportedMethod.Predictions, run_on_all_pipelines=True),
     Startup(
-        "outcome_count",
+        "outcome",
         SupportedModule.Outcome,
         dependency_names=["prediction"],
         run_on_all_pipelines=True,
@@ -125,7 +126,7 @@ BASE_PREDICTION_TASKS = [
         SupportedModule.MetricsPerFilter,
         dependency_names=[
             "prediction",
-            "outcome_count",
+            "outcome",
             "prediction_comparison",
             "perturbation_testing",
             "neighbors_tags",

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -31,7 +31,7 @@ def test_startup_task(tiny_text_config, tiny_text_task_manager):
     assert all(
         on_end in [cbk.fn for cbk in mod._callbacks] for mod in mods.values()
     ), "Some modules don't have callbacks!"
-    assert len(mods) == 19
+    assert len(mods) == 21
 
 
 def test_startup_task_fast(tiny_text_config, tiny_text_task_manager):


### PR DESCRIPTION
## Description:
* While playing with the repo, I realized that the FAISS modules were often started twice, probably because two workers were requesting it for the neighbors tagging module. I added it explicitly to the startup tasks to avoid the problem.

<img width="1119" alt="Screen Shot 2023-03-16 at 16 39 09" src="https://user-images.githubusercontent.com/36087158/225752048-ba84bd77-53b3-4ba2-8a4f-344018ba617b.png">

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [ ] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [ ] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [ ] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [ ] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
