### PR TITLE
Fix CI status checks on PR from forks

### DIFF
--- a/.github/workflows/pythonci.yml
+++ b/.github/workflows/pythonci.yml
@@ -1,7 +1,8 @@
 name: Python CI
 
 on:
-  push
+  - push
+  - pull_request
 
 jobs:
   backend:

--- a/.github/workflows/webapp_ci.yml
+++ b/.github/workflows/webapp_ci.yml
@@ -1,7 +1,8 @@
 name: Webapp CI
 
 on:
-  push
+  - push
+  - pull_request
 
 jobs:
   frontend:


### PR DESCRIPTION
Resolve #621 

## Description:

Pull requests coming from forks do not trigger the CI workflows. This is because the workflows only wait for a `push` and this cannot happen in this specific context.

This commit fixes the issue by also triggering workflows on `pull_request` events.

You can see that the workflows are waiting approval from a maintainer before starting: [backend (3.9) action workflow](https://github.com/ServiceNow/azimuth/actions/runs/7592111550)

## Checklist:

You should check all boxes before the PR is ready. If a box does not apply, check it to acknowledge it.

* [x] **ISSUE NUMBER.** You linked the issue number (Ex: Resolve #XXX).
* [x] **PRE-COMMIT.** You ran pre-commit on all commits, or else, you
  ran `pre-commit run --all-files` at the end.
* [x] **USER CHANGES.** The changes are added to CHANGELOG.md and the documentation, if they impact
  our users.
* [x] **DEV CHANGES.**
    * Update the documentation if this PR changes how to develop/launch on the app.
    * Update the `README` files and our wiki for any big design decisions, if relevant.
    * Add unit tests, docstrings, typing and comments for complex sections.
