### PR TITLE
Return plain text errors

### DIFF
--- a/tests/test_routers/test_app.py
+++ b/tests/test_routers/test_app.py
@@ -78,7 +78,7 @@ def test_validation_error(app: FastAPI):
 
     resp = client.get("/dataset_splits/c/utterances?outcome=a&outcome=b&sort=d&pipeline_index=0")
     assert resp.status_code == HTTP_404_NOT_FOUND, resp.text
-    assert resp.json()["detail"] == (
+    assert resp.text == (
         f"query parameter outcome=a: {get_enum_validation_error_msg(OutcomeName)}\n"
         f"query parameter outcome=b: {get_enum_validation_error_msg(OutcomeName)}\n"
         f"path parameter dataset_split_name=c: {get_enum_validation_error_msg(DatasetSplitName)}\n"

--- a/tests/test_routers/test_config.py
+++ b/tests/test_routers/test_config.py
@@ -256,7 +256,7 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
     # Config Validation Error
     resp = client.patch("/config", json={"model_contract": "potato"})
     assert resp.status_code == HTTP_400_BAD_REQUEST, resp.text
-    assert resp.json()["detail"] == (
+    assert resp.text == (
         f"AzimuthConfig['model_contract']: {get_enum_validation_error_msg(SupportedModelContract)}"
     )
     get_config = client.get("/config").json()

--- a/tests/test_routers/test_export.py
+++ b/tests/test_routers/test_export.py
@@ -21,11 +21,11 @@ def test_get_report(app: FastAPI) -> None:
 
     resp = client.get("/export/perturbation_testing_summary")
     assert resp.status_code == HTTP_400_BAD_REQUEST, resp.text
-    assert resp.json()["detail"] == "query parameter pipeline_index: field required"
+    assert resp.text == "query parameter pipeline_index: field required"
 
     resp = client.get("/export/perturbation_testing_summary?pipeline_index=-10")
     assert resp.status_code == HTTP_400_BAD_REQUEST, resp.text
-    assert resp.json()["detail"] == (
+    assert resp.text == (
         "query parameter pipeline_index=-10: ensure this value is greater than or equal to 0"
     )
 

--- a/tests/test_routers/test_model_performance/test_outcome_count.py
+++ b/tests/test_routers/test_model_performance/test_outcome_count.py
@@ -12,7 +12,7 @@ def test_get_outcome_count_per_threshold(app: FastAPI) -> None:
 
     resp = client.get("/dataset_splits/eval/outcome_count/per_threshold?pipeline_index=0")
     assert resp.status_code == HTTP_400_BAD_REQUEST, resp.text
-    assert resp.json()["detail"] == "Postprocessing is not editable"
+    assert resp.text == "Postprocessing is not editable"
 
 
 def test_get_outcome_count_per_filter(app: FastAPI) -> None:

--- a/tests/test_routers/test_utterances.py
+++ b/tests/test_routers/test_utterances.py
@@ -106,15 +106,11 @@ def test_get_utterances_pagination(app: FastAPI):
 
     resp = client.get("/dataset_splits/eval/utterances?limit=0&offset=0")
     assert resp.status_code == HTTP_400_BAD_REQUEST, resp.text
-    assert resp.json()["detail"] == (
-        "query parameter limit=0: ensure this value is greater than or equal to 1"
-    )
+    assert resp.text == "query parameter limit=0: ensure this value is greater than or equal to 1"
 
     resp = client.get("/dataset_splits/eval/utterances?limit=10&offset=-1")
     assert resp.status_code == HTTP_400_BAD_REQUEST, resp.text
-    assert resp.json()["detail"] == (
-        "query parameter offset=-1: ensure this value is greater than or equal to 0"
-    )
+    assert resp.text == "query parameter offset=-1: ensure this value is greater than or equal to 0"
 
     resp = client.get("/dataset_splits/eval/utterances?limit=10&offset=10").json()
     assert len(resp["utterances"]) == 10
@@ -214,7 +210,7 @@ def test_patch_utterances(app: FastAPI) -> None:
     request = [{"dataAction": "potato"}]
     resp = client.patch("/dataset_splits/eval/utterances", json=request)
     assert resp.status_code == HTTP_400_BAD_REQUEST, resp.text
-    assert resp.json()["detail"] == (
+    assert resp.text == (
         "Request['body'][0]['persistentId']: field required\n"
         f"Request['body'][0]['dataAction']: {get_enum_validation_error_msg(DataAction)}"
     )

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -42,7 +42,6 @@ export type DatasetWarningGroup = components["schemas"]["DatasetWarningGroup"];
 export type FormatType = components["schemas"]["FormatType"];
 export type GetUtterancesResponse =
   components["schemas"]["GetUtterancesResponse"];
-export type HTTPExceptionModel = components["schemas"]["HTTPExceptionModel"];
 export type MetricInfo = components["schemas"]["MetricInfo"];
 export type MetricsPerFilterAPIResponse =
   components["schemas"]["MetricsPerFilterAPIResponse"];

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -356,9 +356,6 @@ export interface components {
       utteranceCount: number;
       confidenceThreshold: number | null;
     };
-    HTTPExceptionModel: {
-      detail: string;
-    };
     /**
      * Base class for settings, allowing values to be overridden by environment variables.
      *
@@ -907,43 +904,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -960,43 +957,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1015,43 +1012,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1073,43 +1070,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1131,43 +1128,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1184,43 +1181,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1237,43 +1234,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1308,43 +1305,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1369,43 +1366,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1445,43 +1442,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1498,43 +1495,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1574,43 +1571,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1635,43 +1632,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1696,43 +1693,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1772,43 +1769,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1846,43 +1843,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1927,43 +1924,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -1988,43 +1985,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2055,43 +2052,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2119,43 +2116,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2176,43 +2173,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2230,43 +2227,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2284,43 +2281,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2341,43 +2338,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2399,43 +2396,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2458,43 +2455,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2534,43 +2531,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };
@@ -2612,43 +2609,43 @@ export interface operations {
       /** Bad Request */
       400: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unauthorized */
       401: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Forbidden */
       403: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Not Found */
       404: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Unprocessable Entity */
       422: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Internal Server Error */
       500: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
       /** Service Unavailable */
       503: {
         content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
+          "text/plain": string;
         };
       };
     };

--- a/webapp/src/utils/api.ts
+++ b/webapp/src/utils/api.ts
@@ -1,8 +1,5 @@
-import { HTTPExceptionModel } from "types/api";
 import { paths } from "types/generated/generatedTypes";
 import { constructApiSearchString } from "./helpers";
-
-const HTTP_EXCEPTION_STATUS_CODES = [400, 401, 403, 404, 422, 500, 503];
 
 type CamelCase<SnakeCase> = SnakeCase extends `${infer FirstWord}_${infer Rest}`
   ? `${FirstWord}${Capitalize<CamelCase<Rest>>}`
@@ -91,12 +88,7 @@ export const fetchApi =
     // fetch() might throw if the user is offline, or some unlikely networking error occurs, such a DNS lookup failure.
     // Let's also throw if the status is not OK, so it's uniform.
     if (!response.ok) {
-      if (HTTP_EXCEPTION_STATUS_CODES.includes(response.status)) {
-        const { detail } = (await response.json()) as HTTPExceptionModel;
-        throw Error(detail);
-      } else {
-        throw Error(`${response.status} ${response.statusText}`);
-      }
+      throw Error(await response.text());
     }
     return response;
   };


### PR DESCRIPTION
## Description:

Don't worry! 199 of those line changes are in the `generatedTypes.ts`.

We used to expect error responses to have a JSON body like `{"detail": string}`. This was dangerous as the front end would fail if it encountered invalid JSON or plain text. And, for some obscure reason, we were still getting some errors in plain text, including some 500 Internal Server Error even though we had a handler for `HTTP_500_INTERNAL_SERVER_ERROR: handle_internal_error` that was returning some JSON. Also, the front end could receive network errors that don't come from the back end, for example if it is unable to reach the back end.

So, the easiest solution is to expect plain text from all error responses. To our knowledge, by default, only `HTTPException`s and `ValidationError`s used to return JSON, so I propose changing those handlers to plain text.

Worst case, if an error turns out to be JSON, it will still be valid text. The other way around is not true.

Also, this results in 21 fewer lines of code. 🤷‍♂️ 

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
