### PR TITLE
Apply feedback on loading previous config

### DIFF
--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -1,4 +1,11 @@
-import { Close, Download, History, Upload, Warning } from "@mui/icons-material";
+import {
+  ArrowDropDown,
+  Close,
+  Download,
+  History,
+  Upload,
+  Warning,
+} from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -372,6 +379,7 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
               <Button
                 disabled={areInputsDisabled}
                 startIcon={<History />}
+                endIcon={<ArrowDropDown />}
                 onClick={(event) => setConfigHistoryAnchor(event.currentTarget)}
               >
                 Load previous config

--- a/webapp/src/pages/Settings.tsx
+++ b/webapp/src/pages/Settings.tsx
@@ -389,25 +389,29 @@ const Settings: React.FC<Props> = ({ open, onClose }) => {
                 open={Boolean(configHistoryAnchor)}
                 onClick={() => setConfigHistoryAnchor(null)}
               >
-                {configHistory.map(({ config, created_on, hash }, index) => (
-                  <MenuItem
-                    key={index}
-                    sx={{ gap: 2 }}
-                    onClick={() => {
-                      setConfigHistoryAnchor(null);
-                      setPartialConfig(azimuthConfigToConfigState(config));
-                    }}
-                  >
-                    <Typography flex={1}>{config.name}</Typography>
-                    {hashChars && <HashChip hash={hash.slice(0, hashChars)} />}
-                    <Typography
-                      variant="body2"
-                      sx={{ fontFamily: "Monospace" }}
+                {configHistory
+                  .map(({ config, created_on, hash }, index) => (
+                    <MenuItem
+                      key={index}
+                      sx={{ gap: 2 }}
+                      onClick={() => {
+                        setConfigHistoryAnchor(null);
+                        setPartialConfig(azimuthConfigToConfigState(config));
+                      }}
                     >
-                      {formatDateISO(new Date(created_on))}
-                    </Typography>
-                  </MenuItem>
-                ))}
+                      <Typography flex={1}>{config.name}</Typography>
+                      {hashChars && (
+                        <HashChip hash={hash.slice(0, hashChars)} />
+                      )}
+                      <Typography
+                        variant="body2"
+                        sx={{ fontFamily: "Monospace" }}
+                      >
+                        {formatDateISO(new Date(created_on))}
+                      </Typography>
+                    </MenuItem>
+                  ))
+                  .reverse()}
               </Menu>
             </>
           )}


### PR DESCRIPTION
## Description:

* [Add drop-down arrow](https://github.com/ServiceNow/azimuth/pull/589/commits/1331b998a5842a8780fc3fb7e7a1b44abed21e5b)
* [Reverse history](https://github.com/ServiceNow/azimuth/pull/589/commits/b4d770e5898411d2a0445e1f30cdc71f25045d8c) bringing the oldest config to the bottom

![image](https://github.com/ServiceNow/azimuth/assets/8386369/ba6ba5a2-676e-4f72-9e94-74bf43fe0d36)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
