### PR TITLE
Hide registering task logs

### DIFF
--- a/azimuth/task_manager.py
+++ b/azimuth/task_manager.py
@@ -72,7 +72,7 @@ class TaskManager:
         for route, tasks in root_routes.items():
             for name, task in tasks.items():
                 page_name = f"{route}/{name}"
-                log.info(f"Registering new task in {route}.", name=page_name, clss=task)
+                log.debug(f"Registering new task in {route}.", name=page_name, clss=task)
                 self.register_task(name, task)
 
     def get_all_tasks_status(self, task: Optional[str] = None) -> Dict[str, str]:


### PR DESCRIPTION
## Description:
* Tiny PR. These logs take a lot of space, and when updating the config, they were printed again and it's harder to debug.

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
