### PR TITLE
Add settings for model averaging in the frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Released changes are shown in the
 ## [Not released]
 
 ### Added
+* Prediction after BMA can now be displayed in the app.
 
 ### Changed
 

--- a/azimuth/modules/base_classes/aggregation_module.py
+++ b/azimuth/modules/base_classes/aggregation_module.py
@@ -31,7 +31,7 @@ class FilterableModule(AggregationModule[ConfigScope], ExpirableMixin, ABC):
     """Filterable Module are affected by filters in mod options."""
 
     required_mod_options = {"pipeline_index"}
-    optional_mod_options = {"filters", "without_postprocessing"}
+    optional_mod_options = {"filters", "without_postprocessing", "use_bma"}
 
     def get_dataset_split(self, name: DatasetSplitName = None) -> Dataset:
         """Get the specified dataset_split, filtered according to mod_options.

--- a/azimuth/modules/model_contracts/text_classification.py
+++ b/azimuth/modules/model_contracts/text_classification.py
@@ -109,6 +109,7 @@ class TextClassificationModule(ModelContractModule, abc.ABC):
             mod_options=ModuleOptions(
                 model_contract_method_name=SupportedMethod.Predictions,
                 pipeline_index=self.mod_options.pipeline_index,
+                use_bma=self.mod_options.use_bma,
                 indices=cast(List[int], batch[DatasetColumn.row_idx]),
             ),
         )

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -22,7 +22,6 @@ CONFIDENCE_BINS_COUNT = 20
 class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
     """Return a confidence histogram of the predictions."""
 
-
     @staticmethod
     def get_outcome_mask(
         ds, outcome: OutcomeName, without_postprocessing: bool = False

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -22,6 +22,8 @@ CONFIDENCE_BINS_COUNT = 20
 class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
     """Return a confidence histogram of the predictions."""
 
+    optional_mod_options = FilterableModule.optional_mod_options | {"use_bma"}
+
     @staticmethod
     def get_outcome_mask(
         ds, outcome: OutcomeName, without_postprocessing: bool = False
@@ -114,7 +116,7 @@ class ConfidenceBinIndexModule(DatasetResultModule[ModelContractConfig]):
     """Return confidence bin indices for the selected dataset split."""
 
     required_mod_options = {"pipeline_index"}
-    optional_mod_options = DatasetResultModule.optional_mod_options | {"threshold"}
+    optional_mod_options = DatasetResultModule.optional_mod_options | {"threshold", "use_bma"}
 
     def compute_on_dataset_split(self) -> List[int]:  # type: ignore
         """Get the bin indices for each utterance in the dataset split.

--- a/azimuth/modules/model_performance/confidence_binning.py
+++ b/azimuth/modules/model_performance/confidence_binning.py
@@ -22,7 +22,6 @@ CONFIDENCE_BINS_COUNT = 20
 class ConfidenceHistogramModule(FilterableModule[ModelContractConfig]):
     """Return a confidence histogram of the predictions."""
 
-    optional_mod_options = FilterableModule.optional_mod_options | {"use_bma"}
 
     @staticmethod
     def get_outcome_mask(

--- a/azimuth/modules/model_performance/outcome_count.py
+++ b/azimuth/modules/model_performance/outcome_count.py
@@ -178,7 +178,7 @@ class OutcomeCountPerThresholdModule(AggregationModule[ModelContractConfig]):
     """Compute the outcome count per threshold."""
 
     required_mod_options = {"pipeline_index"}
-    optional_mod_options = {"x_ticks_count"}
+    optional_mod_options = {"x_ticks_count", "use_bma"}
 
     def compute_on_dataset_split(self) -> List[OutcomeCountPerThresholdResponse]:  # type: ignore
         if not postprocessing_editable(self.config, self.mod_options.pipeline_index):
@@ -199,6 +199,7 @@ class OutcomeCountPerThresholdModule(AggregationModule[ModelContractConfig]):
                     # Convert to float instead of numpy.float64
                     threshold=float(th),
                     pipeline_index=self.mod_options.pipeline_index,
+                    use_bma=self.mod_options.use_bma,
                 ),
             )
             outcomes = outcomes_mod.compute_on_dataset_split()

--- a/azimuth/modules/model_performance/outcomes.py
+++ b/azimuth/modules/model_performance/outcomes.py
@@ -20,7 +20,7 @@ class OutcomesModule(DatasetResultModule[ModelContractConfig]):
     """Computes the outcome for each utterance in the dataset split."""
 
     required_mod_options = {"pipeline_index"}
-    optional_mod_options = DatasetResultModule.optional_mod_options | {"threshold"}
+    optional_mod_options = DatasetResultModule.optional_mod_options | {"threshold", "use_bma"}
 
     def _get_predictions(self, without_postprocessing: bool) -> ndarray:
         mod_options = self.mod_options.copy(deep=True)

--- a/azimuth/routers/app.py
+++ b/azimuth/routers/app.py
@@ -104,6 +104,8 @@ def get_dataset_info(
             eval=eval_dm and eval_dm.num_rows, train=training_dm and training_dm.num_rows
         ),
         similarity_available=similarity_available(config),
+        model_averaging_available=config.uncertainty is not None
+        and config.uncertainty.iterations > 1,
         postprocessing_editable=None
         if config.pipelines is None
         else [postprocessing_editable(config, idx) for idx in range(len(config.pipelines))],

--- a/azimuth/routers/model_performance/confidence_histogram.py
+++ b/azimuth/routers/model_performance/confidence_histogram.py
@@ -31,7 +31,7 @@ def get_confidence_histogram(
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
     without_postprocessing: bool = Query(False, title="Without Postprocessing"),
-    use_bma: bool = Query(True, title="Use BMA"),  # TODO Remove
+    use_bma: bool = Query(False, title="Use BMA"),
 ) -> ConfidenceHistogramResponse:
     mod_options = ModuleOptions(
         filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),

--- a/azimuth/routers/model_performance/confidence_histogram.py
+++ b/azimuth/routers/model_performance/confidence_histogram.py
@@ -31,10 +31,12 @@ def get_confidence_histogram(
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
     without_postprocessing: bool = Query(False, title="Without Postprocessing"),
+    use_bma: bool = Query(True, title="Use BMA"),  # TODO Remove
 ) -> ConfidenceHistogramResponse:
     mod_options = ModuleOptions(
         filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),
         pipeline_index=pipeline_index,
+        use_bma=use_bma,
         without_postprocessing=without_postprocessing,
     )
 

--- a/azimuth/routers/model_performance/confusion_matrix.py
+++ b/azimuth/routers/model_performance/confusion_matrix.py
@@ -31,12 +31,14 @@ def get_confusion_matrix(
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
     without_postprocessing: bool = Query(False, title="Without Postprocessing"),
+    use_bma: bool = Query(False, title="Use BMA"),
     normalize: bool = Query(True, title="Normalize"),
     reorder_classes: bool = Query(True, title="Reorder Classes"),
 ) -> ConfusionMatrixResponse:
     mod_options = ModuleOptions(
         filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),
         pipeline_index=pipeline_index,
+        use_bma=use_bma,
         without_postprocessing=without_postprocessing,
         cf_normalize=normalize,
         cf_reorder_classes=reorder_classes,

--- a/azimuth/routers/model_performance/metrics.py
+++ b/azimuth/routers/model_performance/metrics.py
@@ -39,10 +39,12 @@ def get_metrics(
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
     without_postprocessing: bool = Query(False, title="Without Postprocessing"),
+    use_bma: bool = Query(False, title="Use BMA"),
 ) -> MetricsAPIResponse:
     mod_options = ModuleOptions(
         filters=named_filters.to_dataset_filters(dataset_split_manager.get_class_names()),
         pipeline_index=pipeline_index,
+        use_bma=use_bma,
         without_postprocessing=without_postprocessing,
     )
 

--- a/azimuth/routers/model_performance/outcome_count.py
+++ b/azimuth/routers/model_performance/outcome_count.py
@@ -35,10 +35,9 @@ def get_outcome_count_per_threshold(
     task_manager: TaskManager = Depends(get_task_manager),
     dataset_split_manager: DatasetSplitManager = Depends(get_dataset_split_manager),
     pipeline_index: int = Depends(require_pipeline_index),
+    use_bma: bool = Query(False, title="Use BMA"),
 ) -> OutcomeCountPerThresholdResponse:
-    mod_options = ModuleOptions(
-        pipeline_index=pipeline_index,
-    )
+    mod_options = ModuleOptions(pipeline_index=pipeline_index, use_bma=use_bma)
 
     try:
         task_result: List[OutcomeCountPerThresholdResponse] = get_standard_task_result(

--- a/azimuth/startup.py
+++ b/azimuth/startup.py
@@ -65,7 +65,21 @@ BMA_PREDICTION_TASKS = [
         SupportedMethod.Predictions,
         mod_options={"use_bma": True},
         run_on_all_pipelines=True,
-    )
+    ),
+    Startup(
+        "outcomes_bma",
+        SupportedModule.Outcome,
+        dependency_names=["prediction_bma"],
+        mod_options={"use_bma": True},
+        run_on_all_pipelines=True,
+    ),
+    Startup(
+        "confidence_bins_bma",
+        SupportedModule.ConfidenceBinIndex,
+        dependency_names=["prediction_bma"],
+        mod_options={"use_bma": True},
+        run_on_all_pipelines=True,
+    ),
 ]
 
 PERTURBATION_TESTING_TASKS = [

--- a/azimuth/types/app.py
+++ b/azimuth/types/app.py
@@ -43,6 +43,7 @@ class DatasetInfoResponse(AliasModel):
         ..., title="Utterance count per dataset split."
     )
     similarity_available: bool = Field(..., title="Indicator if similarities are available.")
+    model_averaging_available: bool = Field(..., title="Indicator if model averaging is available.")
     postprocessing_editable: Optional[List[bool]] = Field(
         ..., title="Indicator if postprocessing can be overwritten.", nullable=True
     )

--- a/tests/test_routers/test_app.py
+++ b/tests/test_routers/test_app.py
@@ -52,6 +52,7 @@ def test_get_dataset_info(app: FastAPI) -> None:
         "dataActions": ALL_DATA_ACTION_FILTERS,
         "similarityAvailable": True,
         "smartTags": ALL_SMART_TAG_FILTERS,
+        "modelAveragingAvailable": False,
     }
 
 

--- a/webapp/src/components/Analysis/UtterancesTable.tsx
+++ b/webapp/src/components/Analysis/UtterancesTable.tsx
@@ -62,6 +62,7 @@ import {
   QueryPaginationState,
   QueryPipelineState,
   QueryPostprocessingState,
+  QueryBMAState,
   QueryState,
 } from "types/models";
 import {
@@ -145,6 +146,7 @@ type Props = {
   pagination: QueryPaginationState;
   pipeline: QueryPipelineState;
   postprocessing: QueryPostprocessingState;
+  modelAveraging: QueryBMAState;
 };
 
 const UtterancesTable: React.FC<Props> = ({
@@ -157,6 +159,7 @@ const UtterancesTable: React.FC<Props> = ({
   pagination,
   pipeline,
   postprocessing,
+  modelAveraging,
 }) => {
   const history = useHistory();
   const classes = useStyles();
@@ -175,6 +178,7 @@ const UtterancesTable: React.FC<Props> = ({
     offset,
     ...pipeline,
     ...postprocessing,
+    ...modelAveraging,
   };
 
   const {
@@ -212,6 +216,7 @@ const UtterancesTable: React.FC<Props> = ({
         ...pagination,
         ...pipeline,
         ...postprocessing,
+        ...modelAveraging,
         ...update,
       }
     )}`;

--- a/webapp/src/components/ConfidenceHistogramTopWords.tsx
+++ b/webapp/src/components/ConfidenceHistogramTopWords.tsx
@@ -15,6 +15,7 @@ import {
   QueryPaginationState,
   QueryPipelineState,
   QueryPostprocessingState,
+  QueryBMAState,
   WordCount,
 } from "types/models";
 import { ALL_OUTCOMES } from "utils/const";
@@ -26,6 +27,7 @@ type Props = {
   pagination: QueryPaginationState;
   pipeline: Required<QueryPipelineState>;
   postprocessing: QueryPostprocessingState;
+  modelAveraging: QueryBMAState;
 };
 
 const ConfidenceHistogramTopWords: React.FC<Props> = ({
@@ -35,6 +37,7 @@ const ConfidenceHistogramTopWords: React.FC<Props> = ({
   pagination,
   pipeline,
   postprocessing,
+  modelAveraging,
 }) => {
   const { jobId, datasetSplitName } = useParams<{
     jobId: string;
@@ -58,6 +61,7 @@ const ConfidenceHistogramTopWords: React.FC<Props> = ({
     ...filtersWithoutBins,
     ...pipeline,
     ...postprocessing,
+    ...modelAveraging,
   });
 
   const { data: topWords, isFetching: isFetchingTopWords } =
@@ -67,6 +71,7 @@ const ConfidenceHistogramTopWords: React.FC<Props> = ({
       ...filters,
       ...pipeline,
       ...postprocessing,
+      ...modelAveraging,
     });
 
   const topWordsCounts = topWords;

--- a/webapp/src/components/ConfusionMatrix.tsx
+++ b/webapp/src/components/ConfusionMatrix.tsx
@@ -19,6 +19,7 @@ import {
   QueryFilterState,
   QueryPipelineState,
   QueryPostprocessingState,
+  QueryBMAState,
 } from "types/models";
 import { OUTCOME_COLOR, UNKNOWN_ERROR } from "utils/const";
 import { classNames, constructSearchString } from "utils/helpers";
@@ -36,6 +37,7 @@ type Props = {
   filters: QueryFilterState;
   pipeline: Required<QueryPipelineState>;
   postprocessing: QueryPostprocessingState;
+  modelAveraging: QueryBMAState;
   predictionFilters?: string[];
   labelFilters?: string[];
 };
@@ -93,6 +95,7 @@ const ConfusionMatrix: React.FC<Props> = ({
   filters,
   pipeline,
   postprocessing,
+  modelAveraging,
   predictionFilters,
   labelFilters,
 }) => {
@@ -114,6 +117,7 @@ const ConfusionMatrix: React.FC<Props> = ({
       ...filters,
       ...pipeline,
       ...postprocessing,
+      ...modelAveraging,
     });
 
   if (isLoading) {
@@ -140,6 +144,7 @@ const ConfusionMatrix: React.FC<Props> = ({
         ...filters,
         ...pipeline,
         ...postprocessing,
+        ...modelAveraging,
         ...newConfusionMatrix,
       })}`
     );
@@ -152,6 +157,7 @@ const ConfusionMatrix: React.FC<Props> = ({
         ...filters,
         ...pipeline,
         ...postprocessing,
+        ...modelAveraging,
         prediction: [data.classNames[columnIndex]],
         label: [data.classNames[rowIndex]],
       })}`}
@@ -299,6 +305,7 @@ const ConfusionMatrix: React.FC<Props> = ({
                 ...filters,
                 ...pipeline,
                 ...postprocessing,
+                ...modelAveraging,
                 prediction: [data.classNames[i]],
               })}`}
               key={`column-${i}`}
@@ -333,6 +340,7 @@ const ConfusionMatrix: React.FC<Props> = ({
                 ...filters,
                 ...pipeline,
                 ...postprocessing,
+                ...modelAveraging,
                 label: [data.classNames[i]],
               })}`}
               key={`row-${i}`}

--- a/webapp/src/components/Controls/Controls.tsx
+++ b/webapp/src/components/Controls/Controls.tsx
@@ -33,6 +33,7 @@ import {
   QueryPaginationState,
   QueryPipelineState,
   QueryPostprocessingState,
+  QueryBMAState,
   QueryConfusionMatrixState,
   QueryArrayFiltersState,
 } from "types/models";
@@ -56,6 +57,7 @@ type Props = {
   pagination: QueryPaginationState;
   pipeline: QueryPipelineState;
   postprocessing: QueryPostprocessingState;
+  modelAveraging: QueryBMAState;
   searchString: string;
 };
 
@@ -71,6 +73,7 @@ const Controls: React.FC<Props> = ({
   pagination,
   pipeline,
   postprocessing,
+  modelAveraging,
   searchString,
 }) => {
   const [searchValue, setSearchValue] = React.useState("");
@@ -94,6 +97,7 @@ const Controls: React.FC<Props> = ({
         ...filters,
         ...pipeline,
         ...postprocessing,
+        ...modelAveraging,
       })
     : getUtteranceCountPerFilterEndpoint.useQuery({
         jobId,
@@ -125,6 +129,7 @@ const Controls: React.FC<Props> = ({
         ...pagination,
         ...pipeline,
         ...postprocessing,
+        ...modelAveraging,
       })}`
     );
   };
@@ -137,6 +142,7 @@ const Controls: React.FC<Props> = ({
         ...pagination,
         ...pipeline,
         ...postprocessing,
+        ...modelAveraging,
       })}`
     );
 
@@ -162,7 +168,20 @@ const Controls: React.FC<Props> = ({
         ...filters,
         ...pagination,
         ...pipeline,
+        ...modelAveraging,
         withoutPostprocessing: checked || undefined,
+      })}`
+    );
+
+  const handleModelAveragingChange = (checked: boolean) =>
+    history.push(
+      `${baseUrl}${constructSearchString({
+        ...confusionMatrix,
+        ...filters,
+        ...pagination,
+        ...pipeline,
+        ...postprocessing,
+        useBma: checked || undefined,
       })}`
     );
 
@@ -267,6 +286,24 @@ const Controls: React.FC<Props> = ({
               />
             </Tooltip>
           </Box>
+          {datasetInfo?.modelAveragingAvailable && (
+            <Box margin={1}>
+              <Tooltip title="Enables Bayesian Model Averaging in predictions and any derived output. This only affects the Exploration Space, and won't affect the smart tags.">
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={modelAveraging.useBma ?? false}
+                      color="secondary"
+                      onChange={(_, checked) =>
+                        handleModelAveragingChange(checked)
+                      }
+                    />
+                  }
+                  label="Enable model averaging"
+                />
+              </Tooltip>
+            </Box>
+          )}
           <Box display="flex" justifyContent="space-between" marginX={1}>
             <Box display="flex" alignItems="center" gap={1} whiteSpace="nowrap">
               <Typography variant="subtitle2">Filters</Typography>

--- a/webapp/src/components/Metrics/Metrics.tsx
+++ b/webapp/src/components/Metrics/Metrics.tsx
@@ -7,6 +7,7 @@ import {
   QueryFilterState,
   QueryPipelineState,
   QueryPostprocessingState,
+  QueryBMAState,
 } from "types/models";
 import { ECE_TOOLTIP, OUTCOME_COLOR, OUTCOME_PRETTY_NAMES } from "utils/const";
 import { formatRatioAsPercentageString } from "utils/format";
@@ -38,6 +39,7 @@ type Props = {
   filters: QueryFilterState;
   pipeline: Required<QueryPipelineState>;
   postprocessing: QueryPostprocessingState;
+  modelAveraging: QueryBMAState;
 };
 
 const Metrics: React.FC<Props> = ({
@@ -46,6 +48,7 @@ const Metrics: React.FC<Props> = ({
   filters,
   pipeline,
   postprocessing,
+  modelAveraging,
 }) => {
   const { data: metrics, isFetching } = getMetricsEndpoint.useQuery({
     jobId,
@@ -53,6 +56,7 @@ const Metrics: React.FC<Props> = ({
     ...filters,
     ...pipeline,
     ...postprocessing,
+    ...modelAveraging,
   });
 
   const { data: metricsInfo } = getCustomMetricInfoEndpoint.useQuery({ jobId });

--- a/webapp/src/components/PageHeader.tsx
+++ b/webapp/src/components/PageHeader.tsx
@@ -95,6 +95,7 @@ const PageHeader = () => {
     pagination,
     pipeline,
     postprocessing,
+    modelAveraging,
   } = useQueryState();
 
   // If present, preserve pipelineIndex when navigating, but nothing else
@@ -108,6 +109,7 @@ const PageHeader = () => {
         ...filters,
         ...pagination,
         ...postprocessing,
+        ...modelAveraging,
         pipelineIndex,
       })}`
     );

--- a/webapp/src/mocks/api/mockDatasetInfoAPI.ts
+++ b/webapp/src/mocks/api/mockDatasetInfoAPI.ts
@@ -64,6 +64,7 @@ export const getDatasetInfoAPIResponse = rest.get(
       modelContract: "hf_text_classification",
       predictionAvailable: true,
       perturbationTestingAvailable: true,
+      modelAveragingAvailable: true,
       availableDatasetSplits: { train: true, eval: true },
       similarityAvailable: true,
       postprocessingEditable: [true],

--- a/webapp/src/pages/Exploration.tsx
+++ b/webapp/src/pages/Exploration.tsx
@@ -54,6 +54,7 @@ const Exploration = () => {
     pagination,
     pipeline,
     postprocessing,
+    modelAveraging,
     searchString,
   } = useQueryState();
 
@@ -85,6 +86,7 @@ const Exploration = () => {
           pagination={pagination}
           pipeline={pipeline}
           postprocessing={postprocessing}
+          modelAveraging={modelAveraging}
           searchString={searchString}
         />
         <div className={classes.content}>
@@ -132,6 +134,7 @@ const Exploration = () => {
                     filters={filters}
                     pipeline={pipeline}
                     postprocessing={postprocessing}
+                    modelAveraging={modelAveraging}
                   />
                   <ConfidenceHistogramTopWords
                     baseUrl={baseUrl}
@@ -140,6 +143,7 @@ const Exploration = () => {
                     pagination={pagination}
                     pipeline={pipeline}
                     postprocessing={postprocessing}
+                    modelAveraging={modelAveraging}
                   />
                 </>
               )}
@@ -158,6 +162,7 @@ const Exploration = () => {
                   predictionFilters={filters.prediction}
                   labelFilters={filters.label}
                   postprocessing={postprocessing}
+                  modelAveraging={modelAveraging}
                 />
               </>
             )}
@@ -172,6 +177,7 @@ const Exploration = () => {
                 pagination={pagination}
                 pipeline={pipeline}
                 postprocessing={postprocessing}
+                modelAveraging={modelAveraging}
               />
             )}
           </Paper>

--- a/webapp/src/types/generated/generatedTypes.ts
+++ b/webapp/src/types/generated/generatedTypes.ts
@@ -306,6 +306,7 @@ export interface components {
       availableDatasetSplits: components["schemas"]["AvailableDatasetSplits"];
       utteranceCountPerDatasetSplit: components["schemas"]["UtteranceCountPerDatasetSplit"];
       similarityAvailable: boolean;
+      modelAveragingAvailable: boolean;
       postprocessingEditable: boolean[] | null;
     };
     /** An enumeration. */
@@ -1488,6 +1489,7 @@ export interface operations {
       };
       query: {
         without_postprocessing?: boolean;
+        use_bma?: boolean;
         pipeline_index: number;
         confidence_min?: number;
         confidence_max?: number;
@@ -1605,6 +1607,7 @@ export interface operations {
       };
       query: {
         without_postprocessing?: boolean;
+        use_bma?: boolean;
         pipeline_index: number;
         confidence_min?: number;
         confidence_max?: number;
@@ -1729,6 +1732,7 @@ export interface operations {
         dataset_split_name: components["schemas"]["DatasetSplitName"];
       };
       query: {
+        use_bma?: boolean;
         pipeline_index: number;
       };
     };
@@ -2549,6 +2553,7 @@ export interface operations {
       };
       query: {
         without_postprocessing?: boolean;
+        use_bma?: boolean;
         normalize?: boolean;
         reorder_classes?: boolean;
         pipeline_index: number;

--- a/webapp/src/types/models.ts
+++ b/webapp/src/types/models.ts
@@ -49,6 +49,10 @@ export type QueryPostprocessingState = {
   withoutPostprocessing?: true;
 };
 
+export type QueryBMAState = {
+  useBma?: boolean;
+};
+
 export type QueryConfusionMatrixState = {
   normalize?: false;
   reorderClasses?: false;
@@ -60,6 +64,7 @@ export type QueryState = QueryClassOverlapState &
   QueryPaginationState &
   QueryPipelineState &
   QueryPostprocessingState &
+  QueryBMAState &
   QueryConfusionMatrixState;
 
 export type Tags = { [Tag: string]: boolean };

--- a/webapp/src/utils/helpers.ts
+++ b/webapp/src/utils/helpers.ts
@@ -10,6 +10,7 @@ import {
   QueryState,
   QueryConfusionMatrixState,
   QueryDetailsState,
+  QueryBMAState,
 } from "types/models";
 
 export const classNames = (...args: any[]) => args.filter(Boolean).join(" ");
@@ -82,6 +83,9 @@ export const parseSearchString = (searchString: string) => {
     }),
     postprocessing: convertSearchParams<QueryPostprocessingState>(q, {
       withoutPostprocessing: (s) => s !== null || undefined,
+    }),
+    modelAveraging: convertSearchParams<QueryBMAState>(q, {
+      useBma: (s) => s !== null || undefined,
     }),
   };
 };


### PR DESCRIPTION
Resolve #Nothing

## Description:

This PR allows the user to see the performance after bayesian model averaging. This generally improves the performance by ~1-2% and the ECE by a couple percentage as well.

In my company, we use BMA in production to get good ECE, this is why I need this toggle.

Lot of code, but mostly poutine here are the relevant bits:

* Added `model_averaging_available` to Dataset Info
* Added new startup tasks when model averaging is enabled.
* Added new query state in the FE and new toggle
    * I acknowledge that this takes a lot of space, I'm open to an alternative.

![image](https://github.com/ServiceNow/azimuth/assets/8976546/5bb0f959-56cc-4e57-a414-dabae8602777)


## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
