### PR TITLE
Clean up config vs task_manager.config

### DIFF
--- a/azimuth/routers/app.py
+++ b/azimuth/routers/app.py
@@ -84,14 +84,11 @@ def get_dataset_info(
         get_dataset_split_manager_mapping
     ),
     startup_tasks: Dict[str, Module] = Depends(get_startup_tasks),
-    task_manager: TaskManager = Depends(get_task_manager),
     config: AzimuthConfig = Depends(get_config),
 ):
     eval_dm = dataset_split_managers.get(DatasetSplitName.eval)
     training_dm = dataset_split_managers.get(DatasetSplitName.train)
     dm = assert_not_none(eval_dm or training_dm)
-
-    model_contract = task_manager.config.model_contract
 
     return DatasetInfoResponse(
         project_name=config.name,
@@ -105,19 +102,16 @@ def get_dataset_info(
         if training_dm is not None
         else [],
         startup_tasks={k: v.status() for k, v in startup_tasks.items()},
-        model_contract=model_contract,
-        prediction_available=predictions_available(task_manager.config),
-        perturbation_testing_available=perturbation_testing_available(task_manager.config),
+        model_contract=config.model_contract,
+        prediction_available=predictions_available(config),
+        perturbation_testing_available=perturbation_testing_available(config),
         available_dataset_splits=AvailableDatasetSplits(
             eval=eval_dm is not None, train=training_dm is not None
         ),
-        similarity_available=similarity_available(task_manager.config),
+        similarity_available=similarity_available(config),
         postprocessing_editable=None
         if config.pipelines is None
-        else [
-            postprocessing_editable(task_manager.config, idx)
-            for idx in range(len(config.pipelines))
-        ],
+        else [postprocessing_editable(config, idx) for idx in range(len(config.pipelines))],
     )
 
 

--- a/azimuth/routers/export.py
+++ b/azimuth/routers/export.py
@@ -112,14 +112,13 @@ def get_export_perturbation_testing_summary(
         mod_options=ModuleOptions(pipeline_index=pipeline_index),
     )[0].all_tests_summary
 
-    cfg = task_manager.config
     df = pd.DataFrame.from_records([t.dict() for t in task_result])
     df["example"] = df["example"].apply(lambda i: i["perturbedUtterance"])
     file_label = time.strftime("%Y%m%d_%H%M%S", time.localtime())
 
-    filename = f"azimuth_export_behavioral_testing_summary_{cfg.name}_{file_label}.csv"
+    filename = f"azimuth_export_behavioral_testing_summary_{config.name}_{file_label}.csv"
 
-    path = pjoin(cfg.get_project_path(), filename)
+    path = pjoin(config.get_project_path(), filename)
 
     df.to_csv(path, index=False)
 
@@ -143,10 +142,9 @@ def get_export_perturbed_set(
 ) -> FileResponse:
     pipeline_index_not_null = assert_not_none(pipeline_index)
     file_label = time.strftime("%Y%m%d_%H%M%S", time.localtime())
-    cfg = task_manager.config
 
-    filename = f"azimuth_export_modified_set_{cfg.name}_{dataset_split_name}_{file_label}.json"
-    path = pjoin(cfg.get_project_path(), filename)
+    filename = f"azimuth_export_modified_set_{config.name}_{dataset_split_name}_{file_label}.json"
+    path = pjoin(config.get_project_path(), filename)
 
     task_result: List[List[PerturbedUtteranceResult]] = get_standard_task_result(
         SupportedModule.PerturbationTesting,

--- a/azimuth/routers/utterances.py
+++ b/azimuth/routers/utterances.py
@@ -101,7 +101,7 @@ def get_utterances(
     if predictions_available(config) and pipeline_index is not None:
         threshold = (
             assert_not_none(config.pipelines)[pipeline_index].threshold
-            if postprocessing_known(task_manager.config, pipeline_index)
+            if postprocessing_known(config, pipeline_index)
             else None
         )
         table_key = PredictionTableKey.from_pipeline_index(pipeline_index, config)

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -1,7 +1,6 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
-
 import threading
 import time
 from collections import defaultdict
@@ -236,18 +235,18 @@ def startup_tasks(
     ]
     if predictions_available(config):
         start_up_tasks += BASE_PREDICTION_TASKS
-        if perturbation_testing_available(task_manager.config):
+        if perturbation_testing_available(config):
             start_up_tasks += PERTURBATION_TESTING_TASKS
-        if task_manager.config.uncertainty.iterations > 1:
+        if config.uncertainty.iterations > 1:
             start_up_tasks += BMA_PREDICTION_TASKS
         if config.pipelines is not None and len(config.pipelines) > 1:
             start_up_tasks += PIPELINE_COMPARISON_TASKS
         # TODO We only check pipeline_index=0, but we should check all pipelines.
-        if postprocessing_editable(task_manager.config, 0):
+        if postprocessing_editable(config, 0):
             start_up_tasks += POSTPROCESSING_TASKS
-        if saliency_available(task_manager.config):
+        if saliency_available(config):
             start_up_tasks += SALIENCY_TASKS
-    if similarity_available(task_manager.config):
+    if similarity_available(config):
         start_up_tasks += SIMILARITY_TASKS
 
     mods = start_tasks_for_dms(config, dataset_split_managers, task_manager, start_up_tasks)


### PR DESCRIPTION
## Description:
* Quick cleanup. When task_manager and config were both present in a function args, we would often arbitrarily use `task_manager.config` or `config`.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
