### PR TITLE
Add discard buttons to individual config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Released changes are shown in the
 ### Added
 - Two buttons in the config UI to import/export a JSON config file.
 - Drop-down menu to load a previous config.
+- Discard buttons to individual config fields.
 - For HF pipelines, the saliency layer is now automatically detected and no longer needs to be specified in the config. To disable saliency maps, the user can still specify `null`.
 
 ### Changed

--- a/webapp/src/components/Settings/AutocompleteStringField.tsx
+++ b/webapp/src/components/Settings/AutocompleteStringField.tsx
@@ -42,16 +42,16 @@ const AutocompleteStringField: React.FC<
         {...params}
         InputProps={{
           ...params.InputProps,
-          startAdornment: (
+          endAdornment: (
             <>
-              {originalValue !== undefined && (
+              {params.InputProps.endAdornment}
+              {originalValue !== undefined && originalValue !== value && (
                 <DiscardButton
                   title={String(originalValue)}
-                  disabled={disabled || value === originalValue}
+                  disabled={disabled}
                   onClick={() => onChange(originalValue)}
                 />
               )}
-              {params.InputProps.startAdornment}
             </>
           ),
         }}

--- a/webapp/src/components/Settings/AutocompleteStringField.tsx
+++ b/webapp/src/components/Settings/AutocompleteStringField.tsx
@@ -6,12 +6,13 @@ import {
 } from "@mui/material";
 import React from "react";
 import { FieldProps, FIELD_COMMON_PROPS } from "./utils";
+import { DiscardButton } from "./DiscardButton";
 
 const filterOptions = createFilterOptions<string>();
 
 const AutocompleteStringField: React.FC<
   Omit<TextFieldProps, "onChange"> & FieldProps<string> & { options: string[] }
-> = ({ value, onChange, options, disabled, ...props }) => (
+> = ({ value, originalValue, onChange, options, disabled, ...props }) => (
   <Autocomplete
     freeSolo
     disableClearable
@@ -39,6 +40,21 @@ const AutocompleteStringField: React.FC<
     renderInput={(params) => (
       <TextField
         {...params}
+        InputProps={{
+          ...params.InputProps,
+          startAdornment: (
+            <>
+              {originalValue !== undefined && (
+                <DiscardButton
+                  title={String(originalValue)}
+                  disabled={disabled || value === originalValue}
+                  onClick={() => onChange(originalValue)}
+                />
+              )}
+              {params.InputProps.startAdornment}
+            </>
+          ),
+        }}
         {...FIELD_COMMON_PROPS}
         {...props}
         {...(value.trim() === "" && { error: true, helperText: "Set a value" })}

--- a/webapp/src/components/Settings/CustomObjectFields.tsx
+++ b/webapp/src/components/Settings/CustomObjectFields.tsx
@@ -7,13 +7,15 @@ const CustomObjectFields: React.FC<{
   excludeClassName?: boolean;
   disabled: boolean;
   value: CustomObject;
+  originalValue: CustomObject | undefined;
   onChange: (update: Partial<CustomObject>) => void;
-}> = ({ excludeClassName, disabled, value, onChange }) => (
+}> = ({ excludeClassName, disabled, value, originalValue, onChange }) => (
   <>
     {!excludeClassName && (
       <StringField
         label="class_name"
         value={value.class_name}
+        originalValue={originalValue?.class_name}
         disabled={disabled}
         onChange={(class_name) => onChange({ class_name })}
       />
@@ -22,6 +24,7 @@ const CustomObjectFields: React.FC<{
       label="remote"
       nullable
       value={value.remote}
+      originalValue={originalValue?.remote}
       disabled={disabled}
       onChange={(remote) => onChange({ remote })}
     />
@@ -29,12 +32,14 @@ const CustomObjectFields: React.FC<{
       array
       label="args"
       value={value.args}
+      originalValue={originalValue?.args}
       disabled={disabled}
       onChange={(args) => onChange({ args })}
     />
     <JSONField
       label="kwargs"
       value={value.kwargs}
+      originalValue={originalValue?.kwargs}
       disabled={disabled}
       onChange={(kwargs) => onChange({ kwargs })}
     />

--- a/webapp/src/components/Settings/DiscardButton.tsx
+++ b/webapp/src/components/Settings/DiscardButton.tsx
@@ -1,0 +1,19 @@
+import { Replay } from "@mui/icons-material";
+import { InputAdornment, Tooltip, IconButton } from "@mui/material";
+
+export const DiscardButton: React.FC<{
+  title: string;
+  disabled: boolean;
+  onClick: () => void;
+}> = ({ title, ...props }) => (
+  <InputAdornment position="start">
+    <Tooltip
+      placement="bottom-start"
+      title={props.disabled ? "" : `Discard change, reset to ${title}`}
+    >
+      <IconButton color="secondary" sx={{ padding: 0 }} {...props}>
+        <Replay />
+      </IconButton>
+    </Tooltip>
+  </InputAdornment>
+);

--- a/webapp/src/components/Settings/DiscardButton.tsx
+++ b/webapp/src/components/Settings/DiscardButton.tsx
@@ -6,9 +6,9 @@ export const DiscardButton: React.FC<{
   disabled: boolean;
   onClick: () => void;
 }> = ({ title, ...props }) => (
-  <InputAdornment position="start">
+  <InputAdornment position="end" sx={{ marginLeft: 0, marginRight: "-20px" }}>
     <Tooltip
-      placement="bottom-start"
+      placement="bottom-end"
       title={props.disabled ? "" : `Discard change, reset to ${title}`}
     >
       <IconButton color="secondary" sx={{ padding: 0 }} {...props}>

--- a/webapp/src/components/Settings/JSONField.tsx
+++ b/webapp/src/components/Settings/JSONField.tsx
@@ -57,23 +57,24 @@ const JSONField: React.FC<
       onBlur={(event) => handleBlur(event.target.value)}
       InputProps={{
         startAdornment: (
-          <>
-            {originalValue !== undefined && (
-              <DiscardButton
-                title={adornments.join(stringOriginalValue)}
-                disabled={props.disabled || stringValue === stringOriginalValue}
-                onClick={() => onChange(originalValue as any)}
-              />
-            )}
-            <Typography variant="inherit" alignSelf="start">
-              {adornments[0]}&nbsp;
-            </Typography>
-          </>
+          <Typography variant="inherit" alignSelf="start">
+            {adornments[0]}&nbsp;
+          </Typography>
         ),
         endAdornment: (
-          <Typography variant="inherit" alignSelf="end">
-            &nbsp;{adornments[1]}
-          </Typography>
+          <>
+            <Typography variant="inherit" alignSelf="end">
+              &nbsp;{adornments[1]}
+            </Typography>
+            {originalValue !== undefined &&
+              stringOriginalValue !== stringValue && (
+                <DiscardButton
+                  title={adornments.join(stringOriginalValue)}
+                  disabled={props.disabled}
+                  onClick={() => onChange(originalValue as any)}
+                />
+              )}
+          </>
         ),
       }}
       {...props}

--- a/webapp/src/components/Settings/JSONField.tsx
+++ b/webapp/src/components/Settings/JSONField.tsx
@@ -1,6 +1,7 @@
 import { TextFieldProps, TextField, Typography } from "@mui/material";
 import React from "react";
 import { FieldProps, FIELD_COMMON_PROPS } from "./utils";
+import { DiscardButton } from "./DiscardButton";
 
 const stringifyJSON = (value: unknown, spaces = 2) =>
   JSON.stringify(value, null, spaces)
@@ -13,12 +14,14 @@ const JSONField: React.FC<
       | ({ array: true } & FieldProps<any[]>)
       | ({ array?: false } & FieldProps<Record<string, unknown>>)
     )
-> = ({ value, onChange, array, ...props }) => {
+> = ({ value, originalValue, onChange, array, ...props }) => {
   const [stringValue, setStringValue] = React.useState(stringifyJSON(value));
 
   React.useEffect(() => setStringValue(stringifyJSON(value)), [value]);
 
   const [errorText, setErrorText] = React.useState("");
+
+  const stringOriginalValue = originalValue && stringifyJSON(originalValue);
 
   const adornments = array ? (["[", "]"] as const) : (["{", "}"] as const);
 
@@ -54,9 +57,18 @@ const JSONField: React.FC<
       onBlur={(event) => handleBlur(event.target.value)}
       InputProps={{
         startAdornment: (
-          <Typography variant="inherit" alignSelf="start">
-            {adornments[0]}&nbsp;
-          </Typography>
+          <>
+            {originalValue !== undefined && (
+              <DiscardButton
+                title={adornments.join(stringOriginalValue)}
+                disabled={props.disabled || stringValue === stringOriginalValue}
+                onClick={() => onChange(originalValue as any)}
+              />
+            )}
+            <Typography variant="inherit" alignSelf="start">
+              {adornments[0]}&nbsp;
+            </Typography>
+          </>
         ),
         endAdornment: (
           <Typography variant="inherit" alignSelf="end">

--- a/webapp/src/components/Settings/NumberField.tsx
+++ b/webapp/src/components/Settings/NumberField.tsx
@@ -1,11 +1,12 @@
 import { TextField, TextFieldProps, Typography } from "@mui/material";
 import React from "react";
 import { FieldProps, FIELD_COMMON_PROPS } from "./utils";
+import { DiscardButton } from "./DiscardButton";
 
 const NumberField: React.FC<
   Omit<TextFieldProps, "onChange"> &
     FieldProps<number> & { scale?: number; units?: string }
-> = ({ value, scale = 1, units, onChange, ...props }) => {
+> = ({ value, originalValue, scale = 1, units, onChange, ...props }) => {
   // Control value with a `string` (and not with a `number`) so that for example
   // when hitting backspace at the end of `0.01`, you get `0.0` (and not `0`).
   const [stringValue, setStringValue] = React.useState(String(value * scale));
@@ -15,6 +16,12 @@ const NumberField: React.FC<
       setStringValue(String(value * scale));
     }
   }, [value, scale, stringValue]);
+
+  const formatNumber = React.useCallback(
+    (x: number) =>
+      `${x}${units ? ` ${x === 1 ? units.replace(/s$/, "") : units}` : ""}`,
+    [units]
+  );
 
   const helperText = React.useMemo(() => {
     if (props.inputProps === undefined) {
@@ -31,10 +38,8 @@ const NumberField: React.FC<
     }
 
     const limit = props.inputProps[prop];
-    return `Set ${prop}imum ${limit}${
-      units ? ` ${limit === 1 ? units.replace(/s$/, "") : units}` : ""
-    }`;
-  }, [props.inputProps, scale, units, value]);
+    return `Set ${prop}imum ${formatNumber(limit)}`;
+  }, [props.inputProps, scale, value, formatNumber]);
 
   return (
     <TextField
@@ -45,7 +50,15 @@ const NumberField: React.FC<
       error={helperText !== undefined}
       helperText={helperText}
       InputProps={{
-        sx: { maxWidth: "12ch" },
+        sx: { maxWidth: "15ch" },
+        startAdornment:
+          originalValue === undefined ? null : (
+            <DiscardButton
+              title={formatNumber(originalValue * scale)}
+              disabled={props.disabled || value === originalValue}
+              onClick={() => onChange(originalValue)}
+            />
+          ),
         // If we put text in an <InputAdornment>, it gets a different font size and color (that doesn't get disabled).
         endAdornment: units && (
           <Typography variant="inherit" marginLeft={1}>

--- a/webapp/src/components/Settings/NumberField.tsx
+++ b/webapp/src/components/Settings/NumberField.tsx
@@ -50,20 +50,23 @@ const NumberField: React.FC<
       error={helperText !== undefined}
       helperText={helperText}
       InputProps={{
-        sx: { maxWidth: "15ch" },
-        startAdornment:
-          originalValue === undefined ? null : (
-            <DiscardButton
-              title={formatNumber(originalValue * scale)}
-              disabled={props.disabled || value === originalValue}
-              onClick={() => onChange(originalValue)}
-            />
-          ),
-        // If we put text in an <InputAdornment>, it gets a different font size and color (that doesn't get disabled).
-        endAdornment: units && (
-          <Typography variant="inherit" marginLeft={1}>
-            {units}
-          </Typography>
+        sx: { maxWidth: "12ch" },
+        endAdornment: (
+          <>
+            {units && (
+              // If we put text in an <InputAdornment>, it gets a different font size and color (that doesn't get disabled).
+              <Typography variant="inherit" marginLeft={1}>
+                {units}
+              </Typography>
+            )}
+            {originalValue !== undefined && originalValue !== value && (
+              <DiscardButton
+                title={formatNumber(originalValue * scale)}
+                disabled={props.disabled}
+                onClick={() => onChange(originalValue)}
+              />
+            )}
+          </>
         ),
       }}
       onChange={(event) => {

--- a/webapp/src/components/Settings/StringArrayField.tsx
+++ b/webapp/src/components/Settings/StringArrayField.tsx
@@ -8,12 +8,14 @@ import {
 } from "@mui/material";
 import React from "react";
 import { FieldProps, FIELD_COMMON_PROPS } from "./utils";
+import { DiscardButton } from "./DiscardButton";
 
 const StringArrayField: React.FC<
   Omit<TextFieldProps, "onChange"> &
     FieldProps<string[]> & { label?: string; units?: string }
 > = ({
   value,
+  originalValue,
   onChange,
   label,
   units = label || "token",
@@ -38,6 +40,24 @@ const StringArrayField: React.FC<
             Write a{/^[aeio]/.test(units) && "n"} {units} and press enter
           </>
         }
+        InputProps={{
+          ...params.InputProps,
+          startAdornment: (
+            <>
+              {originalValue !== undefined && (
+                <DiscardButton
+                  title={originalValue.join(", ")}
+                  disabled={
+                    disabled ||
+                    JSON.stringify(value) === JSON.stringify(originalValue)
+                  }
+                  onClick={() => onChange(originalValue)}
+                />
+              )}
+              {params.InputProps.startAdornment}
+            </>
+          ),
+        }}
         {...props}
       />
     )}

--- a/webapp/src/components/Settings/StringArrayField.tsx
+++ b/webapp/src/components/Settings/StringArrayField.tsx
@@ -42,19 +42,17 @@ const StringArrayField: React.FC<
         }
         InputProps={{
           ...params.InputProps,
-          startAdornment: (
+          endAdornment: (
             <>
-              {originalValue !== undefined && (
-                <DiscardButton
-                  title={originalValue.join(", ")}
-                  disabled={
-                    disabled ||
-                    JSON.stringify(value) === JSON.stringify(originalValue)
-                  }
-                  onClick={() => onChange(originalValue)}
-                />
-              )}
-              {params.InputProps.startAdornment}
+              {params.InputProps.endAdornment}
+              {originalValue !== undefined &&
+                JSON.stringify(originalValue) !== JSON.stringify(value) && (
+                  <DiscardButton
+                    title={originalValue.join(", ")}
+                    disabled={disabled}
+                    onClick={() => onChange(originalValue)}
+                  />
+                )}
             </>
           ),
         }}

--- a/webapp/src/components/Settings/StringField.tsx
+++ b/webapp/src/components/Settings/StringField.tsx
@@ -25,11 +25,11 @@ const StringField = <T extends string | null>({
     required={!nullable && !options}
     {...(value?.trim() === "" && { error: true, helperText: "Set a value" })}
     InputProps={{
-      startAdornment:
-        originalValue === undefined ? null : (
+      endAdornment:
+        originalValue === undefined || originalValue === value ? null : (
           <DiscardButton
             title={String(originalValue)}
-            disabled={props.disabled || value === originalValue}
+            disabled={props.disabled}
             onClick={() => onChange(originalValue)}
           />
         ),

--- a/webapp/src/components/Settings/StringField.tsx
+++ b/webapp/src/components/Settings/StringField.tsx
@@ -1,8 +1,10 @@
 import { MenuItem, TextField, TextFieldProps } from "@mui/material";
 import { FieldProps, FIELD_COMMON_PROPS } from "./utils";
+import { DiscardButton } from "./DiscardButton";
 
 const StringField = <T extends string | null>({
   value,
+  originalValue,
   onChange,
   nullable,
   options,
@@ -22,6 +24,16 @@ const StringField = <T extends string | null>({
     value={value ?? ""}
     required={!nullable && !options}
     {...(value?.trim() === "" && { error: true, helperText: "Set a value" })}
+    InputProps={{
+      startAdornment:
+        originalValue === undefined ? null : (
+          <DiscardButton
+            title={String(originalValue)}
+            disabled={props.disabled || value === originalValue}
+            onClick={() => onChange(originalValue)}
+          />
+        ),
+    }}
     onChange={
       nullable
         ? (event) => onChange((event.target.value || null) as T)

--- a/webapp/src/components/Settings/utils.ts
+++ b/webapp/src/components/Settings/utils.ts
@@ -1,4 +1,8 @@
-export type FieldProps<T> = { value: T; onChange: (newValue: T) => void };
+export type FieldProps<T> = {
+  value: T;
+  originalValue: T | undefined;
+  onChange: (newValue: T) => void;
+};
 
 export const FIELD_COMMON_PROPS = {
   size: "small",

--- a/webapp/src/components/Settings/utils.ts
+++ b/webapp/src/components/Settings/utils.ts
@@ -1,6 +1,7 @@
 export type FieldProps<T> = {
   value: T;
   originalValue: T | undefined;
+  disabled: boolean;
   onChange: (newValue: T) => void;
 };
 

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -1,7 +1,6 @@
 import { Close, Download, History, Upload, Warning } from "@mui/icons-material";
 import {
   Box,
-  BoxProps,
   Button,
   Checkbox,
   CircularProgress,
@@ -155,8 +154,17 @@ const KNOWN_POSTPROCESSORS: {
   "azimuth.utils.ml.postprocessing.Thresholding": { threshold: 0.5 },
 };
 
-const Columns: React.FC<{ columns?: number }> = ({ columns = 1, children }) => (
-  <Box display="grid" gap={4} gridTemplateColumns={`repeat(${columns}, 1fr)`}>
+const Columns: React.FC<{ columns: number | string }> = ({
+  columns,
+  children,
+}) => (
+  <Box
+    display="grid"
+    gap={4}
+    gridTemplateColumns={
+      typeof columns === "number" ? `repeat(${columns}, 1fr)` : columns
+    }
+  >
     {children}
   </Box>
 );
@@ -167,18 +175,16 @@ const displaySectionTitle = (section: string) => (
   </Typography>
 );
 
-const KeyValuePairs: React.FC<
-  {
-    label: string;
-    disabled: boolean;
-    keyValuePairs: [string, React.ReactNode][];
-  } & BoxProps
-> = ({ label, disabled, keyValuePairs, ...props }) => {
+const KeyValuePairs: React.FC<{
+  label: string;
+  disabled: boolean;
+  keyValuePairs: [string, React.ReactNode][];
+}> = ({ label, disabled, keyValuePairs }) => {
   const sx = disabled
     ? { color: (theme: Theme) => theme.palette.text.disabled }
     : {};
   return (
-    <Box display="flex" flexDirection="column" {...props}>
+    <Box display="flex" flexDirection="column">
       <Typography variant="caption" sx={sx}>
         {label}
       </Typography>
@@ -968,7 +974,9 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
 
   const getAnalysesCustomization = (config: SubConfigKeys) => (
     <FormGroup>
-      <Columns columns={5}>
+      <Columns
+        columns={config === "behavioral_testing" ? "5fr 2fr 2fr 3fr" : 5}
+      >
         {Object.entries(
           resultingConfig[config] ?? defaultConfig[config] ?? {}
         ).map(([field, value]) =>
@@ -1004,9 +1012,6 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
               key={field}
               label={field}
               disabled={areInputsDisabled || resultingConfig[config] === null}
-              {...(field === "neutral_token" && {
-                sx: { gridColumnEnd: "span 2" },
-              })}
               keyValuePairs={Object.entries(value).map(
                 ([objField, objValue]) => [
                   objField,

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -614,6 +614,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           <StringField
             label="name"
             value={resultingConfig.name}
+            originalValue={azimuthConfig.name}
             disabled={areInputsDisabled}
             onChange={(name) => updatePartialConfig({ name })}
           />
@@ -621,6 +622,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
             label="rejection_class"
             nullable
             value={resultingConfig.rejection_class}
+            originalValue={azimuthConfig.rejection_class}
             disabled={areInputsDisabled}
             onChange={(rejection_class) =>
               updatePartialConfig({ rejection_class })
@@ -633,6 +635,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
               column,
               <StringField
                 value={resultingConfig.columns[column]}
+                originalValue={azimuthConfig.columns[column]}
                 disabled={areInputsDisabled}
                 onChange={(newValue) =>
                   updateSubConfig("columns", { [column]: newValue })
@@ -650,6 +653,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
               <CustomObjectFields
                 disabled={areInputsDisabled}
                 value={resultingConfig.dataset}
+                originalValue={azimuthConfig.dataset ?? undefined}
                 onChange={(update) => updateSubConfig("dataset", update)}
               />
             </Columns>
@@ -668,6 +672,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
             label="model_contract"
             options={SUPPORTED_MODEL_CONTRACTS}
             value={resultingConfig.model_contract}
+            originalValue={azimuthConfig.model_contract}
             disabled={areInputsDisabled}
             onChange={(model_contract) =>
               updatePartialConfig({ model_contract })
@@ -677,6 +682,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
             label="saliency_layer"
             nullable
             value={resultingConfig.saliency_layer}
+            originalValue={azimuthConfig.saliency_layer}
             disabled={areInputsDisabled}
             onChange={(saliency_layer) =>
               updatePartialConfig({ saliency_layer })
@@ -690,6 +696,11 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                 field,
                 <NumberField
                   value={value}
+                  originalValue={
+                    azimuthConfig.uncertainty[
+                      field as keyof AzimuthConfig["uncertainty"]
+                    ]
+                  }
                   disabled={
                     areInputsDisabled || resultingConfig.uncertainty === null
                   }
@@ -719,6 +730,9 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                   <StringField
                     label="name"
                     value={pipeline.name}
+                    originalValue={
+                      azimuthConfig.pipelines?.[pipelineIndex]?.name
+                    }
                     disabled={areInputsDisabled}
                     onChange={(name) => updatePipeline(pipelineIndex, { name })}
                   />
@@ -730,6 +744,9 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                   <StringField
                     label="class_name"
                     value={pipeline.model.class_name}
+                    originalValue={
+                      azimuthConfig.pipelines?.[pipelineIndex]?.model.class_name
+                    }
                     disabled={areInputsDisabled}
                     onChange={(class_name) =>
                       updateModel(pipelineIndex, { class_name })
@@ -739,6 +756,9 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                     label="remote"
                     nullable
                     value={pipeline.model.remote}
+                    originalValue={
+                      azimuthConfig.pipelines?.[pipelineIndex]?.model.remote
+                    }
                     disabled={areInputsDisabled}
                     onChange={(remote) =>
                       updateModel(pipelineIndex, { remote })
@@ -748,12 +768,18 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                     array
                     label="args"
                     value={pipeline.model.args}
+                    originalValue={
+                      azimuthConfig.pipelines?.[pipelineIndex]?.model.args
+                    }
                     disabled={areInputsDisabled}
                     onChange={(args) => updateModel(pipelineIndex, { args })}
                   />
                   <JSONField
                     label="kwargs"
                     value={pipeline.model.kwargs}
+                    originalValue={
+                      azimuthConfig.pipelines?.[pipelineIndex]?.model.kwargs
+                    }
                     disabled={areInputsDisabled}
                     onChange={(kwargs) =>
                       updateModel(pipelineIndex, { kwargs })
@@ -780,6 +806,10 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                         label="class_name"
                         options={Object.keys(KNOWN_POSTPROCESSORS)}
                         value={postprocessor.class_name}
+                        originalValue={
+                          azimuthConfig.pipelines?.[pipelineIndex]
+                            ?.postprocessors?.[index]?.class_name
+                        }
                         autoFocus
                         disabled={
                           areInputsDisabled || pipeline.postprocessors === null
@@ -811,6 +841,14 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                           excludeClassName
                           disabled={areInputsDisabled}
                           value={postprocessor}
+                          originalValue={
+                            azimuthConfig.pipelines?.[pipelineIndex]
+                              ?.postprocessors?.[index]?.class_name ===
+                            postprocessor.class_name
+                              ? azimuthConfig.pipelines?.[pipelineIndex]
+                                  ?.postprocessors?.[index]
+                              : undefined
+                          }
                           onChange={(update) =>
                             updatePostprocessor(pipelineIndex, index, update)
                           }
@@ -820,6 +858,12 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                         <NumberField
                           label="temperature"
                           value={postprocessor.temperature}
+                          originalValue={
+                            (
+                              azimuthConfig.pipelines?.[pipelineIndex]
+                                ?.postprocessors?.[index] as any
+                            )?.temperature
+                          }
                           disabled={
                             areInputsDisabled ||
                             pipeline.postprocessors === null
@@ -837,6 +881,12 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                         <NumberField
                           label="threshold"
                           value={postprocessor.threshold}
+                          originalValue={
+                            (
+                              azimuthConfig.pipelines?.[pipelineIndex]
+                                ?.postprocessors?.[index] as any
+                            )?.threshold
+                          }
                           disabled={
                             areInputsDisabled ||
                             pipeline.postprocessors === null
@@ -879,6 +929,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                 label="name"
                 options={Object.keys(defaultConfig.metrics)}
                 value={metric.name}
+                originalValue={undefined}
                 {...(splicedArray(resultingConfig.metrics, index, 1).some(
                   ({ name }) => name.trim() === metric.name.trim()
                 ) && {
@@ -894,11 +945,15 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
               <CustomObjectFields
                 disabled={areInputsDisabled}
                 value={metric}
+                originalValue={azimuthConfig.metrics[metric.name]}
                 onChange={(update) => updateMetric(index, update)}
               />
               <JSONField
                 label="additional_kwargs"
                 value={metric.additional_kwargs}
+                originalValue={
+                  azimuthConfig.metrics[metric.name]?.additional_kwargs
+                }
                 disabled={areInputsDisabled}
                 onChange={(additional_kwargs) =>
                   updateMetric(index, { additional_kwargs })
@@ -922,6 +977,9 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
               key={field}
               label={field}
               value={value}
+              originalValue={
+                ((azimuthConfig[config] ?? defaultConfig[config]) as any)[field]
+              }
               disabled={areInputsDisabled || resultingConfig[config] === null}
               onChange={(newValue) =>
                 updateSubConfig(config, { [field]: newValue })
@@ -933,6 +991,9 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
               key={field}
               label={field}
               value={value}
+              originalValue={
+                ((azimuthConfig[config] ?? defaultConfig[config]) as any)[field]
+              }
               disabled={areInputsDisabled || resultingConfig[config] === null}
               onChange={(newValue) =>
                 updateSubConfig(config, { [field]: newValue })
@@ -952,6 +1013,12 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                   Array.isArray(objValue) ? (
                     <StringArrayField
                       value={objValue}
+                      originalValue={
+                        (
+                          (azimuthConfig[config] ??
+                            defaultConfig[config]) as any
+                        )[field][objField]
+                      }
                       disabled={
                         areInputsDisabled || resultingConfig[config] === null
                       }
@@ -964,6 +1031,12 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                   ) : (
                     <NumberField
                       value={objValue as number}
+                      originalValue={
+                        (
+                          (azimuthConfig[config] ??
+                            defaultConfig[config]) as any
+                        )[field][objField]
+                      }
                       disabled={
                         areInputsDisabled || resultingConfig[config] === null
                       }
@@ -984,6 +1057,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
               label={field}
               options={SUPPORTED_SPACY_MODELS}
               value={resultingConfig.syntax.spacy_model}
+              originalValue={azimuthConfig.syntax.spacy_model}
               disabled={areInputsDisabled}
               onChange={(spacy_model) =>
                 updateSubConfig("syntax", { spacy_model })
@@ -995,6 +1069,11 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                 key={field}
                 label={field}
                 value={value}
+                originalValue={
+                  ((azimuthConfig[config] ?? defaultConfig[config]) as any)[
+                    field
+                  ] as string
+                }
                 disabled={areInputsDisabled || resultingConfig[config] === null}
                 onChange={(newValue) =>
                   updateSubConfig(config, { [field]: newValue })
@@ -1013,6 +1092,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
         <StringField
           label="artifact_path"
           value={resultingConfig.artifact_path}
+          originalValue={undefined}
           disabled={areInputsDisabled}
           InputProps={{ readOnly: true, disableUnderline: true }}
           onChange={() => {}}
@@ -1020,6 +1100,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
         <NumberField
           label="batch_size"
           value={resultingConfig.batch_size}
+          originalValue={azimuthConfig.batch_size}
           disabled={areInputsDisabled}
           onChange={(batch_size) => updatePartialConfig({ batch_size })}
           {...INT}
@@ -1029,6 +1110,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           options={USE_CUDA_OPTIONS}
           className="fixedWidthInput"
           value={String(resultingConfig.use_cuda) as UseCUDAOption}
+          originalValue={String(azimuthConfig.use_cuda) as UseCUDAOption}
           disabled={areInputsDisabled}
           onChange={(use_cuda) =>
             updatePartialConfig({
@@ -1062,6 +1144,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
           options={SUPPORTED_LANGUAGES}
           sx={{ width: "6ch" }}
           value={language ?? resultingConfig.language}
+          originalValue={azimuthConfig.language}
           disabled={areInputsDisabled}
           onChange={(newValue) => setLanguage(newValue)}
         />

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -160,10 +160,11 @@ const Columns: React.FC<{ columns: number | string }> = ({
 }) => (
   <Box
     display="grid"
-    gap={4}
     gridTemplateColumns={
       typeof columns === "number" ? `repeat(${columns}, 1fr)` : columns
     }
+    columnGap={6}
+    rowGap={4}
   >
     {children}
   </Box>
@@ -975,7 +976,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
   const getAnalysesCustomization = (config: SubConfigKeys) => (
     <FormGroup>
       <Columns
-        columns={config === "behavioral_testing" ? "5fr 2fr 2fr 3fr" : 5}
+        columns={config === "behavioral_testing" ? "3fr 1fr 1fr 2fr" : 5}
       >
         {Object.entries(
           resultingConfig[config] ?? defaultConfig[config] ?? {}


### PR DESCRIPTION
## Description:

Here is a screenshot.
<img width="1324" alt="image" src="https://github.com/ServiceNow/azimuth/assets/8386369/be453e31-8f03-4a94-bfec-142db933ebb4">
And here is another one showing the tooltips. They are shown for demo purposes. They usually only pop up when hovering.
<img width="1324" alt="image" src="https://github.com/ServiceNow/azimuth/assets/8386369/77af9c8f-f5aa-4e92-99c5-1857d0612724">

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
