### PR TITLE
Remove deprecation warning from pytest output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 env = ["DASK_DISTRIBUTED__WORKER__DAEMON=False"]
+filterwarnings = ["ignore::DeprecationWarning"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Remove the annoying DeprecationWarning from the CI. From HuggingFace, TF, etc.