### PR TITLE
Don't block execution when waiting for startup tasks

### DIFF
--- a/azimuth/modules/base_classes/dask_module.py
+++ b/azimuth/modules/base_classes/dask_module.py
@@ -237,7 +237,7 @@ class DaskModule(HDF5CacheMixin, Generic[ConfigScope]):
         """Return the status of the future.
 
         Returns:
-            One of {'not_started', 'pending', 'lost', 'error', 'done'}.
+            One of {'not_started', 'pending', 'lost', 'error', 'finished'}.
             If the task was not launched, `not_started` will be returned by default.
         """
         if self.future:

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -338,9 +338,15 @@ def wait_for_startup(startup_mods: Dict[str, DaskModule], task_manager: TaskMana
                 continue
             last_per_status = per_status
 
-            log.info(f"Startup tasks statuses: {len(per_status['finished'])}/{len(startup_mods)}")
-            for status, modules in per_status.items():
-                log.info(f"{status} ({len(modules)}): {', '.join(modules)}")
+            logs = [
+                f"Startup tasks statuses: {len(per_status['finished'])}/{len(startup_mods)}",
+                *(
+                    f"{status} ({len(per_status[status])}): {', '.join(per_status[status])}"
+                    for status in ("not_started", "pending", "lost", "error", "saving", "finished")
+                    if status in per_status
+                ),
+            ]
+            log.info("\n\t".join(logs))
 
     thread_log_progress = threading.Thread(target=log_progress)
     thread_log_progress.start()

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -324,12 +324,11 @@ def wait_for_startup(startup_mods: Dict[str, DaskModule], task_manager: TaskMana
     task_manager.lock()  # Lock the TaskManager to prevent new tasks.
     while not all(m.done() for m in startup_mods.values()):
         time.sleep(30)  # We wait to not spam the user with logs.
-        is_done = {k: v.done() for k, v in startup_mods.items()}
         per_status = defaultdict(list)
         for name, mod in startup_mods.items():
             status = "saving" if mod.status() == "finished" and not mod.done() else mod.status()
             per_status[status].append(name)
-        log.info(f"Startup tasks statuses: {sum(is_done.values())}/{len(is_done)}")
+        log.info(f"Startup tasks statuses: {len(per_status['finished'])}/{len(startup_mods)}")
         for status, modules in per_status.items():
             log.info(f"{status} ({len(modules)}): {', '.join(modules)}")
 

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -326,7 +326,7 @@ def wait_for_startup(startup_mods: Dict[str, DaskModule], task_manager: TaskMana
     done = False
 
     def log_progress():
-        last_per_status: Dict[str, List[str]] = {}
+        last_per_status = None
         while not done:
             time.sleep(5)  # to avoid spamming the user with logs.
             per_status = defaultdict(list)
@@ -371,5 +371,3 @@ def wait_for_startup(startup_mods: Dict[str, DaskModule], task_manager: TaskMana
     # After restarting, it is safe to unlock the task manager.
     task_manager.unlock()
     log.info("Cluster restarted to free memory.")
-
-    thread_log_progress.join()

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -348,7 +348,7 @@ def wait_for_startup(startup_mods: Dict[str, DaskModule], task_manager: TaskMana
             ]
             log.info("\n\t".join(logs))
 
-    thread_log_progress = threading.Thread(target=log_progress)
+    thread_log_progress = threading.Thread(target=log_progress, daemon=True)
     thread_log_progress.start()
     for mod in startup_mods.values():
         mod.result()


### PR DESCRIPTION
## Description:

* [Avoid checking `.done()` twice](https://github.com/ServiceNow/azimuth/pull/547/commits/1c7d7070d307971b8312889d130329d4ea028797)
* [**Check** for startup status a lot more frequently](https://github.com/ServiceNow/azimuth/pull/547/commits/41c081dfcbba15fbeee7d6896864e75c52806485) and **log** status updates only when there are some changes (to avoid spamming the user with logs).
* [Log progress in a separate thread](https://github.com/ServiceNow/azimuth/pull/547/commits/817524fb6ef0a99db4cb3e299c11d1e3915005ac)
* [Always log statuses in the same (logical) order](https://github.com/ServiceNow/azimuth/pull/547/commits/6d242fb5e8d071807164ab1056ad103db52b770a) and in one multiline log to make sure no logs from other processes get inserted in between.

<img width="1414" alt="image" src="https://user-images.githubusercontent.com/8386369/232520268-6035d004-fdfd-46cb-86db-48d0ec59050c.png">


## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
