### PR TITLE
Simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
 endif
 
 ifeq ($(DEVICE),gpu)
-	COMPOSE_EXT=-f docker-compose-gpu.yml
+	COMPOSE_EXT=-gpu
 else
 	COMPOSE_EXT=
 endif
@@ -55,7 +55,7 @@ compose: build launch
 
 .PHONY: launch
 launch:
-	docker-compose -f docker-compose.yml $(COMPOSE_EXT) --env-file $(ENV_FILE) up
+	docker compose -f docker-compose$(COMPOSE_EXT).yml --env-file $(ENV_FILE) up
 
 .PHONY: push
 push:


### PR DESCRIPTION
## Description:

- `COMPOSE_EXT` used to overwrite the `-f docker-compose.yml` by specifying a second `-f docker-compose-gpu.yml`, which (fortunately) made `docker-compose` "forget" about the first file. This undocumented behavior is not straightforward and makes our `Makefile` confusing. I propose making `COMPOSE_EXT` only handle the `-gpu` part of the file name.
- When running `docker-compose`, a message suggests using `docker compose` instead.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
