### PR TITLE
Make the Swagger UI work through the front-end proxy

### DIFF
--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -134,6 +134,8 @@ def create_app() -> FastAPI:
         description="Azimuth API",
         version="1.0",
         default_response_class=JSONResponseIgnoreNan,
+        root_path=".",  # Tells Swagger UI and ReDoc to fetch the OpenAPI spec from ./openapi.json
+        # (relative) so it works through the front-end proxy.
     )
 
     # Setup routes


### PR DESCRIPTION
## Description:

In certain contexts, for example, our demo, the only (easy) way to access the back end API is through the front end's proxy, at `/api/local/...`. The Swagger UI was therefore available at `/api/local/docs`, but it didn't work since it was trying to fetch the spec from `/openapi.json` instead of `/api/local/openapi.json`. This PR tells the Swagger UI to fetch the spec from `./openapi.json` (relative path), so it works through the front-end proxy too. This also applies to the API URL if you `Try it out`. Here is the screenshot of the Swagger UI as expected when accessed through the front-end API:

Before:
![image](https://user-images.githubusercontent.com/8386369/226424430-5a072fc3-f416-4409-80bc-e21d5ddadc2c.png)

After:
![Screen Shot 2023-03-20 at 1 28 18 PM](https://user-images.githubusercontent.com/8386369/226423805-974f7a7a-1001-4952-bfdb-657ad965c621.png)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
