### PR TITLE
Clean up `links` from Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       - "BEHAVIORAL_TESTING"
       - "SIMILARITY"
     volumes:
-    - ./config:/config
-    - ./azimuth_shr:/azimuth_shr
-    - ./cache:/cache
+      - ./config:/config
+      - ./azimuth_shr:/azimuth_shr
+      - ./cache:/cache
   web:
     image: "${REGISTRY}/azimuth-app:${FRONTEND_VERSION}"
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
       - ./server.js
     environment:
       - "PORT=8080"
+      - "REACT_APP_BACKEND_HOSTNAME=backend"
     ports:
       - "8080:8080"
-    links:
-      - backend:host.docker.internal

--- a/webapp/server.js
+++ b/webapp/server.js
@@ -20,9 +20,7 @@ app.use(cors(corsConfig));
 app.use(
   "/api/local",
   createProxyMiddleware({
-    pathRewrite: {
-      "^/api/[^/]+/": "/", // rewrite path
-    },
+    pathRewrite: { "^/api/[^/]+/": "/" },
     target: process.env.REACT_APP_BACKEND_PORT
       ? `http://host.docker.internal:${process.env.REACT_APP_BACKEND_PORT}`
       : "http://host.docker.internal:8091",

--- a/webapp/server.js
+++ b/webapp/server.js
@@ -21,9 +21,9 @@ app.use(
   "/api/local",
   createProxyMiddleware({
     pathRewrite: { "^/api/[^/]+/": "/" },
-    target: process.env.REACT_APP_BACKEND_PORT
-      ? `http://host.docker.internal:${process.env.REACT_APP_BACKEND_PORT}`
-      : "http://host.docker.internal:8091",
+    target: `http://${
+      process.env.REACT_APP_BACKEND_HOSTNAME || "host.docker.internal"
+    }:${process.env.REACT_APP_BACKEND_PORT || 8091}`,
     changeOrigin: true,
   })
 );


### PR DESCRIPTION
## Description:

Clean up `links` from Docker Compose (a deprecated feature) by calling `backend` directly, instead of `host.docker.internal`.

Also making two other trivial cleanup commits.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
