### PR TITLE
Align `isort`'s max line length with `flake8` and `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,6 @@ repos:
     hooks:
       - id: isort
         name: isort
-        args: [ "--profile", "black", "--skip", "__init__.py", "--filter-files" ]
   - repo: local
     hooks:
       - id: mypy

--- a/azimuth/app.py
+++ b/azimuth/app.py
@@ -182,16 +182,10 @@ def create_app() -> FastAPI:
     from azimuth.routers.model_performance.confidence_histogram import (
         router as confidence_histogram_router,
     )
-    from azimuth.routers.model_performance.confusion_matrix import (
-        router as confusion_matrix_router,
-    )
+    from azimuth.routers.model_performance.confusion_matrix import router as confusion_matrix_router
     from azimuth.routers.model_performance.metrics import router as metrics_router
-    from azimuth.routers.model_performance.outcome_count import (
-        router as outcome_count_router,
-    )
-    from azimuth.routers.model_performance.utterance_count import (
-        router as utterance_count_router,
-    )
+    from azimuth.routers.model_performance.outcome_count import router as outcome_count_router
+    from azimuth.routers.model_performance.utterance_count import router as utterance_count_router
     from azimuth.routers.top_words import router as top_words_router
     from azimuth.routers.utterances import router as utterances_router
     from azimuth.utils.routers import require_application_ready, require_available_model

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -11,15 +11,9 @@ from azimuth.config import ModelContractConfig
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.base_classes import DatasetResultModule, FilterableModule
 from azimuth.types import DatasetColumn
-from azimuth.types.model_performance import (
-    ConfidenceBinDetails,
-    ConfidenceHistogramResponse,
-)
+from azimuth.types.model_performance import ConfidenceBinDetails, ConfidenceHistogramResponse
 from azimuth.types.outcomes import ALL_OUTCOMES, OutcomeName
-from azimuth.utils.dataset_operations import (
-    get_confidences_from_ds,
-    get_outcomes_from_ds,
-)
+from azimuth.utils.dataset_operations import get_confidences_from_ds, get_outcomes_from_ds
 from azimuth.utils.validation import assert_not_none
 
 CONFIDENCE_BINS_COUNT = 20

--- a/azimuth/modules/model_performance/metrics.py
+++ b/azimuth/modules/model_performance/metrics.py
@@ -14,9 +14,7 @@ from tqdm import tqdm
 
 from azimuth.config import MetricsConfig, MetricsPerFilterConfig
 from azimuth.modules.base_classes import AggregationModule, FilterableModule
-from azimuth.modules.model_performance.confidence_binning import (
-    ConfidenceHistogramModule,
-)
+from azimuth.modules.model_performance.confidence_binning import ConfidenceHistogramModule
 from azimuth.plots.ece import make_ece_figure
 from azimuth.types import DatasetColumn, DatasetFilters
 from azimuth.types.model_performance import (

--- a/azimuth/modules/model_performance/outcome_count.py
+++ b/azimuth/modules/model_performance/outcome_count.py
@@ -21,11 +21,7 @@ from azimuth.types.model_performance import (
     OutcomeCountPerThresholdValue,
 )
 from azimuth.types.outcomes import ALL_OUTCOMES, OutcomeName
-from azimuth.types.tag import (
-    ALL_DATA_ACTION_FILTERS,
-    SMART_TAGS_FAMILY_MAPPING,
-    SmartTag,
-)
+from azimuth.types.tag import ALL_DATA_ACTION_FILTERS, SMART_TAGS_FAMILY_MAPPING, SmartTag
 from azimuth.utils.dataset_operations import get_outcomes_from_ds
 from azimuth.utils.ml.model_performance import (
     sorted_by_utterance_count,

--- a/azimuth/modules/perturbation_testing/perturbation_testing.py
+++ b/azimuth/modules/perturbation_testing/perturbation_testing.py
@@ -12,12 +12,7 @@ from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.base_classes import DatasetResultModule
 from azimuth.modules.base_classes.dask_module import Worker
 from azimuth.modules.model_contract_task_mapping import model_contract_task_mapping
-from azimuth.types import (
-    DatasetColumn,
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedMethod,
-)
+from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, SupportedMethod
 from azimuth.types.perturbation_testing import (
     PRETTY_PERTURBATION_TYPES,
     PerturbationTestClass,

--- a/azimuth/routers/export.py
+++ b/azimuth/routers/export.py
@@ -21,12 +21,7 @@ from azimuth.app import (
 from azimuth.config import AzimuthConfig
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
 from azimuth.task_manager import TaskManager
-from azimuth.types import (
-    DatasetColumn,
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedModule,
-)
+from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, SupportedModule
 from azimuth.types.perturbation_testing import (
     PerturbationTestSummary,
     PerturbedUtteranceDetailedResult,

--- a/azimuth/routers/model_performance/confidence_histogram.py
+++ b/azimuth/routers/model_performance/confidence_histogram.py
@@ -7,12 +7,7 @@ from fastapi import APIRouter, Depends, Query
 from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    NamedDatasetFilters,
-    SupportedModule,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, NamedDatasetFilters, SupportedModule
 from azimuth.types.model_performance import ConfidenceHistogramResponse
 from azimuth.utils.routers import (
     build_named_dataset_filters,

--- a/azimuth/routers/model_performance/confusion_matrix.py
+++ b/azimuth/routers/model_performance/confusion_matrix.py
@@ -7,12 +7,7 @@ from fastapi import APIRouter, Depends, Query
 from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    NamedDatasetFilters,
-    SupportedModule,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, NamedDatasetFilters, SupportedModule
 from azimuth.types.model_performance import ConfusionMatrixResponse
 from azimuth.utils.routers import (
     build_named_dataset_filters,

--- a/azimuth/routers/model_performance/metrics.py
+++ b/azimuth/routers/model_performance/metrics.py
@@ -9,12 +9,7 @@ from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.modules.model_performance.metrics import MetricsModule
 from azimuth.task_manager import TaskManager
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    NamedDatasetFilters,
-    SupportedModule,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, NamedDatasetFilters, SupportedModule
 from azimuth.types.model_performance import (
     MetricsAPIResponse,
     MetricsModuleResponse,

--- a/azimuth/routers/model_performance/outcome_count.py
+++ b/azimuth/routers/model_performance/outcome_count.py
@@ -10,12 +10,7 @@ from starlette.status import HTTP_400_BAD_REQUEST
 from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    NamedDatasetFilters,
-    SupportedModule,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, NamedDatasetFilters, SupportedModule
 from azimuth.types.model_performance import (
     OutcomeCountPerFilterResponse,
     OutcomeCountPerThresholdResponse,

--- a/azimuth/routers/top_words.py
+++ b/azimuth/routers/top_words.py
@@ -7,12 +7,7 @@ from fastapi import APIRouter, Depends, Query
 from azimuth.app import get_dataset_split_manager, get_task_manager
 from azimuth.dataset_split_manager import DatasetSplitManager
 from azimuth.task_manager import TaskManager
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    NamedDatasetFilters,
-    SupportedModule,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, NamedDatasetFilters, SupportedModule
 from azimuth.types.word_analysis import TopWordsResponse
 from azimuth.utils.routers import (
     build_named_dataset_filters,

--- a/azimuth/routers/utterances.py
+++ b/azimuth/routers/utterances.py
@@ -30,10 +30,7 @@ from azimuth.types.perturbation_testing import (
     PerturbedUtteranceResult,
     PerturbedUtteranceWithClassNames,
 )
-from azimuth.types.similarity_analysis import (
-    SimilarUtterance,
-    SimilarUtterancesResponse,
-)
+from azimuth.types.similarity_analysis import SimilarUtterance, SimilarUtterancesResponse
 from azimuth.types.tag import (
     ALL_DATA_ACTIONS,
     DATASET_SMART_TAG_FAMILIES,

--- a/azimuth/task_manager.py
+++ b/azimuth/task_manager.py
@@ -9,12 +9,7 @@ from distributed import Client, SpecCluster
 from azimuth.config import AzimuthConfig
 from azimuth.modules.base_classes import DaskModule, ExpirableMixin
 from azimuth.modules.task_mapping import model_contract_methods, modules
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedMethod,
-    SupportedTask,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod, SupportedTask
 from azimuth.utils.cluster import default_cluster
 
 log = structlog.get_logger()

--- a/azimuth/types/utterance.py
+++ b/azimuth/types/utterance.py
@@ -7,10 +7,7 @@ from typing import List, Optional, Union
 from pydantic import Field
 
 from azimuth.types import AliasModel
-from azimuth.types.model_performance import (
-    ValuePerDatasetSmartTag,
-    ValuePerPipelineSmartTag,
-)
+from azimuth.types.model_performance import ValuePerDatasetSmartTag, ValuePerPipelineSmartTag
 from azimuth.types.outcomes import OutcomeName
 from azimuth.types.tag import DataAction
 from azimuth.utils.ml.postprocessing import PostprocessingStepAPIResponse

--- a/azimuth/utils/ml/perturbation_functions.py
+++ b/azimuth/utils/ml/perturbation_functions.py
@@ -9,10 +9,7 @@ from typing import List
 import nlpaug.augmenter.char as nac
 
 from azimuth.config import PerturbationTestingConfig
-from azimuth.types.perturbation_testing import (
-    PerturbationType,
-    PerturbedUtteranceDetails,
-)
+from azimuth.types.perturbation_testing import PerturbationType, PerturbedUtteranceDetails
 from azimuth.utils.ml.third_parties.contractions import ContractionExpansions
 from azimuth.utils.validation import assert_not_none
 

--- a/azimuth/utils/routers.py
+++ b/azimuth/utils/routers.py
@@ -5,11 +5,7 @@ from threading import Event
 from typing import Any, Dict, List, Optional
 
 from fastapi import Depends, HTTPException, Query
-from starlette.status import (
-    HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
-    HTTP_503_SERVICE_UNAVAILABLE,
-)
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND, HTTP_503_SERVICE_UNAVAILABLE
 
 from azimuth.app import get_config, get_ready_flag, get_startup_tasks, get_task_manager
 from azimuth.config import AzimuthConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ line-length = 100
 profile = "black"
 skip = ["__init__.py"]
 filter_files = true
+line_length = 100
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]

--- a/tests/profiling_debugging.py
+++ b/tests/profiling_debugging.py
@@ -14,12 +14,7 @@ from azimuth.config import AzimuthConfig
 from azimuth.modules.base_classes import DatasetResultModule
 from azimuth.modules.model_performance.metrics import MetricsPerFilterModule
 from azimuth.task_manager import TaskManager
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedMethod,
-    SupportedModule,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod, SupportedModule
 
 CFG_FILE = "../local_configs/development/clinc/conf.json"
 MODULE = MetricsPerFilterModule

--- a/tests/test_modules/test_caching.py
+++ b/tests/test_modules/test_caching.py
@@ -20,12 +20,7 @@ from azimuth.modules.base_classes import (
 from azimuth.modules.base_classes.caching import HDF5FileOpenerWithRetry
 from azimuth.modules.model_performance.confusion_matrix import ConfusionMatrixModule
 from azimuth.modules.task_execution import get_task_result
-from azimuth.types import (
-    DatasetFilters,
-    DatasetSplitName,
-    ModuleOptions,
-    ModuleResponse,
-)
+from azimuth.types import DatasetFilters, DatasetSplitName, ModuleOptions, ModuleResponse
 from azimuth.types.model_performance import ConfusionMatrixResponse
 from azimuth.utils.exclude_fields_from_cache import exclude_fields_from_cache
 from tests.utils import save_outcomes, save_predictions

--- a/tests/test_modules/test_model_contracts/test_model_contract_module.py
+++ b/tests/test_modules/test_model_contracts/test_model_contract_module.py
@@ -13,12 +13,7 @@ from azimuth.modules.model_contracts import (
     CustomTextClassificationModule,
     HFTextClassificationModule,
 )
-from azimuth.types import (
-    DatasetColumn,
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedMethod,
-)
+from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, SupportedMethod
 from azimuth.types.tag import SmartTag
 from azimuth.types.task import PredictionResponse
 from azimuth.utils.ml.postprocessing import PostProcessingIO

--- a/tests/test_modules/test_model_performance/test_metrics.py
+++ b/tests/test_modules/test_model_performance/test_metrics.py
@@ -9,10 +9,7 @@ import numpy as np
 import pytest
 
 from azimuth.config import MetricDefinition
-from azimuth.modules.model_performance.metrics import (
-    MetricsModule,
-    MetricsPerFilterModule,
-)
+from azimuth.modules.model_performance.metrics import MetricsModule, MetricsPerFilterModule
 from azimuth.modules.model_performance.outcome_count import (
     OutcomeCountPerFilterModule,
     OutcomeCountPerThresholdModule,

--- a/tests/test_modules/test_perturbation_testing/test_perturbation_testing.py
+++ b/tests/test_modules/test_perturbation_testing/test_perturbation_testing.py
@@ -3,9 +3,7 @@
 # in the root directory of this source tree.
 import re
 
-from azimuth.modules.perturbation_testing.perturbation_testing import (
-    PerturbationTestingModule,
-)
+from azimuth.modules.perturbation_testing.perturbation_testing import PerturbationTestingModule
 from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions
 from azimuth.types.perturbation_testing import (
     PerturbationTestClass,

--- a/tests/test_modules/test_pipeline_comparison/test_prediction_comparison.py
+++ b/tests/test_modules/test_pipeline_comparison/test_prediction_comparison.py
@@ -1,9 +1,7 @@
 import pytest
 
 from azimuth.dataset_split_manager import PredictionTableKey
-from azimuth.modules.pipeline_comparison.prediction_comparison import (
-    PredictionComparisonModule,
-)
+from azimuth.modules.pipeline_comparison.prediction_comparison import PredictionComparisonModule
 from azimuth.types import DatasetSplitName
 from azimuth.types.pipeline_comparison import PredictionComparisonResponse
 from azimuth.types.tag import SmartTag

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,12 +1,7 @@
 import time
 
 from azimuth.modules.model_contracts import HFTextClassificationModule
-from azimuth.types import (
-    DatasetFilters,
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedMethod,
-)
+from azimuth.types import DatasetFilters, DatasetSplitName, ModuleOptions, SupportedMethod
 from azimuth.utils.dataset_operations import filter_dataset_split
 
 

--- a/tests/test_routers/test_config.py
+++ b/tests/test_routers/test_config.py
@@ -1,10 +1,6 @@
 from fastapi import FastAPI
 from jsonlines import jsonlines
-from starlette.status import (
-    HTTP_200_OK,
-    HTTP_400_BAD_REQUEST,
-    HTTP_500_INTERNAL_SERVER_ERROR,
-)
+from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 from starlette.testclient import TestClient
 
 from azimuth.config import SupportedLanguage, config_defaults_per_language

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -6,20 +6,11 @@ from unittest.mock import Mock
 import pytest
 from datasets import Dataset, DatasetDict
 
-from azimuth.app import (
-    get_ready_flag,
-    load_dataset_split_managers_from_config,
-    run_startup_tasks,
-)
+from azimuth.app import get_ready_flag, load_dataset_split_managers_from_config, run_startup_tasks
 from azimuth.config import CustomObject
 from azimuth.modules.model_contracts import HFTextClassificationModule
 from azimuth.startup import on_end, startup_tasks
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedMethod,
-    SupportedModule,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod, SupportedModule
 from tests.utils import get_table_key, get_tiny_text_config_one_ds_name
 
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -9,12 +9,7 @@ import pytest
 from azimuth.config import SyntaxConfig
 from azimuth.modules.base_classes import AggregationModule, FilterableModule, Module
 from azimuth.task_manager import TaskManagerLockedException
-from azimuth.types import (
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedMethod,
-    SupportedModule,
-)
+from azimuth.types import DatasetSplitName, ModuleOptions, SupportedMethod, SupportedModule
 
 
 def test_get_all_task(tiny_text_task_manager):

--- a/tests/test_utils/test_task_running.py
+++ b/tests/test_utils/test_task_running.py
@@ -2,12 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from azimuth.types import (
-    DatasetFilters,
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedModule,
-)
+from azimuth.types import DatasetFilters, DatasetSplitName, ModuleOptions, SupportedModule
 from azimuth.utils.routers import get_custom_task_result, get_standard_task_result
 
 standard_task_result = "task_result"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,20 +7,11 @@ from typing import Type
 
 import numpy as np
 
-from azimuth.config import (
-    BehavioralTestingOptions,
-    NeutralTokenOptions,
-    TypoTestOptions,
-)
+from azimuth.config import BehavioralTestingOptions, NeutralTokenOptions, TypoTestOptions
 from azimuth.dataset_split_manager import DatasetSplitManager, PredictionTableKey
 from azimuth.modules.model_contract_task_mapping import model_contract_task_mapping
 from azimuth.modules.model_performance.outcomes import OutcomesModule
-from azimuth.types import (
-    DatasetColumn,
-    DatasetSplitName,
-    ModuleOptions,
-    SupportedMethod,
-)
+from azimuth.types import DatasetColumn, DatasetSplitName, ModuleOptions, SupportedMethod
 from azimuth.types.tag import (
     ALL_DATA_ACTIONS,
     ALL_PREDICTION_TAGS,


### PR DESCRIPTION
## Description:

* [Remove `args` for `isort` in `.pre-commit-config.yaml` since they are redundant with their definitions in `pyproject.toml`](https://github.com/ServiceNow/azimuth/pull/559/commits/8a5e51e740aee68f09c8c5204ef04ee5126f0ce9)
* [Align `isort`'s max line length with `flake8` and `black`](https://github.com/ServiceNow/azimuth/pull/559/commits/378b37e856ef8fd31aa27b00d442928d532e5845)
* [Apply isort](https://github.com/ServiceNow/azimuth/pull/559/commits/8e163c59b41470bba89f849fdab1ed4d710e5d93)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
