### PR TITLE
Open utterance details in a modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Released changes are shown in the
 - Meaningful error messages in the error toasts.
 
 ### Changed
+- When clicking on an utterance from the Exploration space's Utterance Table, the Utterance Details now open in a modal on top of the table. This preserves the filter context and allows for going through the utterances one by one, using some new arrow buttons or keyboard arrows.
 
 ### Deprecated/Breaking Changes
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -34,4 +34,4 @@ def test_dataset_processing_speed(simple_text_config):
         config=simple_text_config,
     )
     stop = time.perf_counter()
-    assert (stop - start) <= 0.0002
+    assert (stop - start) <= 0.0003

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,11 +1,3 @@
-import React from "react";
-import {
-  BrowserRouter as Router,
-  Redirect,
-  Route,
-  Switch,
-  useParams,
-} from "react-router-dom";
 import { CssBaseline } from "@mui/material";
 import {
   StyledEngineProvider,
@@ -14,26 +6,34 @@ import {
 } from "@mui/material/styles";
 import AppLayout from "components/AppLayout";
 import BasicLayout from "components/BasicLayout";
-import PageHeader from "components/PageHeader";
-import WarningsOverview from "pages/WarningsOverview";
-import UtteranceDetail from "pages/UtteranceDetail";
-import customTheme, { GlobalCss } from "styles/theme";
 import ErrorBoundary from "components/ErrorBoundary";
-import "react-toastify/dist/ReactToastify.css";
-import { ToastContainer } from "react-toastify";
-import StatusCheck from "components/StatusCheck";
+import PageHeader from "components/PageHeader";
 import PipelineCheck from "components/PipelineCheck";
-import store from "store";
-import { Provider } from "react-redux";
+import StatusCheck from "components/StatusCheck";
+import ClassOverlap from "pages/ClassOverlap";
 import Dashboard from "pages/Dashboard";
-import PerformanceAnalysis from "pages/PerformanceAnalysis";
-import PerturbationTestingSummary from "pages/PerturbationTestingSummary";
-import Threshold from "pages/Threshold";
-import { DatasetSplitName } from "types/api";
 import Exploration from "pages/Exploration";
 import NotFound from "pages/NotFound";
-import ClassOverlap from "pages/ClassOverlap";
+import PerformanceAnalysis from "pages/PerformanceAnalysis";
+import PerturbationTestingSummary from "pages/PerturbationTestingSummary";
 import SmartTags from "pages/SmartTags";
+import Threshold from "pages/Threshold";
+import UtteranceDetails from "pages/UtteranceDetails";
+import WarningsOverview from "pages/WarningsOverview";
+import React from "react";
+import { Provider } from "react-redux";
+import {
+  BrowserRouter as Router,
+  Redirect,
+  Route,
+  Switch,
+  useParams,
+} from "react-router-dom";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import store from "store";
+import customTheme, { GlobalCss } from "styles/theme";
+import { DatasetSplitName } from "types/api";
 
 declare module "@mui/styles/defaultTheme" {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -144,7 +144,7 @@ export default class App extends React.Component<Props> {
                               exact
                             >
                               <BasicLayout>
-                                <UtteranceDetail />
+                                <UtteranceDetails />
                               </BasicLayout>
                             </Route>
                             <Route>

--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -222,34 +222,18 @@ const UtterancesTable: React.FC<Props> = ({
         })
       : "";
 
-  const handlePageChange = (page: number) => {
-    const q = constructSearchString({
-      ...confusionMatrix,
-      ...filters,
-      ...pagination,
-      ...pipeline,
-      ...postprocessing,
-      page: page + 1,
-    });
-    history.push(`/${jobId}/dataset_splits/${datasetSplitName}/utterances${q}`);
-  };
+  const handlePageChange = (page: number) =>
+    history.push(getUpdatedLocation({ page: page + 1 }));
 
   const handleSortModelChange = ([model]:
     | GridSortItem[]
     | [GridSortItem]
     | []) =>
     history.push(
-      `/${jobId}/dataset_splits/${datasetSplitName}/utterances${constructSearchString(
-        {
-          ...confusionMatrix,
-          ...filters,
-          ...pagination,
-          ...pipeline,
-          ...postprocessing,
-          sort: model?.field as UtterancesSortableColumn | undefined,
-          descending: model?.sort === "desc" || undefined,
-        }
-      )}`
+      getUpdatedLocation({
+        sort: model?.field as UtterancesSortableColumn | undefined,
+        descending: model?.sort === "desc" || undefined,
+      })
     );
 
   const toCloseDetails = getUpdatedLocation({ details: undefined });

--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -1,8 +1,25 @@
-import { ArrowDropDown, GetApp, SvgIconComponent } from "@mui/icons-material";
+import {
+  ArrowDropDown,
+  Close,
+  Fullscreen,
+  GetApp,
+  SvgIconComponent,
+} from "@mui/icons-material";
 import FilterAltOutlinedIcon from "@mui/icons-material/FilterAltOutlined";
 import MultilineChartIcon from "@mui/icons-material/MultilineChart";
 import UploadIcon from "@mui/icons-material/Upload";
-import { Box, Button, Menu, MenuItem } from "@mui/material";
+import {
+  Box,
+  Button,
+  Dialog,
+  dialogClasses,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Menu,
+  MenuItem,
+} from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import {
   GridCellParams,
@@ -16,10 +33,12 @@ import CopyButton from "components/CopyButton";
 import Description from "components/Description";
 import OutcomeIcon from "components/Icons/OutcomeIcon";
 import TargetIcon from "components/Icons/Target";
+import Loading from "components/Loading";
 import SmartTagFamilyBadge from "components/SmartTagFamilyBadge";
 import { Column, RowProps, Table } from "components/Table";
 import UtteranceDataAction from "components/Utterance/UtteranceDataAction";
 import UtteranceSaliency from "components/Utterance/UtteranceSaliency";
+import UtteranceDetails from "components/UtteranceDetails";
 import React from "react";
 import { Link, useHistory } from "react-router-dom";
 import {
@@ -37,10 +56,12 @@ import {
 } from "types/api";
 import {
   QueryConfusionMatrixState,
+  QueryDetailsState,
   QueryFilterState,
   QueryPaginationState,
   QueryPipelineState,
   QueryPostprocessingState,
+  QueryState,
 } from "types/models";
 import {
   downloadDatasetSplit,
@@ -51,6 +72,7 @@ import {
   ID_TOOLTIP,
   PAGE_SIZE,
   SMART_TAG_FAMILIES,
+  UNKNOWN_ERROR,
 } from "utils/const";
 import { formatRatioAsPercentageString } from "utils/format";
 import { getUtteranceIdTooltip } from "utils/getUtteranceIdTooltip";
@@ -117,6 +139,7 @@ type Props = {
   datasetInfo?: DatasetInfoResponse;
   datasetSplitName: DatasetSplitName;
   confusionMatrix: QueryConfusionMatrixState;
+  details: QueryDetailsState;
   filters: QueryFilterState;
   pagination: QueryPaginationState;
   pipeline: QueryPipelineState;
@@ -128,6 +151,7 @@ const UtterancesTable: React.FC<Props> = ({
   datasetInfo,
   datasetSplitName,
   confusionMatrix,
+  details,
   filters,
   pagination,
   pipeline,
@@ -137,6 +161,7 @@ const UtterancesTable: React.FC<Props> = ({
   const classes = useStyles();
 
   const { page = 1, sort, descending } = pagination;
+  const offset = (page - 1) * PAGE_SIZE;
 
   const getUtterancesQueryState = {
     jobId,
@@ -145,13 +170,16 @@ const UtterancesTable: React.FC<Props> = ({
     sort,
     descending,
     limit: PAGE_SIZE,
-    offset: (page - 1) * PAGE_SIZE,
+    offset,
     ...pipeline,
     ...postprocessing,
   };
 
-  const { data: utterancesResponse, isFetching } =
-    getUtterancesEndpoint.useQuery(getUtterancesQueryState);
+  const {
+    data: utterancesResponse,
+    isFetching,
+    error,
+  } = getUtterancesEndpoint.useQuery(getUtterancesQueryState);
 
   const [updateDataAction] = updateDataActionsEndpoint.useMutation();
 
@@ -173,6 +201,26 @@ const UtterancesTable: React.FC<Props> = ({
 
   // If config was undefined, PipelineCheck would not even render the page.
   if (config === undefined) return null;
+
+  const getUpdatedLocation = (update: Partial<QueryState>) =>
+    `/${jobId}/dataset_splits/${datasetSplitName}/utterances${constructSearchString(
+      {
+        ...confusionMatrix,
+        ...filters,
+        ...pagination,
+        ...pipeline,
+        ...postprocessing,
+        ...update,
+      }
+    )}`;
+
+  const getToDetails = (i: number) =>
+    0 <= i && i < utterancesResponse!.utteranceCount
+      ? getUpdatedLocation({
+          details: i % PAGE_SIZE,
+          page: Math.floor(i / PAGE_SIZE) + 1,
+        })
+      : "";
 
   const handlePageChange = (page: number) => {
     const q = constructSearchString({
@@ -203,6 +251,10 @@ const UtterancesTable: React.FC<Props> = ({
         }
       )}`
     );
+
+  const toCloseDetails = getUpdatedLocation({ details: undefined });
+
+  const handleCloseDetails = () => history.push(toCloseDetails);
 
   const smartTagFamilies = isPipelineSelected(pipeline)
     ? SMART_TAG_FAMILIES
@@ -399,8 +451,6 @@ const UtterancesTable: React.FC<Props> = ({
     },
   ];
 
-  const searchString = constructSearchString(pipeline);
-
   const importProposedActions = (file: File) => {
     const fileReader = new FileReader();
     fileReader.onload = ({ target }) => {
@@ -435,7 +485,7 @@ const UtterancesTable: React.FC<Props> = ({
   const RowLink = (props: RowProps<Row>) => (
     <Link
       style={{ color: "unset", textDecoration: "unset" }}
-      to={`/${jobId}/dataset_splits/${datasetSplitName}/utterances/${props.row.index}${searchString}`}
+      to={getUpdatedLocation({ details: props.index })}
     >
       <GridRow {...props} />
     </Link>
@@ -509,6 +559,7 @@ const UtterancesTable: React.FC<Props> = ({
       <Table
         pagination
         loading={isFetching}
+        error={error}
         rows={rows}
         columns={columns}
         columnVisibilityModel={
@@ -546,6 +597,65 @@ const UtterancesTable: React.FC<Props> = ({
           },
         }}
       />
+      <Dialog
+        open={details.details !== undefined}
+        onClose={handleCloseDetails}
+        maxWidth="xl"
+        fullWidth
+        sx={{ [`& .${dialogClasses.paper}`]: { height: "inherit" } }} // the equivalent of fullWidth, but for height
+      >
+        <DialogTitle>
+          Utterance Details
+          <Box
+            position="absolute"
+            right={(theme) => theme.spacing(2)}
+            top={(theme) => theme.spacing(2)}
+          >
+            {!isFetching &&
+              utterancesResponse &&
+              details.details !== undefined &&
+              details.details in utterancesResponse.utterances && (
+                <IconButton
+                  size="small"
+                  component={Link}
+                  to={`/${jobId}/dataset_splits/${datasetSplitName}/utterances/${
+                    utterancesResponse.utterances[details.details].index
+                  }${constructSearchString(pipeline)}`}
+                >
+                  <Fullscreen />
+                </IconButton>
+              )}
+            <IconButton size="small" component={Link} to={toCloseDetails}>
+              <Close />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          {details.details !== undefined &&
+            (isFetching ? (
+              <Loading />
+            ) : utterancesResponse === undefined ? (
+              <DialogContentText>
+                {error?.message || UNKNOWN_ERROR}
+              </DialogContentText>
+            ) : !(details.details in utterancesResponse.utterances) ? (
+              <DialogContentText>Invalid URL</DialogContentText>
+            ) : (
+              <UtteranceDetails
+                jobId={jobId}
+                index={utterancesResponse.utterances[details.details].index}
+                datasetSplitName={datasetSplitName}
+                getUtterancesQueryState={getUtterancesQueryState}
+                utterance={utterancesResponse.utterances[details.details]}
+                confidenceThreshold={utterancesResponse.confidenceThreshold}
+                arrows={{
+                  toPrevious: getToDetails(offset + details.details - 1),
+                  toNext: getToDetails(offset + details.details + 1),
+                }}
+              />
+            ))}
+        </DialogContent>
+      </Dialog>
     </Box>
   );
 };

--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -162,6 +162,7 @@ const UtterancesTable: React.FC<Props> = ({
 
   const { page = 1, sort, descending } = pagination;
   const offset = (page - 1) * PAGE_SIZE;
+  const { detailsForPageItem } = details;
 
   const getUtterancesQueryState = {
     jobId,
@@ -217,7 +218,7 @@ const UtterancesTable: React.FC<Props> = ({
   const getToDetails = (i: number) =>
     0 <= i && i < utterancesResponse!.utteranceCount
       ? getUpdatedLocation({
-          details: i % PAGE_SIZE,
+          detailsForPageItem: i % PAGE_SIZE,
           page: Math.floor(i / PAGE_SIZE) + 1,
         })
       : "";
@@ -236,7 +237,7 @@ const UtterancesTable: React.FC<Props> = ({
       })
     );
 
-  const toCloseDetails = getUpdatedLocation({ details: undefined });
+  const toCloseDetails = getUpdatedLocation({ detailsForPageItem: undefined });
 
   const handleCloseDetails = () => history.push(toCloseDetails);
 
@@ -469,7 +470,7 @@ const UtterancesTable: React.FC<Props> = ({
   const RowLink = (props: RowProps<Row>) => (
     <Link
       style={{ color: "unset", textDecoration: "unset" }}
-      to={getUpdatedLocation({ details: props.index })}
+      to={getUpdatedLocation({ detailsForPageItem: props.index })}
     >
       <GridRow {...props} />
     </Link>
@@ -582,7 +583,7 @@ const UtterancesTable: React.FC<Props> = ({
         }}
       />
       <Dialog
-        open={details.details !== undefined}
+        open={detailsForPageItem !== undefined}
         onClose={handleCloseDetails}
         maxWidth="xl"
         fullWidth
@@ -597,13 +598,13 @@ const UtterancesTable: React.FC<Props> = ({
           >
             {!isFetching &&
               utterancesResponse &&
-              details.details !== undefined &&
-              details.details in utterancesResponse.utterances && (
+              detailsForPageItem !== undefined &&
+              detailsForPageItem in utterancesResponse.utterances && (
                 <IconButton
                   size="small"
                   component={Link}
                   to={`/${jobId}/dataset_splits/${datasetSplitName}/utterances/${
-                    utterancesResponse.utterances[details.details].index
+                    utterancesResponse.utterances[detailsForPageItem].index
                   }${constructSearchString(pipeline)}`}
                 >
                   <Fullscreen />
@@ -615,26 +616,26 @@ const UtterancesTable: React.FC<Props> = ({
           </Box>
         </DialogTitle>
         <DialogContent>
-          {details.details !== undefined &&
+          {detailsForPageItem !== undefined &&
             (isFetching ? (
               <Loading />
             ) : utterancesResponse === undefined ? (
               <DialogContentText>
                 {error?.message || UNKNOWN_ERROR}
               </DialogContentText>
-            ) : !(details.details in utterancesResponse.utterances) ? (
+            ) : !(detailsForPageItem in utterancesResponse.utterances) ? (
               <DialogContentText>Invalid URL</DialogContentText>
             ) : (
               <UtteranceDetails
                 jobId={jobId}
-                index={utterancesResponse.utterances[details.details].index}
+                index={utterancesResponse.utterances[detailsForPageItem].index}
                 datasetSplitName={datasetSplitName}
                 getUtterancesQueryState={getUtterancesQueryState}
-                utterance={utterancesResponse.utterances[details.details]}
+                utterance={utterancesResponse.utterances[detailsForPageItem]}
                 confidenceThreshold={utterancesResponse.confidenceThreshold}
                 arrows={{
-                  toPrevious: getToDetails(offset + details.details - 1),
-                  toNext: getToDetails(offset + details.details + 1),
+                  toPrevious: getToDetails(offset + detailsForPageItem - 1),
+                  toNext: getToDetails(offset + detailsForPageItem + 1),
                 }}
               />
             ))}

--- a/webapp/src/components/NoMaxWidthTooltip.tsx
+++ b/webapp/src/components/NoMaxWidthTooltip.tsx
@@ -1,0 +1,12 @@
+import { TooltipProps, Tooltip, tooltipClasses, styled } from "@mui/material";
+
+// From https://mui.com/material-ui/react-tooltip/#variable-width
+const NoMaxWidthTooltip = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))({
+  [`& .${tooltipClasses.tooltip}`]: {
+    maxWidth: "none",
+  },
+});
+
+export default NoMaxWidthTooltip;

--- a/webapp/src/components/Utterance/SimilarUtterances.tsx
+++ b/webapp/src/components/Utterance/SimilarUtterances.tsx
@@ -36,6 +36,7 @@ type Props = {
   baseUtterance: Utterance;
   persistentIdColumn: string;
   pipeline: QueryPipelineState;
+  loading: boolean;
   utterances: SimilarUtterance[];
 };
 
@@ -44,6 +45,7 @@ const SimilarUtterances: React.FC<Props> = ({
   baseUtterance,
   persistentIdColumn,
   pipeline,
+  loading,
   utterances,
 }) => {
   const classes = useStyles();
@@ -169,6 +171,7 @@ const SimilarUtterances: React.FC<Props> = ({
 
   return (
     <Table
+      loading={loading}
       rows={rows}
       columns={columns}
       columnVisibilityModel={

--- a/webapp/src/pages/Exploration.tsx
+++ b/webapp/src/pages/Exploration.tsx
@@ -49,6 +49,7 @@ const Exploration = () => {
 
   const {
     confusionMatrix,
+    details,
     filters,
     pagination,
     pipeline,
@@ -166,6 +167,7 @@ const Exploration = () => {
                 datasetInfo={datasetInfo}
                 datasetSplitName={datasetSplitName}
                 confusionMatrix={confusionMatrix}
+                details={details}
                 filters={filters}
                 pagination={pagination}
                 pipeline={pipeline}

--- a/webapp/src/pages/UtteranceDetails.tsx
+++ b/webapp/src/pages/UtteranceDetails.tsx
@@ -1,0 +1,50 @@
+import { Box, Typography } from "@mui/material";
+import noData from "assets/void.svg";
+import Loading from "components/Loading";
+import UtteranceDetails from "components/UtteranceDetails";
+import useQueryState from "hooks/useQueryState";
+import React from "react";
+import { useParams } from "react-router-dom";
+import { getUtterancesEndpoint } from "services/api";
+import { DatasetSplitName } from "types/api";
+import { UNKNOWN_ERROR } from "utils/const";
+
+const UtteranceDetailsPage = () => {
+  const { jobId, utteranceId, datasetSplitName } = useParams<{
+    jobId: string;
+    utteranceId: string;
+    datasetSplitName: DatasetSplitName;
+  }>();
+  const index = Number(utteranceId);
+  const { pipeline } = useQueryState();
+
+  const query = { jobId, datasetSplitName, indices: [index], ...pipeline };
+
+  const { data, isFetching, error } = getUtterancesEndpoint.useQuery(query);
+
+  // data will be defined while it isFetching after updating the
+  // dataAction tag, in which case we want to render the utterance.
+  if (data === undefined) {
+    return isFetching ? (
+      <Loading />
+    ) : (
+      <Box alignItems="center" display="grid" justifyItems="center">
+        <img src={noData} width="50%" alt="error" />
+        <Typography>{error?.message || UNKNOWN_ERROR}</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <UtteranceDetails
+      jobId={jobId}
+      index={index}
+      datasetSplitName={datasetSplitName}
+      getUtterancesQueryState={query}
+      utterance={data.utterances[0]}
+      confidenceThreshold={data.confidenceThreshold}
+    />
+  );
+};
+
+export default React.memo(UtteranceDetailsPage);

--- a/webapp/src/types/models.ts
+++ b/webapp/src/types/models.ts
@@ -12,7 +12,7 @@ export type QueryClassOverlapState = {
 };
 
 export type QueryDetailsState = {
-  details?: number;
+  detailsForPageItem?: number;
 };
 
 export type QueryArrayFiltersState = {

--- a/webapp/src/types/models.ts
+++ b/webapp/src/types/models.ts
@@ -11,6 +11,10 @@ export type QueryClassOverlapState = {
   overlapThreshold?: number;
 };
 
+export type QueryDetailsState = {
+  details?: number;
+};
+
 export type QueryArrayFiltersState = {
   label?: string[];
   prediction?: string[];
@@ -51,6 +55,7 @@ export type QueryConfusionMatrixState = {
 };
 
 export type QueryState = QueryClassOverlapState &
+  QueryDetailsState &
   QueryFilterState &
   QueryPaginationState &
   QueryPipelineState &

--- a/webapp/src/utils/helpers.ts
+++ b/webapp/src/utils/helpers.ts
@@ -9,6 +9,7 @@ import {
   QueryPostprocessingState,
   QueryState,
   QueryConfusionMatrixState,
+  QueryDetailsState,
 } from "types/models";
 
 export const classNames = (...args: any[]) => args.filter(Boolean).join(" ");
@@ -51,6 +52,9 @@ export const parseSearchString = (searchString: string) => {
     confusionMatrix: convertSearchParams<QueryConfusionMatrixState>(q, {
       normalize: (s) => s === null && undefined,
       reorderClasses: (s) => s === null && undefined,
+    }),
+    details: convertSearchParams<QueryDetailsState>(q, {
+      details: convertNumber,
     }),
     filters: convertSearchParams<QueryFilterState>(q, {
       confidenceMin: convertNumber,

--- a/webapp/src/utils/helpers.ts
+++ b/webapp/src/utils/helpers.ts
@@ -54,7 +54,7 @@ export const parseSearchString = (searchString: string) => {
       reorderClasses: (s) => s === null && undefined,
     }),
     details: convertSearchParams<QueryDetailsState>(q, {
-      details: convertNumber,
+      detailsForPageItem: convertNumber,
     }),
     filters: convertSearchParams<QueryFilterState>(q, {
       confidenceMin: convertNumber,


### PR DESCRIPTION
## Description:

When clicking on an utterance from the Exploration space's Utterance Table, the Utterance Details now open in a modal on top of the table. This preserves the filter context and allows for going through the utterances one by one, using some new arrow buttons or keyboard arrows.

Try it [here](https://snow-azimuth-app_utterance_detail_modal.job.console.elementai.com/snow-azimuth-clinc150-8091/dataset_splits/eval/utterances?outcome=IncorrectAndRejected&page=1&sort=confidence&pipeline_index=0).

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
