### PR TITLE
Fix front end failing to parse unexpected errors

### DIFF
--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -17,7 +17,6 @@ from starlette.status import (
     HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
     HTTP_422_UNPROCESSABLE_ENTITY,
-    HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_503_SERVICE_UNAVAILABLE,
 )
 
@@ -29,10 +28,7 @@ from azimuth.task_manager import TaskManager
 from azimuth.types import DatasetSplitName, ModuleOptions, SupportedModule
 from azimuth.utils.cluster import default_cluster
 from azimuth.utils.conversion import JSONResponseIgnoreNan
-from azimuth.utils.exception_handlers import (
-    handle_internal_error,
-    handle_validation_error,
-)
+from azimuth.utils.exception_handlers import handle_validation_error
 from azimuth.utils.logs import set_logger_config
 from azimuth.utils.validation import assert_not_none
 
@@ -53,7 +49,6 @@ COMMON_HTTP_ERROR_CODES = (
     # conventional HTTP codes.
     # This overwrites the default ValidationError response for 422 in the OpenAPI spec.
     HTTP_422_UNPROCESSABLE_ENTITY,
-    HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_503_SERVICE_UNAVAILABLE,
 )
 
@@ -172,7 +167,6 @@ def create_app() -> FastAPI:
             ValidationError: handle_validation_error,  # for PATCH "/config",
             # where we call old_config.copy(update=partial_config, deep=True) ourselves.
             RequestValidationError: handle_validation_error,
-            HTTP_500_INTERNAL_SERVER_ERROR: handle_internal_error,
         },
         root_path=".",  # Tells Swagger UI and ReDoc to fetch the OpenAPI spec from ./openapi.json
         # (relative) so it works through the front-end proxy.

--- a/azimuth/utils/exception_handlers.py
+++ b/azimuth/utils/exception_handlers.py
@@ -1,11 +1,7 @@
 from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
-from starlette.status import (
-    HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
-    HTTP_500_INTERNAL_SERVER_ERROR,
-)
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 
 async def handle_validation_error(request: Request, exception: ValidationError):
@@ -43,12 +39,4 @@ async def handle_validation_error(request: Request, exception: ValidationError):
         if "path" in (error["loc"][0] for error in exception.errors())
         else HTTP_400_BAD_REQUEST,  # for other errors like in query params, e.g., pipeline_index=-1
         content={"detail": detail},
-    )
-
-
-async def handle_internal_error(request: Request, exception: Exception):
-    # Don't expose this unexpected internal error as that could expose a security vulnerability.
-    return JSONResponse(
-        status_code=HTTP_500_INTERNAL_SERVER_ERROR,
-        content={"detail": "Internal server error"},
     )

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -934,12 +934,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -983,12 +977,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -1038,12 +1026,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -1100,12 +1082,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -1158,12 +1134,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -1211,12 +1181,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -1260,12 +1224,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -1335,12 +1293,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -1392,12 +1344,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -1472,12 +1418,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -1521,12 +1461,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -1601,12 +1535,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -1662,12 +1590,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -1719,12 +1641,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -1799,12 +1715,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -1869,12 +1779,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -1954,12 +1858,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -2011,12 +1909,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -2082,12 +1974,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -2146,12 +2032,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -2199,12 +2079,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -2257,12 +2131,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -2307,12 +2175,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -2364,12 +2226,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -2426,12 +2282,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -2481,12 +2331,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
@@ -2561,12 +2405,6 @@ export interface operations {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };
       };
-      /** Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
       /** Service Unavailable */
       503: {
         content: {
@@ -2635,12 +2473,6 @@ export interface operations {
       };
       /** Unprocessable Entity */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPExceptionModel"];
-        };
-      };
-      /** Internal Server Error */
-      500: {
         content: {
           "application/json": components["schemas"]["HTTPExceptionModel"];
         };

--- a/webapp/src/utils/api.ts
+++ b/webapp/src/utils/api.ts
@@ -2,7 +2,7 @@ import { HTTPExceptionModel } from "types/api";
 import { paths } from "types/generated/generatedTypes";
 import { constructApiSearchString } from "./helpers";
 
-const HTTP_EXCEPTION_STATUS_CODES = [400, 401, 403, 404, 422, 500, 503];
+const HTTP_EXCEPTION_STATUS_CODES = [400, 401, 403, 404, 422, 503];
 
 type CamelCase<SnakeCase> = SnakeCase extends `${infer FirstWord}_${infer Rest}`
   ? `${FirstWord}${Capitalize<CamelCase<Rest>>}`


### PR DESCRIPTION
## Description:

Because of what appears to be a bug in FastAPI, our `HTTP_500_INTERNAL_SERVER_ERROR: handle_internal_error` supposed to handle unexpected errors as `{"detail": "Internal server error"}` works for some 500 errors, but not for others.

Therefore, the front end was expecting a JSON response from 500 errors, and failing to parse it sometimes.

Let's remove our nonfunctional 500 error handler for now, and treat all 500 errors as unexpected, by not showing them to the user.

> Uncaught SyntaxError: Unexpected token 'S', "Something "... is not valid JSON

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
