### PR TITLE
Fix importing the same proposed actions CSV file twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,6 @@ Released changes are shown in the
 ### Removed
 
 ### Fixed
+- Fixed importing the same proposed actions CSV file twice
 
 ### Security

--- a/webapp/src/components/FileInputButton.tsx
+++ b/webapp/src/components/FileInputButton.tsx
@@ -1,0 +1,28 @@
+import { Button, ButtonProps } from "@mui/material";
+import React from "react";
+
+const FileInputButton: React.FC<
+  { accept: string; onFileRead: (text: string) => void } & ButtonProps<"label">
+> = ({ accept, onFileRead, children, ...props }) => (
+  <Button component="label" {...props}>
+    {children}
+    <input
+      hidden
+      accept={accept}
+      type="file"
+      onChange={({ target }) => {
+        if (target.files?.length) {
+          const fileReader = new FileReader();
+          fileReader.onload = ({ target }) => {
+            if (target) {
+              onFileRead(target.result as string);
+            }
+          };
+          fileReader.readAsText(target.files[0]);
+        }
+      }}
+    />
+  </Button>
+);
+
+export default React.memo(FileInputButton);

--- a/webapp/src/components/FileInputButton.tsx
+++ b/webapp/src/components/FileInputButton.tsx
@@ -20,7 +20,7 @@ const FileInputButton: React.FC<
           };
           fileReader.readAsText(target.files[0]);
         }
-        // Reset input so that the same file can be selected again.
+        // Reset input value so that selecting the same file re-triggers onChange.
         target.value = "";
       }}
     />

--- a/webapp/src/components/FileInputButton.tsx
+++ b/webapp/src/components/FileInputButton.tsx
@@ -20,6 +20,8 @@ const FileInputButton: React.FC<
           };
           fileReader.readAsText(target.files[0]);
         }
+        // Reset input so that the same file can be selected again.
+        target.value = "";
       }}
     />
   </Button>

--- a/webapp/src/components/FileInputButton.tsx
+++ b/webapp/src/components/FileInputButton.tsx
@@ -20,7 +20,7 @@ const FileInputButton: React.FC<
           };
           fileReader.readAsText(target.files[0]);
         }
-        // Reset input value so that selecting the same file re-triggers onChange.
+        // Reset input value so that selecting the same file again re-triggers onChange.
         target.value = "";
       }}
     />


### PR DESCRIPTION
Resolve #479

## Description:

* [Create reusable component FileInputButton](https://github.com/ServiceNow/azimuth/pull/580/commits/42509e900e1dceaa4dcd891d0be72f5b2859303b) (I will be reusing it in a future PR)
* [Fix uploading same file twice](https://github.com/ServiceNow/azimuth/pull/580/commits/bb26895760eab31a7c1ad6003d74d3ccdd0c9d01)
* [Log changes](https://github.com/ServiceNow/azimuth/pull/580/commits/9dcdc5c0710a8ce4eb95b666984b9eb9576fdd92)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
