### PR TITLE
Support custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Released changes are shown in the
 ### Added
 - Meaningful error messages in the error toasts.
 - Support for no dataset at startup, in which case Azimuth will wait until the user sets it up via the config UI.
+- Support for customizing, adding, and removing some pipelines, postprocessors, and metrics.
 
 ### Changed
 - When clicking on an utterance from the Exploration space's Utterance Table, the Utterance Details now open in a modal on top of the table. This preserves the filter context and allows for going through the utterances one by one, using some new arrow buttons or keyboard arrows.

--- a/webapp/src/components/PipelineCheck.tsx
+++ b/webapp/src/components/PipelineCheck.tsx
@@ -17,18 +17,16 @@ const PipelineCheck: React.FC<Props> = ({ children }) => {
 
   const { data: config } = getConfigEndpoint.useQuery({ jobId });
 
-  if (!isPipelineSelected(pipeline)) {
-    // No need to check
-    return <>{children}</>;
-  }
-
   if (!config) {
+    // Even if there is no pipeline selected, we wait for the config to load so
+    // that all pages can assume that the config is loaded.
     return <Loading />;
   }
 
-  return config.pipelines &&
-    pipeline.pipelineIndex >= 0 &&
-    pipeline.pipelineIndex < config.pipelines.length ? (
+  return !isPipelineSelected(pipeline) ||
+    (config.pipelines &&
+      pipeline.pipelineIndex >= 0 &&
+      pipeline.pipelineIndex < config.pipelines.length) ? (
     <>{children}</>
   ) : (
     <Redirect to={location.pathname} />

--- a/webapp/src/components/Settings/AutocompleteStringField.tsx
+++ b/webapp/src/components/Settings/AutocompleteStringField.tsx
@@ -44,7 +44,7 @@ const AutocompleteStringField: React.FC<
         {...params}
         {...FIELD_COMMON_PROPS}
         {...props}
-        {...(value === "" && { error: true, helperText: "Set a value" })}
+        {...(value.trim() === "" && { error: true, helperText: "Set a value" })}
       />
     )}
   />

--- a/webapp/src/components/Settings/CustomObjectFields.tsx
+++ b/webapp/src/components/Settings/CustomObjectFields.tsx
@@ -1,0 +1,44 @@
+import { CustomObject } from "types/api";
+import JSONField from "./JSONField";
+import StringField from "./StringField";
+import React from "react";
+
+const CustomObjectFields: React.FC<{
+  excludeClassName?: boolean;
+  disabled: boolean;
+  value: CustomObject;
+  onChange: (update: Partial<CustomObject>) => void;
+}> = ({ excludeClassName, disabled, value, onChange }) => (
+  <>
+    {!excludeClassName && (
+      <StringField
+        label="class_name"
+        value={value.class_name}
+        disabled={disabled}
+        onChange={(class_name) => onChange({ class_name })}
+      />
+    )}
+    <StringField
+      label="remote"
+      nullable
+      value={value.remote}
+      disabled={disabled}
+      onChange={(remote) => onChange({ remote })}
+    />
+    <JSONField
+      array
+      label="args"
+      value={value.args}
+      disabled={disabled}
+      onChange={(args) => onChange({ args })}
+    />
+    <JSONField
+      label="kwargs"
+      value={value.kwargs}
+      disabled={disabled}
+      onChange={(kwargs) => onChange({ kwargs })}
+    />
+  </>
+);
+
+export default React.memo(CustomObjectFields);

--- a/webapp/src/components/Settings/StringField.tsx
+++ b/webapp/src/components/Settings/StringField.tsx
@@ -20,7 +20,7 @@ const StringField = <T extends string | null>({
     select={Boolean(options)}
     inputProps={{ sx: { textOverflow: "ellipsis" } }}
     value={value ?? ""}
-    {...(value === "" && { error: true, helperText: "Set a value" })}
+    {...(value?.trim() === "" && { error: true, helperText: "Set a value" })}
     onChange={
       onChange &&
       (nullable

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -207,7 +207,10 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
     onClose();
   };
 
-  const resultingConfig = Object.assign({}, config, partialConfig);
+  const resultingConfig = React.useMemo(
+    () => Object.assign({}, config, partialConfig),
+    [config, partialConfig]
+  );
 
   const {
     data: defaultConfig,

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -40,6 +40,7 @@ import {
 } from "services/api";
 import {
   AzimuthConfig,
+  CustomObject,
   PipelineDefinition,
   SupportedLanguage,
   SupportedModelContract,
@@ -137,6 +138,44 @@ const KeyValuePairs: React.FC = ({ children }) => (
 
 const updateArrayAt = <T,>(array: T[], index: number, update: Partial<T>) =>
   splicedArray(array, index, 1, { ...array[index], ...update });
+
+const CustomObjectFields: React.FC<{
+  excludeClassName?: boolean;
+  disabled: boolean;
+  value: CustomObject;
+  onChange: (update: Partial<CustomObject>) => void;
+}> = ({ excludeClassName, disabled, value, onChange }) => (
+  <>
+    {!excludeClassName && (
+      <StringField
+        label="class_name"
+        value={value.class_name}
+        disabled={disabled}
+        onChange={(class_name) => onChange({ class_name })}
+      />
+    )}
+    <StringField
+      label="remote"
+      nullable
+      value={value.remote}
+      disabled={disabled}
+      onChange={(remote) => onChange({ remote })}
+    />
+    <JSONField
+      array
+      label="args"
+      value={value.args}
+      disabled={disabled}
+      onChange={(args) => onChange({ args })}
+    />
+    <JSONField
+      label="kwargs"
+      value={value.kwargs}
+      disabled={disabled}
+      onChange={(kwargs) => onChange({ kwargs })}
+    />
+  </>
+);
 
 type Props = {
   open: boolean;
@@ -489,33 +528,10 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           {displaySectionTitle("Dataset")}
           <FormGroup>
             <Columns columns={2}>
-              <StringField
-                label="class_name"
-                value={resultingConfig.dataset!.class_name}
+              <CustomObjectFields
                 disabled={isUpdatingConfig}
-                onChange={(class_name) =>
-                  updateSubConfig("dataset", { class_name })
-                }
-              />
-              <StringField
-                label="remote"
-                nullable
-                value={resultingConfig.dataset!.remote}
-                disabled={isUpdatingConfig}
-                onChange={(remote) => updateSubConfig("dataset", { remote })}
-              />
-              <JSONField
-                array
-                label="args"
-                value={resultingConfig.dataset!.args}
-                disabled={isUpdatingConfig}
-                onChange={(args) => updateSubConfig("dataset", { args })}
-              />
-              <JSONField
-                label="kwargs"
-                value={resultingConfig.dataset!.kwargs}
-                disabled={isUpdatingConfig}
-                onChange={(kwargs) => updateSubConfig("dataset", { kwargs })}
+                value={resultingConfig.dataset}
+                onChange={(update) => updateSubConfig("dataset", update)}
               />
             </Columns>
           </FormGroup>
@@ -674,40 +690,14 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                         }
                       />
                       {!(postprocessor.class_name in KNOWN_POSTPROCESSORS) && (
-                        <>
-                          <StringField
-                            label="remote"
-                            nullable
-                            value={postprocessor.remote}
-                            disabled={isUpdatingConfig}
-                            onChange={(remote) =>
-                              updatePostprocessor(pipelineIndex, index, {
-                                remote,
-                              })
-                            }
-                          />
-                          <JSONField
-                            array
-                            label="args"
-                            value={postprocessor.args}
-                            disabled={isUpdatingConfig}
-                            onChange={(args) =>
-                              updatePostprocessor(pipelineIndex, index, {
-                                args,
-                              })
-                            }
-                          />
-                          <JSONField
-                            label="kwargs"
-                            value={postprocessor.kwargs}
-                            disabled={isUpdatingConfig}
-                            onChange={(kwargs) =>
-                              updatePostprocessor(pipelineIndex, index, {
-                                kwargs,
-                              })
-                            }
-                          />
-                        </>
+                        <CustomObjectFields
+                          excludeClassName
+                          disabled={isUpdatingConfig}
+                          value={postprocessor}
+                          onChange={(update) =>
+                            updatePostprocessor(pipelineIndex, index, update)
+                          }
+                        />
                       )}
                       {"temperature" in postprocessor && (
                         <NumberField

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -24,6 +24,7 @@ import noData from "assets/void.svg";
 import AccordionLayout from "components/AccordionLayout";
 import Loading from "components/Loading";
 import AutocompleteStringField from "components/Settings/AutocompleteStringField";
+import CustomObjectFields from "components/Settings/CustomObjectFields";
 import EditableArray from "components/Settings/EditableArray";
 import JSONField from "components/Settings/JSONField";
 import NumberField from "components/Settings/NumberField";
@@ -39,7 +40,6 @@ import {
 } from "services/api";
 import {
   AzimuthConfig,
-  CustomObject,
   MetricDefinition,
   PipelineDefinition,
   SupportedLanguage,
@@ -144,44 +144,6 @@ const KeyValuePairs: React.FC = ({ children }) => (
 
 const updateArrayAt = <T,>(array: T[], index: number, update: Partial<T>) =>
   splicedArray(array, index, 1, { ...array[index], ...update });
-
-const CustomObjectFields: React.FC<{
-  excludeClassName?: boolean;
-  disabled: boolean;
-  value: CustomObject;
-  onChange: (update: Partial<CustomObject>) => void;
-}> = ({ excludeClassName, disabled, value, onChange }) => (
-  <>
-    {!excludeClassName && (
-      <StringField
-        label="class_name"
-        value={value.class_name}
-        disabled={disabled}
-        onChange={(class_name) => onChange({ class_name })}
-      />
-    )}
-    <StringField
-      label="remote"
-      nullable
-      value={value.remote}
-      disabled={disabled}
-      onChange={(remote) => onChange({ remote })}
-    />
-    <JSONField
-      array
-      label="args"
-      value={value.args}
-      disabled={disabled}
-      onChange={(args) => onChange({ args })}
-    />
-    <JSONField
-      label="kwargs"
-      value={value.kwargs}
-      disabled={disabled}
-      onChange={(kwargs) => onChange({ kwargs })}
-    />
-  </>
-);
 
 type Props = {
   open: boolean;

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -27,6 +27,7 @@ export interface CountPerFilterResponse
 }
 export type CountPerFilterValue = Partial<OutcomeCountPerFilterValue> &
   UtteranceCountPerFilterValue;
+export type CustomObject = components["schemas"]["CustomObject"];
 export type DataAction = components["schemas"]["DataAction"];
 export type DatasetDistributionComparison =
   components["schemas"]["DatasetDistributionComparison"];

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -44,6 +44,7 @@ export type FormatType = components["schemas"]["FormatType"];
 export type GetUtterancesResponse =
   components["schemas"]["GetUtterancesResponse"];
 export type HTTPExceptionModel = components["schemas"]["HTTPExceptionModel"];
+export type MetricDefinition = components["schemas"]["MetricDefinition"];
 export type MetricInfo = components["schemas"]["MetricInfo"];
 export type MetricsPerFilterAPIResponse =
   components["schemas"]["MetricsPerFilterAPIResponse"];


### PR DESCRIPTION
## Description:

This PR adds support for customizing, adding, and removing some metrics.

This is also introducing the functionality of disabling the `Apply and close` button if the names of the metrics are duplicated or empty. It will be possible to extend this functionality to other field validations, but for the sake of this PR, that's it.

One question remains: should we move the metrics to a separate section to keep the Model section small? The cons I see with the separate section are:
1. In the new section, say "Metrics", the "box" would need a sub-title to be uniform with the rest, and repeating "Metrics" looks bad. We would have to come up with a solution.
2. If I have no pipeline, I'm not interested in the Metrics sections, so making them look separate/independent might be more misleading.

![Screenshot 2023-05-31 at 11 25 46 AM](https://github.com/ServiceNow/azimuth/assets/8386369/cf51ce30-226d-4b44-80ff-b619ab0fc916)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
