### PR TITLE
Support serving the front end in HTTPS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,14 +13,10 @@ services:
       - "NAME"
       - "BEHAVIORAL_TESTING"
       - "SIMILARITY"
-    ports:
-      - "8091:8091"
     volumes:
     - ./config:/config
     - ./azimuth_shr:/azimuth_shr
     - ./cache:/cache
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
   web:
     image: "${REGISTRY}/azimuth-app:${FRONTEND_VERSION}"
     command:
@@ -30,5 +26,5 @@ services:
       - "PORT=8080"
     ports:
       - "8080:8080"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    links:
+      - backend:host.docker.internal

--- a/docs/docs/getting-started/c-run.md
+++ b/docs/docs/getting-started/c-run.md
@@ -105,8 +105,8 @@ dataset and model are available in `config/examples` (`CLINC` is also shown belo
     ```
     make launch
     ```
-4. The **app will be accessible** at `http://localhost:8080` after a few minutes of waiting. The
-   start-up tasks will start.
+4. The **app will be accessible** at http://localhost:8080 after a few minutes of waiting. The
+    start-up tasks will start. The back-end API will be accessible at http://localhost:8080/api/local/docs.
 
 After a successful start, Azimuth saves the provided config in its `config_history.jsonl` artifact. If you use the API to edit the config, the edits are saved there. If you restart Azimuth (for example after shutting it down for the night), you can resume where you left off with:
 ```shell

--- a/webapp/server.js
+++ b/webapp/server.js
@@ -2,6 +2,9 @@
 const express = require("express");
 const app = express();
 const cors = require("cors");
+const fs = require("fs");
+const http = require("http");
+const https = require("https");
 const { createProxyMiddleware } = require("http-proxy-middleware");
 const path = require("path");
 
@@ -45,7 +48,16 @@ app.use((err, req, res, next) => {
 
 const port = process.env.PORT || 8080;
 
-app.server = app.listen(port);
+// We use `||` rather than `&&` so that if one env var is set but not the other (probably a mistake), we error out.
+if (process.env.HTTPS_KEY || process.env.HTTPS_CERT) {
+  const tls = {
+    key: fs.readFileSync(process.env.HTTPS_KEY),
+    cert: fs.readFileSync(process.env.HTTPS_CERT),
+  };
+  https.createServer(tls, app).listen(port);
+} else {
+  http.createServer(app).listen(port);
+}
 console.log(`
 API server listening on port ${port}
 Server PID: ${process.pid}


### PR DESCRIPTION
## Description:

* [Support serving the front end in HTTPS](https://github.com/ServiceNow/azimuth/pull/507/commits/f7ab2c7ea9362377c24c83d1d67287fa55cd359d)
* [Stop exposing the back end's port](https://github.com/ServiceNow/azimuth/pull/507/commits/39ad9c79d34c6207e51b42bf83de531a99299ec1) in `docker-compose.yml` and have the front end call the back end using Docker Compose's internal network. So, when using Docker Compose (`make launch`), the back-end API will only be accessible through the front-end proxy (for example, the Swagger UI will be at http://localhost:8080/api/local/docs). This way, if you use HTTPS to secure the front end (by setting env vars `HTTPS_KEY` and `HTTPS_CERT`), the back end will be secured too.

This will be an undocumented "beta" feature for now, until we use it a little bit and make sure it is useful in this state.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [ ] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
