### PR TITLE
Support null dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Released changes are shown in the
 
 ### Added
 - Meaningful error messages in the error toasts.
+- Support for no dataset at startup, in which case Azimuth will wait until the user sets it up via the config UI.
 
 ### Changed
 - When clicking on an utterance from the Exploration space's Utterance Table, the Utterance Details now open in a modal on top of the table. This preserves the filter context and allows for going through the utterances one by one, using some new arrow buttons or keyboard arrows.

--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -124,8 +124,6 @@ def start_app(config_path: Optional[str], load_config_history: bool, debug: bool
     log.info("🔭 Azimuth starting 🔭")
 
     azimuth_config = load_azimuth_config(config_path, load_config_history)
-    if azimuth_config.dataset is None:
-        raise ValueError("No dataset has been specified in the config.")
 
     local_cluster = default_cluster(large=azimuth_config.large_dask_cluster)
 

--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -259,7 +259,7 @@ class ProjectConfig(AzimuthBaseSettings):
     # Name of the current project.
     name: str = Field("New project", exclude_from_cache=True)
     # Dataset object definition.
-    dataset: Optional[CustomObject] = None
+    dataset: Optional[CustomObject] = Field(None, nullable=True)
     # Column names config in dataset
     columns: ColumnConfiguration = ColumnConfiguration()
     # Name of the rejection class.

--- a/azimuth/routers/app.py
+++ b/azimuth/routers/app.py
@@ -24,6 +24,7 @@ from azimuth.types.app import (
     DatasetInfoResponse,
     PerturbationTestingSummary,
     StatusResponse,
+    UtteranceCountPerDatasetSplit,
 )
 from azimuth.types.perturbation_testing import (
     PerturbationTestingMergedResponse,
@@ -92,18 +93,15 @@ def get_dataset_info(
         project_name=config.name,
         data_actions=ALL_DATA_ACTION_FILTERS,
         smart_tags=ALL_SMART_TAG_FILTERS,
-        eval_class_distribution=eval_dm.class_distribution().tolist()
-        if eval_dm is not None
-        else [],
-        train_class_distribution=training_dm.class_distribution().tolist()
-        if training_dm is not None
-        else [],
         startup_tasks={k: v.status() for k, v in startup_tasks.items()},
         model_contract=config.model_contract,
         prediction_available=predictions_available(config),
         perturbation_testing_available=perturbation_testing_available(config),
         available_dataset_splits=AvailableDatasetSplits(
             eval=eval_dm is not None, train=training_dm is not None
+        ),
+        utterance_count_per_dataset_split=UtteranceCountPerDatasetSplit(
+            eval=eval_dm and eval_dm.num_rows, train=training_dm and training_dm.num_rows
         ),
         similarity_available=similarity_available(config),
         postprocessing_editable=None

--- a/azimuth/routers/app.py
+++ b/azimuth/routers/app.py
@@ -44,7 +44,6 @@ from azimuth.utils.routers import (
     require_available_model,
     require_pipeline_index,
 )
-from azimuth.utils.validation import assert_not_none
 
 router = APIRouter()
 
@@ -88,11 +87,9 @@ def get_dataset_info(
 ):
     eval_dm = dataset_split_managers.get(DatasetSplitName.eval)
     training_dm = dataset_split_managers.get(DatasetSplitName.train)
-    dm = assert_not_none(eval_dm or training_dm)
 
     return DatasetInfoResponse(
         project_name=config.name,
-        class_names=dm.get_class_names(),
         data_actions=ALL_DATA_ACTION_FILTERS,
         smart_tags=ALL_SMART_TAG_FILTERS,
         eval_class_distribution=eval_dm.class_distribution().tolist()

--- a/azimuth/routers/config.py
+++ b/azimuth/routers/config.py
@@ -29,7 +29,7 @@ from azimuth.utils.project import update_config
 log = structlog.get_logger(__name__)
 router = APIRouter()
 
-REQUIRED = "required"
+REQUIRED = ""
 
 
 @router.get(

--- a/azimuth/routers/config.py
+++ b/azimuth/routers/config.py
@@ -42,6 +42,7 @@ def get_default_config_def(
     language: SupportedLanguage = Query(AzimuthConfig.__fields__["language"].default),
 ) -> AzimuthConfig:
     return AzimuthConfig(
+        dataset=CustomObject(class_name=REQUIRED),
         language=language,
         pipelines=[PipelineDefinition(name=REQUIRED, model=CustomObject(class_name=REQUIRED))],
     )

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -231,6 +231,10 @@ def startup_tasks(
 
     """
     config = task_manager.config
+
+    if config.dataset is None:
+        return {}
+
     # The order in start_up_tasks matters; a task needs to be added after its dependencies.
     # TODO Refactor so the startup can be robust to the order in start_up_tasks.
     start_up_tasks = [

--- a/azimuth/types/app.py
+++ b/azimuth/types/app.py
@@ -21,12 +21,15 @@ class AvailableDatasetSplits(AliasModel):
     eval: bool
 
 
+class UtteranceCountPerDatasetSplit(AliasModel):
+    train: Optional[int] = Field(..., nullable=True)
+    eval: Optional[int] = Field(..., nullable=True)
+
+
 class DatasetInfoResponse(AliasModel):
     project_name: str = Field(..., title="Name of the project")
     data_actions: List[DataAction] = Field(..., title="Data action tags")
     smart_tags: List[SmartTag] = Field(..., title="Smart tags")
-    eval_class_distribution: List[int] = Field(..., title="Evaluation set class distribution")
-    train_class_distribution: List[int] = Field(..., title="Training set class distribution")
     startup_tasks: Dict[str, Any] = Field(..., title="Startup tasks status")
     model_contract: SupportedModelContract = Field(..., title="Model Contract in the config.")
     prediction_available: bool = Field(..., title="Indicator if prediction values are available.")
@@ -35,6 +38,9 @@ class DatasetInfoResponse(AliasModel):
     )
     available_dataset_splits: AvailableDatasetSplits = Field(
         ..., title="Which dataset splits are available."
+    )
+    utterance_count_per_dataset_split: UtteranceCountPerDatasetSplit = Field(
+        ..., title="Utterance count per dataset split."
     )
     similarity_available: bool = Field(..., title="Indicator if similarities are available.")
     postprocessing_editable: Optional[List[bool]] = Field(

--- a/azimuth/types/app.py
+++ b/azimuth/types/app.py
@@ -23,7 +23,6 @@ class AvailableDatasetSplits(AliasModel):
 
 class DatasetInfoResponse(AliasModel):
     project_name: str = Field(..., title="Name of the project")
-    class_names: List[str] = Field(..., title="Class names")
     data_actions: List[DataAction] = Field(..., title="Data action tags")
     smart_tags: List[SmartTag] = Field(..., title="Smart tags")
     eval_class_distribution: List[int] = Field(..., title="Evaluation set class distribution")

--- a/azimuth/utils/object_loader.py
+++ b/azimuth/utils/object_loader.py
@@ -111,13 +111,11 @@ def load_class(kwargs, reject, value, force_kwargs=False):
         object, the loaded object.
     """
     func = load_obj(value.class_name)
-    if inspect.isclass(func):
-        if has_init(func):
-            varnames = func.__init__.__code__.co_varnames
-        else:
-            varnames = []
-    else:
-        varnames = func.__code__.co_varnames
+    varnames = (
+        (func.__init__.__code__.co_varnames if has_init(func) else [])
+        if inspect.isclass(func)
+        else func.__code__.co_varnames
+    )
 
     not_present = {k: v for k, v in kwargs.items() if k not in varnames}
 
@@ -134,7 +132,5 @@ def load_class(kwargs, reject, value, force_kwargs=False):
 
 def load_obj(cls):
     """Get the function object and load the required modules."""
-    splitted = cls.split(".")
-    mod, cls = ".".join(splitted[:-1]), splitted[-1]
-    func = getattr(importlib.import_module(mod), cls)
-    return func
+    mod, cls = cls.rsplit(".", 1)
+    return getattr(importlib.import_module(mod), cls)

--- a/azimuth/utils/object_loader.py
+++ b/azimuth/utils/object_loader.py
@@ -81,9 +81,9 @@ def load_custom_object(
     return load_class(kwargs, reject, value, force_kwargs=force_kwargs)
 
 
-def has_init(func):
-    # Is overloaded
-    return func.__init__ != object.__init__
+def get_class_init_varnames(cls):
+    # We check if func.__init__ is overloaded, otherwise func.__init__ has no attribute __code__.
+    return cls.__init__.__code__.co_varnames if cls.__init__ != object.__init__ else []
 
 
 def load_args(v, kwargs):
@@ -115,11 +115,7 @@ def load_class(kwargs, reject, value, force_kwargs=False):
     except (ModuleNotFoundError, AttributeError) as e:
         raise AzimuthValidationError(f"Invalid class_name {repr(value.class_name)}: {e}")
 
-    varnames = (
-        (func.__init__.__code__.co_varnames if has_init(func) else [])
-        if inspect.isclass(func)
-        else func.__code__.co_varnames
-    )
+    varnames = get_class_init_varnames(func) if inspect.isclass(func) else func.__code__.co_varnames
 
     not_present = {k: v for k, v in kwargs.items() if k not in varnames}
 

--- a/azimuth/utils/project.py
+++ b/azimuth/utils/project.py
@@ -32,7 +32,7 @@ def load_dataset_from_config(azimuth_config: AzimuthConfig) -> DatasetDict:
 
     """
     if azimuth_config.dataset is None:
-        raise ValueError("No dataset configured.")
+        return DatasetDict()
 
     dataset_in_config: DatasetDict = load_custom_object(
         azimuth_config.dataset, azimuth_config=azimuth_config

--- a/tests/test_routers/test_app.py
+++ b/tests/test_routers/test_app.py
@@ -43,6 +43,7 @@ def test_get_dataset_info(app: FastAPI) -> None:
 
     assert data == {
         "availableDatasetSplits": {"eval": True, "train": True},
+        "utteranceCountPerDatasetSplit": {"eval": 42, "train": 42},
         "modelContract": "custom_text_classification",
         "perturbationTestingAvailable": True,
         "postprocessingEditable": [False],
@@ -51,8 +52,6 @@ def test_get_dataset_info(app: FastAPI) -> None:
         "dataActions": ALL_DATA_ACTION_FILTERS,
         "similarityAvailable": True,
         "smartTags": ALL_SMART_TAG_FILTERS,
-        "evalClassDistribution": [22, 20, 0],
-        "trainClassDistribution": [23, 19, 0],
     }
 
 

--- a/tests/test_routers/test_app.py
+++ b/tests/test_routers/test_app.py
@@ -43,7 +43,6 @@ def test_get_dataset_info(app: FastAPI) -> None:
 
     assert data == {
         "availableDatasetSplits": {"eval": True, "train": True},
-        "classNames": ["negative", "positive", "REJECTION_CLASS"],
         "modelContract": "custom_text_classification",
         "perturbationTestingAvailable": True,
         "postprocessingEditable": [False],

--- a/tests/test_routers/test_config.py
+++ b/tests/test_routers/test_config.py
@@ -263,6 +263,24 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
     assert get_config["model_contract"] == "file_based_text_classification"
 
     # Validation Module Error
+    # TODO assert error detail
+    #  Should be 400, but during tests, AzimuthValidationError gets wrapped in a MultipleExceptions
+
+    resp = client.patch(
+        "/config", json={"pipelines": [{"model": {"class_name": "", "remote": "lol"}}]}
+    )
+    assert resp.status_code == HTTP_500_INTERNAL_SERVER_ERROR, resp.text
+    # TODO assert resp.json()["detail"] == "Can't find remote 'lol' locally or on Pypi."
+
+    resp = client.patch("/config", json={"pipelines": [{"model": {"class_name": "potato.hair"}}]})
+    assert resp.status_code == HTTP_500_INTERNAL_SERVER_ERROR, resp.text
+
+    resp = client.patch(
+        "/config",
+        json={"pipelines": [{"model": {"class_name": "tests.test_loading_resources.hair"}}]},
+    )
+    assert resp.status_code == HTTP_500_INTERNAL_SERVER_ERROR, resp.text
+
     resp = client.patch(
         "/config",
         json={
@@ -272,6 +290,7 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
         },
     )
     assert resp.status_code == HTTP_500_INTERNAL_SERVER_ERROR, resp.text
+
     get_config = client.get("/config").json()
     assert not get_config["pipelines"]
 

--- a/tests/test_routers/test_config.py
+++ b/tests/test_routers/test_config.py
@@ -18,7 +18,7 @@ def test_get_default_config(app: FastAPI):
 
     assert res == {
         "name": "New project",
-        "dataset": {"class_name": "required", "args": [], "kwargs": {}, "remote": None},
+        "dataset": {"class_name": "", "args": [], "kwargs": {}, "remote": None},
         "model_contract": "hf_text_classification",
         "columns": {
             "text_input": "utterance",
@@ -55,8 +55,8 @@ def test_get_default_config(app: FastAPI):
         },
         "pipelines": [
             {
-                "name": "required",
-                "model": {"class_name": "required", "args": [], "kwargs": {}, "remote": None},
+                "name": "Pipeline_0",
+                "model": {"class_name": "", "args": [], "kwargs": {}, "remote": None},
                 "postprocessors": [
                     {
                         "class_name": "azimuth.utils.ml.postprocessing.Thresholding",

--- a/tests/test_routers/test_config.py
+++ b/tests/test_routers/test_config.py
@@ -18,7 +18,7 @@ def test_get_default_config(app: FastAPI):
 
     assert res == {
         "name": "New project",
-        "dataset": None,
+        "dataset": {"class_name": "required", "args": [], "kwargs": {}, "remote": None},
         "model_contract": "hf_text_classification",
         "columns": {
             "text_input": "utterance",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -172,7 +172,7 @@ export default class App extends React.Component<Props> {
                   </Switch>
                 </ErrorBoundary>
               </AppLayout>
-              <ToastContainer />
+              <ToastContainer autoClose={10_000} />
             </ThemeProvider>
           </StyledEngineProvider>
         </Router>

--- a/webapp/src/components/AccordionLayout.tsx
+++ b/webapp/src/components/AccordionLayout.tsx
@@ -2,6 +2,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   Accordion,
   AccordionDetails,
+  AccordionProps,
   AccordionSummary,
   Box,
   Divider,
@@ -10,7 +11,7 @@ import {
 import Description from "components/Description";
 import React from "react";
 
-type Props = {
+type Props = AccordionProps & {
   name: string;
   description: string;
   link: string;
@@ -22,8 +23,9 @@ const AccordionLayout: React.FC<Props> = ({
   description,
   link,
   children,
+  ...props
 }) => (
-  <Accordion>
+  <Accordion {...props}>
     <AccordionSummary expandIcon={<ExpandMoreIcon />} id={name}>
       <Typography fontWeight="bold" width="20%" flexShrink={0}>
         {name}

--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -103,9 +103,8 @@ const Controls: React.FC<Props> = ({
 
   const { data: datasetInfo } = getDatasetInfoEndpoint.useQuery({ jobId });
 
-  const totalUtterances = datasetInfo?.[
-    `${datasetSplitName}ClassDistribution` // datasetSplitName might be invalid
-  ]?.reduce((a, b) => a + b);
+  const totalUtterances =
+    datasetInfo?.utteranceCountPerDatasetSplit[datasetSplitName];
 
   const handleCollapseFilters = () => {
     setIsCollapsed(!isCollapsed);

--- a/webapp/src/components/PageHeader.tsx
+++ b/webapp/src/components/PageHeader.tsx
@@ -112,7 +112,15 @@ const PageHeader = () => {
       })}`
     );
   };
+
   const [configOpen, setConfigOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (config?.dataset === null) {
+      setConfigOpen(true);
+    }
+  }, [config]);
+
   const dashboardPathname = `/${jobId}`;
 
   const isDashboard = location.pathname === dashboardPathname;

--- a/webapp/src/components/Settings/NumberField.tsx
+++ b/webapp/src/components/Settings/NumberField.tsx
@@ -16,12 +16,34 @@ const NumberField: React.FC<
     }
   }, [value, scale, stringValue]);
 
+  const helperText = React.useMemo(() => {
+    if (props.inputProps === undefined) {
+      return;
+    }
+
+    let prop;
+    if (value * scale < props.inputProps.min) {
+      prop = "min";
+    } else if (value * scale > props.inputProps.max) {
+      prop = "max";
+    } else {
+      return;
+    }
+
+    const limit = props.inputProps[prop];
+    return `Set ${prop}imum ${limit}${
+      units ? ` ${limit === 1 ? units.replace(/s$/, "") : units}` : ""
+    }`;
+  }, [props.inputProps, scale, units, value]);
+
   return (
     <TextField
       {...FIELD_COMMON_PROPS}
       type="number"
       title="" // Overwrite any default input validation tooltip
       value={stringValue}
+      error={helperText !== undefined}
+      helperText={helperText}
       InputProps={{
         sx: { maxWidth: "12ch" },
         endAdornment: units && (

--- a/webapp/src/components/Settings/StringField.tsx
+++ b/webapp/src/components/Settings/StringField.tsx
@@ -23,8 +23,8 @@ const StringField = <T extends string | null>({
     onChange={
       onChange &&
       (nullable
-        ? (event) => onChange(event.target.value as T)
-        : (event) => onChange((event.target.value || null) as T))
+        ? (event) => onChange((event.target.value || null) as T)
+        : (event) => onChange(event.target.value as T))
     }
     {...props}
   >

--- a/webapp/src/components/Settings/StringField.tsx
+++ b/webapp/src/components/Settings/StringField.tsx
@@ -20,6 +20,8 @@ const StringField = <T extends string | null>({
     select={Boolean(options)}
     inputProps={{ sx: { textOverflow: "ellipsis" } }}
     value={value ?? ""}
+    error={value === ""}
+    helperText={value === "" ? "Set a value" : undefined}
     onChange={
       onChange &&
       (nullable

--- a/webapp/src/mocks/api/mockDatasetInfoAPI.ts
+++ b/webapp/src/mocks/api/mockDatasetInfoAPI.ts
@@ -8,7 +8,6 @@ export const getDatasetInfoAPIResponse = rest.get(
   (req, res, ctx) => {
     const datasetInfoResponse: DatasetInfoResponse = {
       projectName: "Sentiment Analysis",
-      classNames: ["negative", "positive", "REJECTION_CLASS"],
       dataActions: [
         "relabel",
         "augment_with_similar",

--- a/webapp/src/mocks/api/mockDatasetInfoAPI.ts
+++ b/webapp/src/mocks/api/mockDatasetInfoAPI.ts
@@ -37,8 +37,7 @@ export const getDatasetInfoAPIResponse = rest.get(
         "pipeline_disagreement",
         "NO_SMART_TAGS",
       ],
-      evalClassDistribution: [428, 444, 0],
-      trainClassDistribution: [458, 542, 0],
+      utteranceCountPerDatasetSplit: { train: 1000, eval: 872 },
       startupTasks: {
         syntax_tags_eval: "finished",
         syntax_tags_train: "finished",

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -49,7 +49,21 @@ const Dashboard = () => {
 
   const firstAvailableDatasetSplit = DATASET_SPLIT_NAMES.find(
     (datasetSplitName) => datasetInfo.availableDatasetSplits[datasetSplitName]
-  )!;
+  );
+
+  if (firstAvailableDatasetSplit === undefined) {
+    return (
+      <Box
+        width="100%"
+        height="100%"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Typography>Please set up a dataset</Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box display="flex" flexDirection="column" gap={2}>

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -204,7 +204,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
   }, [defaultConfig, resultingConfig, updatePartialConfig]);
 
   // If config was undefined, PipelineCheck would not even render the page.
-  if (config === undefined) return null;
+  if (config === undefined || !open) return null;
 
   const renderDialog = (children: React.ReactNode) => (
     <Dialog

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -176,6 +176,9 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
   );
 
   React.useEffect(() => {
+    if (defaultConfig && resultingConfig.dataset === null) {
+      updatePartialConfig({ dataset: defaultConfig.dataset });
+    }
     if (defaultConfig && defaultConfig.language !== resultingConfig.language) {
       updatePartialConfig({
         language: defaultConfig.language,
@@ -468,39 +471,43 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           </Box>
         </Columns>
       </FormGroup>
-      {displaySectionTitle("Dataset")}
-      <FormGroup>
-        <Columns columns={2}>
-          <StringField
-            label="class_name"
-            value={resultingConfig.dataset.class_name}
-            disabled={isUpdatingConfig}
-            onChange={(class_name) =>
-              updateSubConfig("dataset", { class_name })
-            }
-          />
-          <StringField
-            label="remote"
-            nullable
-            value={resultingConfig.dataset.remote}
-            disabled={isUpdatingConfig}
-            onChange={(remote) => updateSubConfig("dataset", { remote })}
-          />
-          <JSONField
-            array
-            label="args"
-            value={resultingConfig.dataset.args}
-            disabled={isUpdatingConfig}
-            onChange={(args) => updateSubConfig("dataset", { args })}
-          />
-          <JSONField
-            label="kwargs"
-            value={resultingConfig.dataset.kwargs}
-            disabled={isUpdatingConfig}
-            onChange={(kwargs) => updateSubConfig("dataset", { kwargs })}
-          />
-        </Columns>
-      </FormGroup>
+      {resultingConfig.dataset && (
+        <>
+          {displaySectionTitle("Dataset")}
+          <FormGroup>
+            <Columns columns={2}>
+              <StringField
+                label="class_name"
+                value={resultingConfig.dataset!.class_name}
+                disabled={isUpdatingConfig}
+                onChange={(class_name) =>
+                  updateSubConfig("dataset", { class_name })
+                }
+              />
+              <StringField
+                label="remote"
+                nullable
+                value={resultingConfig.dataset!.remote}
+                disabled={isUpdatingConfig}
+                onChange={(remote) => updateSubConfig("dataset", { remote })}
+              />
+              <JSONField
+                array
+                label="args"
+                value={resultingConfig.dataset!.args}
+                disabled={isUpdatingConfig}
+                onChange={(args) => updateSubConfig("dataset", { args })}
+              />
+              <JSONField
+                label="kwargs"
+                value={resultingConfig.dataset!.kwargs}
+                disabled={isUpdatingConfig}
+                onChange={(kwargs) => updateSubConfig("dataset", { kwargs })}
+              />
+            </Columns>
+          </FormGroup>
+        </>
+      )}
     </>
   );
   const getModelContractConfigSection = () => (

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -893,6 +893,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
         name="Project Configuration"
         description="View the fields that define the dataset to load in Azimuth."
         link="reference/configuration/project/"
+        defaultExpanded
       >
         {getProjectConfigSection()}
       </AccordionLayout>

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -459,7 +459,6 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                 <React.Fragment key={column}>
                   <Typography variant="body2">{column}:</Typography>
                   <StringField
-                    label={column}
                     value={resultingConfig.columns[column]}
                     disabled={isUpdatingConfig}
                     onChange={(newValue) =>

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -263,10 +263,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
         <Button
           variant="contained"
           disabled={isEmptyPartialConfig || isUpdatingConfig}
-          onClick={() => {
-            setPartialConfig({});
-            setLanguage(undefined);
-          }}
+          onClick={handleDiscard}
         >
           Discard
         </Button>

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -278,7 +278,6 @@ export interface components {
      */
     DatasetInfoResponse: {
       projectName: string;
-      classNames: string[];
       dataActions: components["schemas"]["DataAction"][];
       smartTags: components["schemas"]["SmartTag"][];
       evalClassDistribution: number[];

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -280,13 +280,12 @@ export interface components {
       projectName: string;
       dataActions: components["schemas"]["DataAction"][];
       smartTags: components["schemas"]["SmartTag"][];
-      evalClassDistribution: number[];
-      trainClassDistribution: number[];
       startupTasks: { [key: string]: any };
       modelContract: components["schemas"]["SupportedModelContract"];
       predictionAvailable: boolean;
       perturbationTestingAvailable: boolean;
       availableDatasetSplits: components["schemas"]["AvailableDatasetSplits"];
+      utteranceCountPerDatasetSplit: components["schemas"]["UtteranceCountPerDatasetSplit"];
       similarityAvailable: boolean;
       postprocessingEditable: boolean[] | null;
     };
@@ -847,6 +846,14 @@ export interface components {
       dissimilar: string[];
       modelPrediction: components["schemas"]["ModelPrediction"] | null;
       modelSaliency: components["schemas"]["ModelSaliency"] | null;
+    };
+    /**
+     * This model should be used as the base for any model that defines aliases to ensure
+     * that all fields are represented correctly.
+     */
+    UtteranceCountPerDatasetSplit: {
+      train: number | null;
+      eval: number | null;
     };
     /**
      * This model should be used as the base for any model that defines aliases to ensure

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -127,7 +127,7 @@ export interface components {
     /** Fields that can be modified without affecting caching. */
     AzimuthConfig: {
       name: string;
-      dataset: components["schemas"]["CustomObject"];
+      dataset: components["schemas"]["CustomObject"] | null;
       columns: components["schemas"]["ColumnConfiguration"];
       rejection_class: string | null;
       /** Where to store artifacts (Azimuth config history, HDF5 files, HF datasets). */


### PR DESCRIPTION
## Description:

Hello! I know there are a lot of commits, but they are relatively small and straightforward, so I started with one PR. I recommend going through them one by one. Here is a list of who I think should review which commit. Some commits could be independent, so if some changes need more attention than others and it's possible, I'll be happy to move them to separate PRs. Let me know.

@gabegma
* [Clean up unused `datasetInfo.classNames`](https://github.com/ServiceNow/azimuth/pull/558/commits/ddd93b073bb14332299eb09169fe7e5eb47aa12d)
* [Clean up `datasetInfo`](https://github.com/ServiceNow/azimuth/pull/558/commits/7aaa2aba3fa637e1d10d7f4ec40eece3d9197923) 
  - Replace `datasetInfo.evalClassDistribution` and `datasetInfo.trainClassDistribution` with `datasetInfo.utteranceCountPerDatasetSplit`
* [Clean up `object_loader.py`](https://github.com/ServiceNow/azimuth/pull/558/commits/c254c59ecea9103eccbfd0f7c39557244765d4e2)
* [Handle more `AzimuthValidationErrors` when loading a `CustomObject`](https://github.com/ServiceNow/azimuth/pull/558/commits/ea24ad5d87801e64ba328ff5e0cb60a14ccd1940) instead of unexpected internal server errors.

@christyler3030
* [Fix nullable `StringField`](https://github.com/ServiceNow/azimuth/pull/558/commits/f20aef1c78cd943f5e2c153ded89c686b89ea489)
* [Fix dataset columns repeated labels](https://github.com/ServiceNow/azimuth/pull/558/commits/ebc306058bfe5d0394af64eac2589f2781bfb5c3)
* [Reuse `handleDiscard()`](https://github.com/ServiceNow/azimuth/pull/558/commits/231cd8d958be7c05c7e28e871f28fbb7ffd61d6f)
* [Render config modal only if it is open (optimization)](https://github.com/ServiceNow/azimuth/pull/558/commits/0002960087c0343b7bf13b56b7fff9940f13f734)
* [Expand the Project Configuration accordion by default](https://github.com/ServiceNow/azimuth/pull/558/commits/af3d1b8266c85bfb5c5a343ffad45d6222c06d66)

@gabegma and @christyler3030
* [Support null dataset](https://github.com/ServiceNow/azimuth/pull/558/commits/8f75a93805299f6080e72ffbbc3a058518e92900)

@christyler3030
* [Open config modal if dataset is null](https://github.com/ServiceNow/azimuth/pull/558/commits/be6a4fb0fcf6205b64c7c88f527149ecf477f184)
* [Add front-end validation in config](https://github.com/ServiceNow/azimuth/pull/558/commits/74804ce4ed471c6ce9b7191a0f9dd6dcf45c9630) for empty strings and numbers out of range.

With all this, when opening Azimuth, the config pops up and the `class_name` of the `dataset` is red. Here, I also typed some invalid numbers to demonstrate the feature.

<img width="1792" alt="Screenshot 2023-05-01 at 3 04 26 PM" src="https://user-images.githubusercontent.com/8386369/235514984-46201109-8b93-49d9-b320-15d0fa827f69.png">

I started the validation error messages with a verb (e.g. "Set minimum 1 sample") so it is uniform with the existing helper texts like on `subj_tags` ("Write a subj_tags and press enter").

I spent some time trying to disable the `Apply and close` button if there are some validation errors, but that turned out to be much more complex that this simple validation, so I propose starting with that and coming back to it if we really miss it.

---

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
