### PR TITLE
Fix disabled look

### DIFF
--- a/webapp/src/components/Settings/AutocompleteStringField.tsx
+++ b/webapp/src/components/Settings/AutocompleteStringField.tsx
@@ -28,17 +28,14 @@ const AutocompleteStringField: React.FC<
     }}
     value={value}
     disabled={disabled}
-    onChange={onChange && ((_, newValue) => onChange(newValue as string))}
+    onChange={(_, newValue) => onChange(newValue as string)}
     // The autoSelect prop would normally cause onChange when onBlur happens,
     // except it doesn't work when the input is empty, so we do it manually.
-    onBlur={
-      onChange &&
-      ((event: React.FocusEvent<HTMLInputElement>) => {
-        if (event.target.value !== value) {
-          onChange(event.target.value);
-        }
-      })
-    }
+    onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
+      if (event.target.value !== value) {
+        onChange(event.target.value);
+      }
+    }}
     renderInput={(params) => (
       <TextField
         {...params}

--- a/webapp/src/components/Settings/JSONField.tsx
+++ b/webapp/src/components/Settings/JSONField.tsx
@@ -35,15 +35,13 @@ const JSONField: React.FC<
     }
   };
 
-  const handleBlur =
-    onChange &&
-    ((newStringValue: string) => {
-      try {
-        onChange(JSON.parse(adornments.join(newStringValue)));
-      } catch (error) {
-        setErrorText((error as SyntaxError).message);
-      }
-    });
+  const handleBlur = (newStringValue: string) => {
+    try {
+      onChange(JSON.parse(adornments.join(newStringValue)));
+    } catch (error) {
+      setErrorText((error as SyntaxError).message);
+    }
+  };
 
   return (
     <TextField
@@ -53,7 +51,7 @@ const JSONField: React.FC<
       error={errorText !== ""}
       helperText={errorText}
       onChange={(event) => handleChange(event.target.value)}
-      onBlur={handleBlur && ((event) => handleBlur(event.target.value))}
+      onBlur={(event) => handleBlur(event.target.value)}
       InputProps={{
         startAdornment: (
           <Typography variant="inherit" alignSelf="start">

--- a/webapp/src/components/Settings/NumberField.tsx
+++ b/webapp/src/components/Settings/NumberField.tsx
@@ -52,7 +52,7 @@ const NumberField: React.FC<
       }}
       onChange={(event) => {
         setStringValue(event.target.value);
-        onChange && onChange(Number(event.target.value) / scale);
+        onChange(Number(event.target.value) / scale);
       }}
       {...props}
     />

--- a/webapp/src/components/Settings/NumberField.tsx
+++ b/webapp/src/components/Settings/NumberField.tsx
@@ -1,4 +1,4 @@
-import { InputAdornment, TextField, TextFieldProps } from "@mui/material";
+import { TextField, TextFieldProps, Typography } from "@mui/material";
 import React from "react";
 import { FieldProps, FIELD_COMMON_PROPS } from "./utils";
 
@@ -46,8 +46,11 @@ const NumberField: React.FC<
       helperText={helperText}
       InputProps={{
         sx: { maxWidth: "12ch" },
+        // If we put text in an <InputAdornment>, it gets a different font size and color (that doesn't get disabled).
         endAdornment: units && (
-          <InputAdornment position="end">{units}</InputAdornment>
+          <Typography variant="inherit" marginLeft={1}>
+            {units}
+          </Typography>
         ),
       }}
       onChange={(event) => {

--- a/webapp/src/components/Settings/StringArrayField.tsx
+++ b/webapp/src/components/Settings/StringArrayField.tsx
@@ -27,7 +27,7 @@ const StringArrayField: React.FC<
     options={[]}
     value={value}
     disabled={disabled}
-    onChange={onChange && ((_, newValue) => onChange(newValue as string[]))}
+    onChange={(_, newValue) => onChange(newValue as string[])}
     renderInput={(params) => (
       <TextField
         {...params}

--- a/webapp/src/components/Settings/StringField.tsx
+++ b/webapp/src/components/Settings/StringField.tsx
@@ -23,10 +23,9 @@ const StringField = <T extends string | null>({
     required={!nullable && !options}
     {...(value?.trim() === "" && { error: true, helperText: "Set a value" })}
     onChange={
-      onChange &&
-      (nullable
+      nullable
         ? (event) => onChange((event.target.value || null) as T)
-        : (event) => onChange(event.target.value as T))
+        : (event) => onChange(event.target.value as T)
     }
     {...props}
   >

--- a/webapp/src/components/Settings/utils.ts
+++ b/webapp/src/components/Settings/utils.ts
@@ -1,4 +1,4 @@
-export type FieldProps<T> = { value: T; onChange?: (newValue: T) => void };
+export type FieldProps<T> = { value: T; onChange: (newValue: T) => void };
 
 export const FIELD_COMMON_PROPS = {
   size: "small",

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -1000,6 +1000,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           label="artifact_path"
           value={resultingConfig.artifact_path}
           InputProps={{ readOnly: true, disableUnderline: true }}
+          onChange={() => {}}
         />
         <NumberField
           label="batch_size"

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -21,6 +21,7 @@ import {
   inputLabelClasses,
   Menu,
   MenuItem,
+  Theme,
   Typography,
 } from "@mui/material";
 import noData from "assets/void.svg";
@@ -169,16 +170,24 @@ const displaySectionTitle = (section: string) => (
 const KeyValuePairs: React.FC<
   {
     label: string;
+    disabled: boolean;
     keyValuePairs: [string, React.ReactNode][];
   } & BoxProps
-> = ({ label, keyValuePairs, ...props }) => {
+> = ({ label, disabled, keyValuePairs, ...props }) => {
+  const sx = disabled
+    ? { color: (theme: Theme) => theme.palette.text.disabled }
+    : {};
   return (
     <Box display="flex" flexDirection="column" {...props}>
-      <Typography variant="caption">{label}</Typography>
+      <Typography variant="caption" sx={sx}>
+        {label}
+      </Typography>
       <Box display="grid" gridTemplateColumns="max-content auto" gap={1}>
         {keyValuePairs.map(([key, value]) => (
           <React.Fragment key={key}>
-            <Typography variant="body2">{key}:</Typography>
+            <Typography variant="body2" sx={sx}>
+              {key}:
+            </Typography>
             {value}
           </React.Fragment>
         ))}
@@ -619,6 +628,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           />
           <KeyValuePairs
             label="columns"
+            disabled={areInputsDisabled}
             keyValuePairs={COLUMNS.map((column) => [
               column,
               <StringField
@@ -674,6 +684,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           />
           <KeyValuePairs
             label="uncertainty"
+            disabled={areInputsDisabled || resultingConfig.uncertainty === null}
             keyValuePairs={Object.entries(resultingConfig.uncertainty).map(
               ([field, value]) => [
                 field,
@@ -931,6 +942,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
             <KeyValuePairs
               key={field}
               label={field}
+              disabled={areInputsDisabled || resultingConfig[config] === null}
               {...(field === "neutral_token" && {
                 sx: { gridColumnEnd: "span 2" },
               })}
@@ -1001,6 +1013,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
         <StringField
           label="artifact_path"
           value={resultingConfig.artifact_path}
+          disabled={areInputsDisabled}
           InputProps={{ readOnly: true, disableUnderline: true }}
           onChange={() => {}}
         />


### PR DESCRIPTION
## Description:

Three steps:
* [Make `onChange()` required](https://github.com/ServiceNow/azimuth/pull/587/commits/b44fa1edb840c86cdd36b96edddcff4d4fc09990) (unlerated)
  - This ensures we never forget to define `onChange`.
  - It allows for simplifying the handlers in our custom field components.
  - Only one field is read-only and requires adding a `onChange={() => {}}`. I think it's good that it becomes explicit, showing it's not because we forgot `onChange`.
* [Refactor `KeyValuePairs`](https://github.com/ServiceNow/azimuth/pull/587/commits/6ed04dc4be56ca07f6f5e2b893cd81906cf2aea1)
  - Removing duplicated code like
```tsx
          <Box display="flex" flexDirection="column">
            <Typography variant="caption">...</Typography>
            <KeyValuePairs>
              {... => (
                <React.Fragment key={...}>
                  <Typography variant="body2">{...}:</Typography>
                  ...
                </React.Fragment>
              ))}
            </KeyValuePairs>
          </Box>
```
* [Fix disabled look](https://github.com/ServiceNow/azimuth/pull/587/commits/c5430cb7a314ea972f8f26a2b9d5f20e3af9f98f)

Before:
<img width="1324" alt="Screenshot 2023-06-27 at 11 27 23 PM" src="https://github.com/ServiceNow/azimuth/assets/8386369/4514b2a7-e57a-45be-a9d6-ec030abe1ff1">
After:
<img width="1324" alt="Screenshot 2023-06-27 at 11 26 33 PM" src="https://github.com/ServiceNow/azimuth/assets/8386369/fe6a9051-ef52-440b-bdf9-b237b52a8d30">

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
