### PR TITLE
Add a route to validate a config

### DIFF
--- a/azimuth/config.py
+++ b/azimuth/config.py
@@ -284,10 +284,14 @@ class ProjectConfig(AzimuthBaseSettings):
 
 class ArtifactsConfig(AzimuthBaseSettings, extra=Extra.ignore):
     artifact_path: str = Field(
-        "cache",
+        default_factory=lambda: os.path.abspath("cache"),
         description="Where to store artifacts (Azimuth config history, HDF5 files, HF datasets).",
         exclude_from_cache=True,
     )
+
+    @validator("artifact_path")
+    def validate_artifact_path(cls, artifact_path):
+        return os.path.abspath(artifact_path)
 
     def get_config_history_path(self):
         return f"{self.artifact_path}/config_history.jsonl"

--- a/azimuth/routers/config.py
+++ b/azimuth/routers/config.py
@@ -78,6 +78,25 @@ def get_config_def(
 
 
 @router.patch(
+    "/validate",
+    summary="Validate config",
+    description="Validate the given partial config update and return the complete config that would"
+    " result if this update was applied.",
+    response_model=AzimuthConfig,
+    dependencies=[Depends(require_editable_config)],
+)
+def validate_config(
+    config: AzimuthConfig = Depends(get_config),
+    partial_config: Dict = Body(...),
+) -> AzimuthConfig:
+    new_config = update_config(old_config=config, partial_config=partial_config)
+
+    assert_permission_to_update_config(old_config=config, new_config=new_config)
+
+    return new_config
+
+
+@router.patch(
     "",
     summary="Update config",
     description="Update the config.",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from jsonlines import jsonlines
 from pydantic import ValidationError
 
 from azimuth.config import (
+    ArtifactsConfig,
     AzimuthConfig,
     AzimuthConfigHistoryWithHash,
     PipelineDefinition,
@@ -289,3 +290,10 @@ def test_config_history_with_hash():
         ValidationError, match="1 validation error for AzimuthConfigHistoryWithHash\nconfig -> name"
     ):
         AzimuthConfigHistoryWithHash(config={"name": None})
+
+
+def test_artifact_path_equality():
+    # This is important since we forbid updating the config if the artifact_path differs.
+    default = ArtifactsConfig()
+    assert ArtifactsConfig(artifact_path="cache/../cache") == default
+    assert ArtifactsConfig(artifact_path=f"{os.getcwd()}/cache") == default

--- a/tests/test_routers/test_config.py
+++ b/tests/test_routers/test_config.py
@@ -1,5 +1,12 @@
+import os.path
+
 from fastapi import FastAPI
-from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
+from starlette.status import (
+    HTTP_200_OK,
+    HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
+    HTTP_500_INTERNAL_SERVER_ERROR,
+)
 from starlette.testclient import TestClient
 
 from azimuth.config import SupportedLanguage, config_defaults_per_language
@@ -23,7 +30,7 @@ def test_get_default_config(app: FastAPI):
             "persistent_id": "row_idx",
         },
         "rejection_class": "REJECTION_CLASS",
-        "artifact_path": "cache",
+        "artifact_path": os.path.abspath("cache"),
         "batch_size": 32,
         "use_cuda": "auto",
         "large_dask_cluster": False,
@@ -243,6 +250,17 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
     client = TestClient(app)
     initial_config = client.get("/config").json()
     initial_config_count = len(client.get("/config/history").json())
+
+    resp = client.patch("/config", json={"artifact_path": "something/else"})
+    assert resp.status_code == HTTP_403_FORBIDDEN, resp.text
+
+    relative_artifact_path = os.path.relpath(initial_config["artifact_path"])
+    assert relative_artifact_path != initial_config["artifact_path"]
+    resp = client.patch("/config", json={"artifact_path": relative_artifact_path})
+    assert resp.status_code == HTTP_200_OK, resp.text
+    assert resp.json() == initial_config
+    new_config_count = len(client.get("/config/history").json())
+    assert new_config_count == initial_config_count
 
     resp = client.patch(
         "/config",

--- a/tests/test_routers/test_config.py
+++ b/tests/test_routers/test_config.py
@@ -242,8 +242,6 @@ def test_get_config(app: FastAPI):
 def test_update_config(app: FastAPI, wait_for_startup_after):
     client = TestClient(app)
     initial_config = client.get("/config").json()
-    initial_contract = initial_config["model_contract"]
-    initial_pipelines = initial_config["pipelines"]
     initial_config_count = len(client.get("/config/history").json())
 
     resp = client.patch(
@@ -309,9 +307,7 @@ def test_update_config(app: FastAPI, wait_for_startup_after):
     assert not loaded_configs[-1]["config"]["pipelines"]
 
     # Revert config change
-    _ = client.patch(
-        "/config", json={"model_contract": initial_contract, "pipelines": initial_pipelines}
-    )
+    _ = client.patch("/config", json=initial_config)
 
     loaded_configs = client.get("/config/history").json()
     assert loaded_configs[-1]["config"] == loaded_configs[initial_config_count - 1]["config"]

--- a/webapp/src/services/api.ts
+++ b/webapp/src/services/api.ts
@@ -269,14 +269,23 @@ export const api = createApi({
       providesTags: [{ type: "Config" }],
       queryFn: responseToData(
         fetchApi({ path: "/config", method: "get" }),
-        "Something went wrong fetching config"
+        "Something went wrong fetching the config"
       ),
     }),
     getDefaultConfig: build.query({
       providesTags: [{ type: "DefaultConfig" }],
       queryFn: responseToData(
         fetchApi({ path: "/config/default", method: "get" }),
-        "Something went wrong fetching default config"
+        "Something went wrong fetching the default config"
+      ),
+    }),
+    validateConfig: build.mutation<
+      AzimuthConfig,
+      { jobId: string; body: Partial<AzimuthConfig> }
+    >({
+      queryFn: responseToData(
+        fetchApi({ path: "/config/validate", method: "patch" }),
+        "Something went wrong validating the config"
       ),
     }),
     updateConfig: build.mutation<
@@ -285,7 +294,7 @@ export const api = createApi({
     >({
       queryFn: responseToData(
         fetchApi({ path: "/config", method: "patch" }),
-        "Something went wrong updating config"
+        "Something went wrong updating the config"
       ),
       // We invalidate Status first, so StatusCheck stops rendering the app if
       // necessary. We await queryFulfilled before invalidating the other tags.
@@ -353,7 +362,7 @@ export const api = createApi({
       providesTags: () => [{ type: "Status" }],
       queryFn: responseToData(
         fetchApi({ path: "/status", method: "get" }),
-        "Something went wrong fetching status"
+        "Something went wrong fetching the status"
       ),
     }),
   }),
@@ -380,6 +389,7 @@ export const {
   getStatus: getStatusEndpoint,
   getTopWords: getTopWordsEndpoint,
   getUtterances: getUtterancesEndpoint,
+  validateConfig: validateConfigEndpoint,
   updateConfig: updateConfigEndpoint,
   updateDataActions: updateDataActionsEndpoint,
 } = api.endpoints;

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -34,6 +34,10 @@ export interface paths {
     /** Update the config. */
     patch: operations["patch_config_config_patch"];
   };
+  "/config/validate": {
+    /** Validate the given partial config update and return the complete config that would result if this update was applied. */
+    patch: operations["validate_config_config_validate_patch"];
+  };
   "/dataset_splits/{dataset_split_name}/class_overlap/plot": {
     /** Get a plot of class overlap using Spectral clustering and Monte-Carlo sampling (currently set to all samples). */
     get: operations["get_class_overlap_plot_dataset_splits__dataset_split_name__class_overlap_plot_get"];
@@ -1259,6 +1263,58 @@ export interface operations {
   };
   /** Update the config. */
   patch_config_config_patch: {
+    responses: {
+      /** Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["AzimuthConfig"];
+        };
+      };
+      /** Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["HTTPExceptionModel"];
+        };
+      };
+      /** Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["HTTPExceptionModel"];
+        };
+      };
+      /** Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["HTTPExceptionModel"];
+        };
+      };
+      /** Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["HTTPExceptionModel"];
+        };
+      };
+      /** Unprocessable Entity */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPExceptionModel"];
+        };
+      };
+      /** Service Unavailable */
+      503: {
+        content: {
+          "application/json": components["schemas"]["HTTPExceptionModel"];
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": { [key: string]: any };
+      };
+    };
+  };
+  /** Validate the given partial config update and return the complete config that would result if this update was applied. */
+  validate_config_config_validate_patch: {
     responses: {
       /** Successful Response */
       200: {


### PR DESCRIPTION
## Description:

* [Clean up](https://github.com/ServiceNow/azimuth/pull/579/commits/d56cb1bcc8c558d3a1bad416cbca559ea50728c7)
* [Fix updating config with equivalent `artifact_path`](https://github.com/ServiceNow/azimuth/pull/579/commits/9e40e507612a39d2eaf75635e7221f3963902a19) (for example relative vs absolute)
  - Have Pydantic parse `artifact_path` as an absolute path.
  - Have only Pydantic deal with the `partial_config: Dict`, and check permission to update the config on the resulting updated config (instead of on the `partial_config: Dict`).
  - As a result, I can update from a relative `artifact_path="cache"` to an absolute `artifact_path="/Users/joseph/azimuth/cache"` for example, or even weird stuff like `artifact_path="/Users/joseph/azimuth/cache/../cache"`.
* [Add a route to validate a config](https://github.com/ServiceNow/azimuth/pull/579/commits/9019fd24d2decf4c835654b8624f3d67f6082503) without applying it

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
