### PR TITLE
Remove artifact_path from project hash

### DIFF
--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -294,6 +294,7 @@ class CommonFieldsConfig(ProjectConfig, extra=Extra.ignore):
     artifact_path: str = Field(
         "cache",
         description="Where to store artifacts (Azimuth config history, HDF5 files, HF datasets).",
+        exclude_from_cache=True,
     )
     # Batch size to use during inference.
     batch_size: int = Field(32, exclude_from_cache=True)


### PR DESCRIPTION
## Description:
- Since the artifact_path is in the path, there is no use in having it in the project hash as well. 

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
