### PR TITLE
Add drop-down menu to load a previous config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Released changes are shown in the
 
 ### Added
 - Two buttons in the config UI to import/export a JSON config file.
+- Drop-down menu to load a previous config.
 
 ### Changed
 

--- a/webapp/src/components/HashChip.tsx
+++ b/webapp/src/components/HashChip.tsx
@@ -1,0 +1,16 @@
+import { Chip } from "@mui/material";
+import React from "react";
+
+const HashChip: React.FC<{ hash: string }> = ({ hash }) => (
+  <Chip
+    size="small"
+    label={hash}
+    sx={{
+      fontFamily: "Monospace",
+      backgroundColor: `#${hash}`,
+      color: (theme) => theme.palette.getContrastText(`#${hash}`),
+    }}
+  />
+);
+
+export default React.memo(HashChip);

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -282,6 +282,24 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
     metricsNames.has("") ||
     resultingConfig.metrics.some(({ class_name }) => class_name.trim() === "");
 
+  const fullHashCount = new Set(configHistory?.map(({ hash }) => hash)).size;
+  const hashCount = new Set(configHistory?.map(({ hash }) => hash.slice(0, 3)))
+    .size;
+  const nameCount = new Set(configHistory?.map(({ config }) => config.name))
+    .size;
+
+  // Don't show the hash (hashSize = null) if no two different configs have the same name.
+  // Show a 6-char hash if there is a collision in the first 3 chars.
+  // Otherwise, show a 3-char hash.
+  // Probability of a hash collision with the 3-char hash:
+  // 10 different configs: 1 %
+  // 30 different configs: 10 %
+  // 76 different configs: 50 %
+  // With the 6-char hash:
+  // 581 different configs: 1 %
+  const hashChars =
+    nameCount === fullHashCount ? null : hashCount === fullHashCount ? 3 : 6;
+
   const handleFileRead = (text: string) => {
     try {
       const body = JSON.parse(text);
@@ -341,7 +359,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                     }}
                   >
                     <Typography flex={1}>{config.name}</Typography>
-                    <HashChip hash={hash.slice(0, 3)} />
+                    {hashChars && <HashChip hash={hash.slice(0, hashChars)} />}
                     <Typography
                       variant="body2"
                       sx={{ fontFamily: "Monospace" }}

--- a/webapp/src/services/api.ts
+++ b/webapp/src/services/api.ts
@@ -27,6 +27,7 @@ const tagTypes = [
   "DatasetInfo",
   "ConfidenceHistogram",
   "Config",
+  "ConfigHistory",
   "DefaultConfig",
   "Metrics",
   "OutcomeCountPerThreshold",
@@ -272,6 +273,13 @@ export const api = createApi({
         "Something went wrong fetching the config"
       ),
     }),
+    getConfigHistory: build.query({
+      providesTags: [{ type: "ConfigHistory" }],
+      queryFn: responseToData(
+        fetchApi({ path: "/config/history", method: "get" }),
+        "Something went wrong fetching the config history"
+      ),
+    }),
     getDefaultConfig: build.query({
       providesTags: [{ type: "DefaultConfig" }],
       queryFn: responseToData(
@@ -371,6 +379,7 @@ export const api = createApi({
 export const {
   getConfidenceHistogram: getConfidenceHistogramEndpoint,
   getConfig: getConfigEndpoint,
+  getConfigHistory: getConfigHistoryEndpoint,
   getDefaultConfig: getDefaultConfigEndpoint,
   getConfusionMatrix: getConfusionMatrixEndpoint,
   getDatasetInfo: getDatasetInfoEndpoint,

--- a/webapp/src/utils/format.ts
+++ b/webapp/src/utils/format.ts
@@ -12,6 +12,12 @@ export const formatRatioAsPercentageString = (
   digits: number = 2
 ) => `${formatNumberAsString(100 * value, digits)}%`;
 
+const pad = (n: number) => String(n).padStart(2, "0");
+
+export const formatDateISO = (date: Date) =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+  `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+
 export const camelToTitleCase = (camelCase: string) =>
   // Safari and iOS browsers don't support lookbehind in regular expressions.
   camelCase.replace(/([a-z])(?=[A-Z0-9])|([A-Z0-9])(?=[A-Z][a-z])/g, "$& ");


### PR DESCRIPTION
## Description:

I show a hash of each config in a colored chip to easily tell if some configs are duplicates (for example when going back and forth between two configs). The color of the chip is based on the hash. Special cases:
* Don't show the hash (hashSize = null) if no two different configs have the same name. ❓ Maybe that's not desirable?
* Show a 6-char hash if there is a collision in the first 3 chars.❓ Do you think that is overkill? See the probabilities below.
* Otherwise, show a 3-char hash.

I calculated the probability of a hash collision (two different configs producing the same hash)...
* with the 3-char hash:
  - 10 different configs: 1 %
  - 30 different configs: 10 %
  - 76 different configs: 50 %
* with the 6-char hash:
  - 581 different configs: 1 %

![image](https://github.com/ServiceNow/azimuth/assets/8386369/04d66490-adc4-4de6-8d3d-76098fec947d)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
