### PR TITLE
Refactor ArtifactManager and restart TaskManager

### DIFF
--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -25,14 +25,13 @@ from starlette.status import (
 
 from azimuth.config import AzimuthConfig, load_azimuth_config
 from azimuth.dataset_split_manager import DatasetSplitManager
-from azimuth.modules.base_classes import DaskModule
+from azimuth.modules.base_classes import ArtifactManager, DaskModule
 from azimuth.startup import startup_tasks
 from azimuth.task_manager import TaskManager
 from azimuth.types import DatasetSplitName, ModuleOptions, SupportedModule
 from azimuth.utils.cluster import default_cluster
 from azimuth.utils.conversion import JSONResponseIgnoreNan
 from azimuth.utils.logs import set_logger_config
-from azimuth.utils.project import load_dataset_split_managers_from_config
 from azimuth.utils.validation import assert_not_none
 
 _dataset_split_managers: Dict[DatasetSplitName, Optional[DatasetSplitManager]] = {}
@@ -296,6 +295,32 @@ def create_app() -> FastAPI:
     return app
 
 
+def load_dataset_split_managers_from_config(
+    azimuth_config: AzimuthConfig,
+) -> Dict[DatasetSplitName, Optional[DatasetSplitManager]]:
+    """
+    Load all dataset splits for the application.
+
+    Args:
+        azimuth_config: Azimuth Configuration.
+
+    Returns:
+        For all DatasetSplitName, None or a dataset_split manager.
+
+    """
+    artifact_manager = ArtifactManager.instance()
+    dataset = artifact_manager.get_dataset_dict(azimuth_config)
+
+    return {
+        dataset_split_name: None
+        if dataset_split_name not in dataset
+        else artifact_manager.get_dataset_split_manager(
+            azimuth_config, DatasetSplitName[dataset_split_name]
+        )
+        for dataset_split_name in [DatasetSplitName.eval, DatasetSplitName.train]
+    }
+
+
 def initialize_managers(azimuth_config: AzimuthConfig, cluster: SpecCluster):
     """Initialize DatasetSplitManagers and TaskManagers.
 
@@ -346,7 +371,6 @@ def run_validation(
     else:
         for pipeline_index in range(len(config.pipelines)):
             run_validation_module(pipeline_index)
-    task_manager.clear_worker_cache()
 
 
 def run_startup_tasks(azimuth_config: AzimuthConfig, cluster: SpecCluster):

--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -358,6 +358,15 @@ class ModelContractConfig(CommonFieldsConfig):
             raise ValueError(f"Duplicated pipeline names {pipeline_names}.")
         return pipeline_definitions
 
+    def get_model_contract_hash(self):
+        return md5_hash(
+            self.dict(
+                include=ModelContractConfig.__fields__.keys()
+                - CommonFieldsConfig.__fields__.keys(),
+                by_alias=True,
+            )
+        )
+
 
 class MetricsConfig(ModelContractConfig):
     # Custom HuggingFace metrics

--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -359,6 +359,7 @@ class ModelContractConfig(CommonFieldsConfig):
         return pipeline_definitions
 
     def get_model_contract_hash(self):
+        """Hash for fields related to model contract only (excluding fields from the parents)."""
         return md5_hash(
             self.dict(
                 include=ModelContractConfig.__fields__.keys()

--- a/azimuth/modules/base_classes/artifact_manager.py
+++ b/azimuth/modules/base_classes/artifact_manager.py
@@ -67,7 +67,8 @@ class ArtifactManager:
     """This class is a singleton which holds different artifacts.
 
     Artifacts include dataset_split_managers, datasets and models for each config, so they don't
-    need to be reloaded many times for a same module.
+    need to be reloaded many times for a same module. Inspired from
+    https://stackoverflow.com/questions/31875/is-there-a-simple-elegant-way-to-define-singletons.
     """
 
     def __init__(self):

--- a/azimuth/modules/base_classes/module.py
+++ b/azimuth/modules/base_classes/module.py
@@ -79,7 +79,7 @@ class Module(DaskModule[ConfigScope]):
     def artifact_manager(self):
         """This is set as a property so the Module always have access to the current version of
         the ArtifactManager on the worker."""
-        return ArtifactManager.get_instance()
+        return ArtifactManager.instance()
 
     @property
     def available_dataset_splits(self) -> Set[DatasetSplitName]:
@@ -215,6 +215,3 @@ class Module(DaskModule[ConfigScope]):
         pipeline_index = assert_not_none(self.mod_options.pipeline_index)
         current_pipeline = pipelines[pipeline_index]
         return current_pipeline
-
-    def clear_cache(self):
-        self.artifact_manager.clear_cache()

--- a/azimuth/routers/config.py
+++ b/azimuth/routers/config.py
@@ -78,16 +78,19 @@ def patch_config(
         )
 
     try:
+        log.info(f"Validating config change with {partial_config}.")
         new_config = update_config(old_config=config, partial_config=partial_config)
         if attribute_changed_in_config("large_dask_cluster", partial_config, config):
             cluster = default_cluster(partial_config["large_dask_cluster"])
         else:
             cluster = task_manager.cluster
         run_startup_tasks(new_config, cluster)
+        log.info(f"Config successfully updated with {partial_config}.")
     except Exception as e:
         log.error("Rollback config update due to error", exc_info=e)
         new_config = config
         initialize_managers(new_config, task_manager.cluster)
+        log.info("Config update cancelled.")
         if isinstance(e, (AzimuthValidationError, ValidationError)):
             raise HTTPException(HTTP_400_BAD_REQUEST, detail=str(e))
         else:

--- a/azimuth/routers/config.py
+++ b/azimuth/routers/config.py
@@ -98,8 +98,6 @@ def patch_config(
                 HTTP_500_INTERNAL_SERVER_ERROR, detail="Error when loading the new config."
             )
 
-    # Clear workers so that they load the correct config.
-    task_manager.clear_worker_cache()
     return new_config
 
 

--- a/azimuth/routers/export.py
+++ b/azimuth/routers/export.py
@@ -5,7 +5,7 @@
 import os
 import time
 from os.path import join as pjoin
-from typing import Dict, Generator, List, Optional, cast
+from typing import Dict, Generator, List, Optional
 
 import pandas as pd
 from fastapi import APIRouter, Depends, HTTPException
@@ -155,7 +155,10 @@ def get_export_perturbed_set(
 
     output = list(
         make_utterance_level_result(
-            dataset_split_manager, task_result, pipeline_index=pipeline_index_not_null
+            dataset_split_manager,
+            task_result,
+            pipeline_index=pipeline_index_not_null,
+            config=config,
         )
     )
     with open(path, "w") as f:
@@ -164,7 +167,10 @@ def get_export_perturbed_set(
 
 
 def make_utterance_level_result(
-    dm: DatasetSplitManager, results: List[List[PerturbedUtteranceResult]], pipeline_index: int
+    dm: DatasetSplitManager,
+    results: List[List[PerturbedUtteranceResult]],
+    pipeline_index: int,
+    config: AzimuthConfig,
 ) -> Generator[Dict, None, None]:
     """Massage perturbation testing results for the frontend.
 
@@ -172,12 +178,12 @@ def make_utterance_level_result(
         dm: Current DatasetSplitManager.
         results: Output of Perturbation Testing.
         pipeline_index: Index of the pipeline that made the results.
+        config: Azimuth config
 
     Returns:
         Generator that yield json-able object for the frontend.
 
     """
-    config = cast(AzimuthConfig, dm.config)
     for idx, (utterance, test_results) in enumerate(
         zip(
             dm.get_dataset_split(

--- a/azimuth/routers/utterances.py
+++ b/azimuth/routers/utterances.py
@@ -229,7 +229,6 @@ def patch_utterances(
     utterances: List[UtterancePatch] = Body(...),
     config: AzimuthConfig = Depends(get_config),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
-    task_manager: TaskManager = Depends(get_task_manager),
     ignore_not_found: bool = Query(False),
 ) -> List[UtterancePatch]:
     if ignore_not_found:
@@ -250,7 +249,6 @@ def patch_utterances(
 
     dataset_split_manager.add_tags(data_actions)
 
-    task_manager.clear_worker_cache()
     updated_tags = dataset_split_manager.get_tags(row_indices)
 
     return [

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -257,12 +257,16 @@ def startup_tasks(
 
     mods = start_tasks_for_dms(config, dataset_split_managers, task_manager, start_up_tasks)
 
-    # Start a thread to monitor the status.
-    th = threading.Thread(
-        target=wait_for_startup, args=(mods, task_manager), name=START_UP_THREAD_NAME
-    )
-    th.setDaemon(True)
-    th.start()
+    startup_ready = all(m.done() for m in mods.values())
+    if startup_ready:
+        log.info("Loading the application from cache. It should be accessible now.")
+    else:
+        # Start a thread to monitor the status.
+        th = threading.Thread(
+            target=wait_for_startup, args=(mods, task_manager), name=START_UP_THREAD_NAME
+        )
+        th.setDaemon(True)
+        th.start()
 
     return mods
 
@@ -376,4 +380,3 @@ def wait_for_startup(startup_mods: Dict[str, DaskModule], task_manager: TaskMana
     task_manager.restart()
     # After restarting, it is safe to unlock the task manager.
     task_manager.unlock()
-    log.info("Cluster restarted to free memory.")

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -153,8 +153,6 @@ def on_end(fut: Future, module: DaskModule, dm: DatasetSplitManager, task_manage
         # Task is done, save the result.
         if isinstance(module, DatasetResultModule):
             module.save_result(module.result(), dm)
-            # We only need to clear cache when the dataset is modified.
-            task_manager.clear_worker_cache()
     else:
         log.exception("Error in", module=module, fut=fut, exc_info=fut.exception())
 

--- a/azimuth/task_manager.py
+++ b/azimuth/task_manager.py
@@ -7,7 +7,7 @@ import structlog
 from distributed import Client, SpecCluster
 
 from azimuth.config import AzimuthConfig
-from azimuth.modules.base_classes import ArtifactManager, DaskModule, ExpirableMixin
+from azimuth.modules.base_classes import DaskModule, ExpirableMixin
 from azimuth.modules.task_mapping import model_contract_methods, modules
 from azimuth.types import (
     DatasetSplitName,
@@ -66,7 +66,6 @@ class TaskManager:
                     mod.future.cancel()
                 except Exception:
                     pass
-        self.clear_worker_cache()
         self.client.close()
 
     def register_task(self, name, cls):
@@ -212,9 +211,6 @@ class TaskManager:
             "config": self.config.dict(),
             **self.get_all_tasks_status(task=None),
         }
-
-    def clear_worker_cache(self):
-        self.client.run(ArtifactManager.clear_cache)
 
     def restart(self):
         log.info("Cluster restarted to free memory.")

--- a/azimuth/task_manager.py
+++ b/azimuth/task_manager.py
@@ -217,6 +217,7 @@ class TaskManager:
         self.client.run(ArtifactManager.clear_cache)
 
     def restart(self):
-        # Clear futures to free memory.
+        log.info("Cluster restarted to free memory.")
         for task_name, module in self.current_tasks.items():
             module.future = None
+        self.client.restart()

--- a/azimuth/task_manager.py
+++ b/azimuth/task_manager.py
@@ -213,7 +213,7 @@ class TaskManager:
         }
 
     def restart(self):
-        log.info("Cluster restarted to free memory.")
         for task_name, module in self.current_tasks.items():
             module.future = None
         self.client.restart()
+        log.info("Cluster restarted to free memory.")

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -1,7 +1,7 @@
 # Copyright ServiceNow, Inc. 2021 – 2022
 # This source code is licensed under the Apache 2.0 license found in the LICENSE file
 # in the root directory of this source tree.
-from typing import Dict, Optional
+from typing import Dict
 
 import structlog
 from datasets import DatasetDict
@@ -12,9 +12,7 @@ from azimuth.config import (
     PerturbationTestingConfig,
     SimilarityConfig,
 )
-from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.types import DatasetSplitName, SupportedModelContract
-from azimuth.types.tag import ALL_PREDICTION_TAGS, ALL_STANDARD_TAGS
 from azimuth.utils.object_loader import load_custom_object
 
 log = structlog.get_logger()
@@ -57,38 +55,6 @@ def load_dataset_from_config(azimuth_config: AzimuthConfig) -> DatasetDict:
 
 def update_config(old_config: AzimuthConfig, partial_config: Dict) -> AzimuthConfig:
     return old_config.copy(update=partial_config, deep=True)
-
-
-def load_dataset_split_managers_from_config(
-    azimuth_config: AzimuthConfig,
-) -> Dict[DatasetSplitName, Optional[DatasetSplitManager]]:
-    """
-    Load all dataset splits for the application.
-
-    Args:
-        azimuth_config: Azimuth Configuration.
-
-    Returns:
-        For all DatasetSplitName, None or a dataset_split manager.
-
-    """
-    dataset = load_dataset_from_config(azimuth_config)
-
-    def make_dataset_split_manager(name: DatasetSplitName):
-        return DatasetSplitManager(
-            name=name,
-            config=azimuth_config,
-            initial_tags=ALL_STANDARD_TAGS,
-            initial_prediction_tags=ALL_PREDICTION_TAGS,
-            dataset_split=dataset[name],
-        )
-
-    return {
-        dataset_split_name: None
-        if dataset_split_name not in dataset
-        else make_dataset_split_manager(DatasetSplitName[dataset_split_name])
-        for dataset_split_name in [DatasetSplitName.eval, DatasetSplitName.train]
-    }
 
 
 def predictions_available(config: ModelContractConfig) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ from tests.utils import (
 @pytest.fixture(autouse=True, scope="function")
 def cleanup_class():
     yield
-    ArtifactManager.clear_cache()
+    ArtifactManager.clear_instance()
 
 
 def kill_scheduler(dask_scheduler=None):
@@ -42,7 +42,7 @@ def kill_scheduler(dask_scheduler=None):
 def cleanup_workers():
     import gc
 
-    ArtifactManager.clear_cache()
+    ArtifactManager.clear_instance()
     gc.collect()
 
 

--- a/tests/profiling_debugging.py
+++ b/tests/profiling_debugging.py
@@ -9,6 +9,7 @@ import psutil
 from pyinstrument import Profiler
 from tqdm import tqdm
 
+from azimuth.app import load_dataset_split_managers_from_config
 from azimuth.config import AzimuthConfig
 from azimuth.modules.base_classes import DatasetResultModule
 from azimuth.modules.model_performance.metrics import MetricsPerFilterModule
@@ -19,7 +20,6 @@ from azimuth.types import (
     SupportedMethod,
     SupportedModule,
 )
-from azimuth.utils.project import load_dataset_split_managers_from_config
 
 CFG_FILE = "../local_configs/development/clinc/conf.json"
 MODULE = MetricsPerFilterModule

--- a/tests/test_modules/conftest.py
+++ b/tests/test_modules/conftest.py
@@ -11,4 +11,4 @@ from azimuth.modules.base_classes import ArtifactManager
 def cleanup_class():
     yield
     # Code that will run after your test, for example:
-    ArtifactManager.clear_cache()
+    ArtifactManager.clear_instance()

--- a/tests/test_modules/test_artifact_manager.py
+++ b/tests/test_modules/test_artifact_manager.py
@@ -6,7 +6,7 @@ from azimuth.types import DatasetSplitName
 
 
 def test_artifact_manager(simple_text_config, file_text_config_top1):
-    am = ArtifactManager.get_instance()
+    am = ArtifactManager.instance()
 
     # ArtifactManager is empty
     assert len(am.dataset_dict_mapping) == 0
@@ -27,9 +27,8 @@ def test_artifact_manager(simple_text_config, file_text_config_top1):
         ].num_rows
     )
 
-    am.clear_cache()
-    new_am = ArtifactManager.get_instance()
-    assert len(new_am.dataset_dict_mapping) == 0
+    new_am = ArtifactManager.instance()
+    assert id(am) == id(new_am)
 
 
 def test_artifact_manager_from_module(simple_text_config, file_text_config_top1):
@@ -57,8 +56,3 @@ def test_artifact_manager_from_module(simple_text_config, file_text_config_top1)
     dm_mapping = mod.artifact_manager.dataset_split_managers_mapping
     assert len(dm_mapping) == 2
     assert len(dm_mapping[mod3.config.get_project_hash()]) == 1
-
-    # Clear cache in first module
-    mod.clear_cache()
-    # Assess the third module has a cleaned cache too
-    assert len(mod3.artifact_manager.dataset_split_managers_mapping) == 0

--- a/tests/test_modules/test_dataset_analysis/test_similarity_analysis.py
+++ b/tests/test_modules/test_dataset_analysis/test_similarity_analysis.py
@@ -6,6 +6,7 @@ import numpy as np
 from sklearn.preprocessing import normalize
 
 import azimuth.modules.dataset_analysis.similarity_analysis as faiss_mod
+from azimuth.app import load_dataset_split_managers_from_config
 from azimuth.dataset_split_manager import FEATURE_FAISS
 from azimuth.modules.dataset_analysis.similarity_analysis import NeighborsTaggingModule
 from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions
@@ -53,10 +54,10 @@ def test_neighbors(simple_text_config, dask_client, monkeypatch):
     assert any(mod.get_dataset_split()[SmartTag.conflicting_neighbors_eval])
     assert "neighbors_eval" in mod.get_dataset_split().column_names
     assert "no_close_train" in mod.get_dataset_split().column_names
-    mod.clear_cache()
 
     # Reloading the dataset_split, FAISS is still there.
-    ds = mod.get_dataset_split_manager().dataset_split_with_index(simple_table_key)
+    dm = load_dataset_split_managers_from_config(simple_text_config)[DatasetSplitName.eval]
+    ds = dm.dataset_split_with_index(simple_table_key)
     _ = ds.get_nearest_examples(FEATURE_FAISS, embd, k=5)
 
     # Confirm that module works with subset of indices

--- a/tests/test_modules/test_model_contracts/test_model_contract_module.py
+++ b/tests/test_modules/test_model_contracts/test_model_contract_module.py
@@ -256,7 +256,6 @@ def test_structured_output_text_classification(simple_text_config, model_contrac
     )
 
     preds = cast(List[PredictionResponse], mod.compute_on_dataset_split())
-    mod.clear_cache()
 
     ####
     # Postprocessing

--- a/tests/test_modules/test_module.py
+++ b/tests/test_modules/test_module.py
@@ -22,8 +22,6 @@ def test_ds_loading(simple_text_config):
 
     project_hash = mod.config.get_project_hash()
     assert len(mod.artifact_manager.dataset_split_managers_mapping[project_hash]) == 1
-    mod.clear_cache()
-    assert mod.artifact_manager.dataset_split_managers_mapping.get(project_hash) is None
 
 
 def test_model_loading(simple_text_config):
@@ -165,21 +163,23 @@ def my_dataset_fn(valid):
 
 
 def test_validation_priority(simple_text_config):
-    simple_text_config.dataset = CustomObject(
+    new_simple_text_config = simple_text_config.copy(deep=True)
+    new_simple_text_config.dataset = CustomObject(
         class_name="tests.test_modules.test_module.my_dataset_fn", kwargs={"valid": True}
     )
     mod = IndexableModule(
-        DatasetSplitName.eval, config=simple_text_config, mod_options=ModuleOptions(indices=[0, 1])
+        DatasetSplitName.eval,
+        config=new_simple_text_config,
+        mod_options=ModuleOptions(indices=[0, 1]),
     )
     ds = mod.get_dataset_split()
     assert ds["utterance"] == ["d", "e"]
 
     # Otherwise, we take validation
-    simple_text_config.dataset = CustomObject(
+    new_simple_text_config.dataset = CustomObject(
         class_name="tests.test_modules.test_module.my_dataset_fn", kwargs={"valid": False}
     )
-    mod.clear_cache()
-    mod = Module(DatasetSplitName.eval, config=simple_text_config)
+    mod = Module(DatasetSplitName.eval, config=new_simple_text_config)
     ds = mod.get_dataset_split()
     assert ds["utterance"] == ["h", "i", "j"]
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -6,7 +6,11 @@ from unittest.mock import Mock
 import pytest
 from datasets import Dataset, DatasetDict
 
-from azimuth.app import get_ready_flag, run_startup_tasks
+from azimuth.app import (
+    get_ready_flag,
+    load_dataset_split_managers_from_config,
+    run_startup_tasks,
+)
 from azimuth.config import CustomObject
 from azimuth.modules.model_contracts import HFTextClassificationModule
 from azimuth.startup import on_end, startup_tasks
@@ -16,7 +20,6 @@ from azimuth.types import (
     SupportedMethod,
     SupportedModule,
 )
-from azimuth.utils.project import load_dataset_split_managers_from_config
 from tests.utils import get_table_key, get_tiny_text_config_one_ds_name
 
 
@@ -66,7 +69,6 @@ def test_on_end(tiny_text_config):
     task_manager = Mock()
     on_end(mocked_fut, mod, dm=dms[DatasetSplitName.eval], task_manager=task_manager)
     mod.save_result.assert_called_once()
-    task_manager.clear_worker_cache.assert_called_once()
 
 
 def test_startup_task_one_ds(tiny_text_config_one_ds, tiny_text_task_manager):

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -8,7 +8,7 @@ import pytest
 
 from azimuth.config import SyntaxConfig
 from azimuth.modules.base_classes import AggregationModule, FilterableModule, Module
-from azimuth.task_manager import TaskManager, TaskManagerLockedException
+from azimuth.task_manager import TaskManagerLockedException
 from azimuth.types import (
     DatasetSplitName,
     ModuleOptions,
@@ -61,29 +61,6 @@ def get_module_data(simple_text_config):
         len(mod.artifact_manager.dataset_split_managers_mapping) > 0,
         len(mod.artifact_manager.models_mapping) > 0,
     )
-
-
-def test_clearing_cache(tiny_text_config):
-    task_manager = TaskManager(tiny_text_config)
-
-    key, mod = task_manager.get_task(
-        SupportedMethod.Predictions,
-        dataset_split_name=DatasetSplitName.eval,
-        mod_options=ModuleOptions(pipeline_index=0, indices=[0, 1]),
-    )
-    assert mod is not None
-    # The task can be awaited
-    mod.result()
-
-    # The cache is populated somewhere
-    cached = task_manager.client.run(get_module_data, tiny_text_config)
-    assert any([m and d for m, d in cached.values()])
-
-    task_manager.clear_worker_cache()
-
-    # The cache is cleared somewhere
-    cached = task_manager.client.run(get_module_data, tiny_text_config)
-    assert not any([m and d for m, d in cached.values()])
 
 
 def test_expired_task(tiny_text_task_manager, tiny_text_config):


### PR DESCRIPTION
Fixes #521 

## Description:
* `ArtifactManager` is now a real Singleton (1 per process). 3 are created -> 1 per worker and 1 in the main thread.
   * By extension, fewer DMs are created. Different tasks will access the same DM.
* The client is now restarted after the startup tasks. This empties the memory, creating new ArtifactManagers. This avoids that the pipeline and the sentence encoder are kept in memory after the startup.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
