### PR TITLE
Add buttons to upload and download a config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Released changes are shown in the
 ## [Not released]
 
 ### Added
+- Two buttons in the config UI to import/export a JSON config file.
 
 ### Changed
 

--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -1,13 +1,13 @@
 import {
   ArrowDropDown,
   Close,
+  Download,
   Fullscreen,
-  GetApp,
   SvgIconComponent,
+  Upload,
 } from "@mui/icons-material";
 import FilterAltOutlinedIcon from "@mui/icons-material/FilterAltOutlined";
 import MultilineChartIcon from "@mui/icons-material/MultilineChart";
-import UploadIcon from "@mui/icons-material/Upload";
 import {
   Box,
   Button,
@@ -480,7 +480,7 @@ const UtterancesTable: React.FC<Props> = ({
         <Box display="flex" alignItems="center" gap={2}>
           <FileInputButton
             accept=".csv"
-            startIcon={<UploadIcon />}
+            startIcon={<Upload />}
             onFileRead={importProposedActions}
           >
             Import
@@ -490,7 +490,7 @@ const UtterancesTable: React.FC<Props> = ({
             aria-controls="export-menu"
             aria-haspopup="true"
             onClick={(event) => setAnchorEl(event.currentTarget)}
-            startIcon={<GetApp />}
+            startIcon={<Download />}
             endIcon={<ArrowDropDown />}
           >
             Export

--- a/webapp/src/components/PerturbationTestingSummary/PerturbationTestingExporter.tsx
+++ b/webapp/src/components/PerturbationTestingSummary/PerturbationTestingExporter.tsx
@@ -1,4 +1,4 @@
-import { ArrowDropDown, GetApp } from "@mui/icons-material";
+import { ArrowDropDown, Download } from "@mui/icons-material";
 import { Button, Menu, MenuItem } from "@mui/material";
 import React from "react";
 import { QueryPipelineState } from "types/models";
@@ -42,7 +42,7 @@ const PerturbationTestingExporter: React.FC<Props> = ({ jobId, pipeline }) => {
         aria-controls="perturbation-testing-exporter-menu"
         aria-haspopup="true"
         onClick={handleClick}
-        startIcon={<GetApp />}
+        startIcon={<Download />}
         endIcon={<ArrowDropDown />}
       >
         Export

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -278,7 +278,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
       validateConfig({ jobId, body })
         .unwrap()
         .then((config) => setPartialConfig(azimuthConfigToConfigState(config)))
-        .catch(() => {}); // Avoid the uncaught error log.
+        .catch(() => {}); // Avoid the uncaught error log. Toast already raised by `rtkQueryErrorInterceptor` middleware.
     } catch (error) {
       raiseErrorToast(
         `Something went wrong parsing JSON file\n${
@@ -404,7 +404,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
             })
               .unwrap()
               .then(handleClose)
-              .catch(() => {}); // Avoid the uncaught error log.
+              .catch(() => {}); // Avoid the uncaught error log. Toast already raised by `rtkQueryErrorInterceptor` middleware.
           }}
         >
           Apply and close

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -120,13 +120,19 @@ const USE_CUDA_OPTIONS = ["auto", "true", "false"] as const;
 type UseCUDAOption = typeof USE_CUDA_OPTIONS[number];
 
 const FIELDS_TRIGGERING_STARTUP_TASKS: (keyof ConfigState)[] = [
+  "dataset",
+  "columns",
+  "rejection_class",
   "behavioral_testing",
   "similarity",
   "dataset_warnings",
   "syntax",
+  "model_contract",
   "pipelines",
   "uncertainty",
+  "saliency_layer",
   "metrics",
+  "language",
 ];
 
 type KnownPostprocessor = TemperatureScaling | ThresholdConfig;

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { Close, Upload, Warning } from "@mui/icons-material";
+import { Close, Download, Upload, Warning } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -51,6 +51,7 @@ import {
   ThresholdConfig,
 } from "types/api";
 import { PickByValue } from "types/models";
+import { downloadBlob } from "utils/api";
 import { UNKNOWN_ERROR } from "utils/const";
 import { raiseErrorToast } from "utils/helpers";
 
@@ -287,6 +288,13 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
     }
   };
 
+  const handleDownload = () => {
+    const azimuthConfig = configStateToAzimuthConfig(resultingConfig);
+    const text = JSON.stringify(azimuthConfig, null, 2);
+    const blob = new Blob([text], { type: "application/json" });
+    downloadBlob(blob, "config.json");
+  };
+
   const renderDialog = (children: React.ReactNode) => (
     <Dialog
       aria-labelledby="config-dialog-title"
@@ -307,6 +315,13 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           >
             Import JSON config file
           </FileInputButton>
+          <Button
+            disabled={areInputsDisabled}
+            startIcon={<Download />}
+            onClick={handleDownload}
+          >
+            Export JSON config file
+          </Button>
           <IconButton
             size="small"
             color="primary"

--- a/webapp/src/utils/api.ts
+++ b/webapp/src/utils/api.ts
@@ -134,7 +134,7 @@ const downloadFileFromApi =
     downloadBlob(blob, filename);
   };
 
-async function downloadBlob(blob: Blob, filename?: string) {
+export async function downloadBlob(blob: Blob, filename?: string) {
   const downloadUrl = window.URL.createObjectURL(blob);
 
   const link = document.createElement("a");


### PR DESCRIPTION
## Description:

* [Create reusable conversion functions between `AzimuthConfig` and `ConfigState`](https://github.com/ServiceNow/azimuth/pull/581/commits/a15eadd0241b897c013acd50ba8f3ca508f202a4) 
* [Add missing config fields that may trigger time-consuming computations](https://github.com/ServiceNow/azimuth/pull/581/commits/6347aaf97099c97348a1030e5b7270ad12a73df7)
* [Fix download icon semantic](https://github.com/ServiceNow/azimuth/pull/581/commits/7d4a082a8e54cbfcefd6abcca911275b4d330d52) by using the identical `Download` icon instead of `GetApp`.
* [Add button to upload a config file](https://github.com/ServiceNow/azimuth/pull/581/commits/e860569a80d523dd05b0914ca41765da22da5404)
* [Add button to download a config file](https://github.com/ServiceNow/azimuth/pull/581/commits/ad37eab037f4a452011bea7cbb4bc702091357b5)

<img width="1440" alt="image" src="https://github.com/ServiceNow/azimuth/assets/8386369/454211d8-b1ba-4fde-b9af-7b5adbadd1ec">

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
